### PR TITLE
docs: add onboarding pages — How Varity Works + App Store guide

### DIFF
--- a/src/content/docs/deploy/app-store.mdx
+++ b/src/content/docs/deploy/app-store.mdx
@@ -1,0 +1,110 @@
+---
+title: App Store & Developer Portal
+description: How to submit, price, and manage your apps on the Varity App Store. Revenue split, review process, and the Developer Portal.
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+import PageMeta from '../../../components/PageMeta.astro';
+
+<PageMeta
+  author="Varity Team"
+  authorRole="Core Contributors"
+  lastUpdated="March 2026"
+  stability="beta"
+/>
+
+The Varity App Store is where businesses discover and purchase apps built by developers. The Developer Portal is where you manage your listings.
+
+- **App Store** — [store.varity.so](https://store.varity.so) — for end users and businesses
+- **Developer Portal** — [developer.store.varity.so](https://developer.store.varity.so) — for developers
+
+## Revenue split
+
+| | Amount |
+|---|---|
+| **You (developer)** | **90%** |
+| Varity (platform) | 10% |
+
+You set the price. Varity handles billing, payment processing, and distribution.
+
+<Aside type="note">
+Payment processing is coming soon. During beta, you can submit and list apps on the store. Payments will be enabled in a future update.
+</Aside>
+
+## How it works
+
+<Steps>
+
+1. **Deploy your app**
+
+   Use `varity_deploy` or `varitykit app deploy` to get a live URL.
+
+2. **Submit to the store**
+
+   Use the `varity_submit_to_store` MCP tool or visit the Developer Portal directly. You'll provide:
+   - **App name** — what users see on the store
+   - **Description** — what your app does
+   - **Price** — monthly price in USD (or free)
+   - **Deployment ID** — links to your deployed app
+
+3. **Review**
+
+   Varity reviews your submission for quality and security. Most apps are approved within 24 hours.
+
+4. **Listed on the store**
+
+   Your app appears on [store.varity.so](https://store.varity.so). Businesses can discover, evaluate, and purchase it.
+
+</Steps>
+
+## Pricing your app
+
+You have full control over pricing:
+
+- **Free** — great for open-source tools or lead generation
+- **Monthly subscription** — recurring revenue per user (e.g., $49/month, $99/month)
+
+**Example:** You price your client dashboard at $79/month. For every paying user:
+- You receive **$71.10/month** (90%)
+- Varity receives $7.90/month (10%)
+
+## The Developer Portal
+
+The Developer Portal at [developer.store.varity.so](https://developer.store.varity.so) is where you:
+
+- **Submit new apps** — fill in details, link to your deployment
+- **Manage listings** — update descriptions, pricing, screenshots
+- **View analytics** — see how your apps are performing (coming soon)
+- **Track revenue** — monitor earnings across all your apps (coming soon)
+
+Log in with the same account you use for `varitykit auth login`.
+
+## Submitting via MCP
+
+The fastest way to submit is through your AI coding tool:
+
+**"Submit my last deployment to the app store at $99/month"**
+
+This calls the `varity_submit_to_store` tool, which generates a pre-filled submission link to the Developer Portal. Click the link, review your details, and confirm.
+
+## Submission requirements
+
+- Your app must be deployed on Varity (`varity_deploy`)
+- The app must load and function correctly at the deployed URL
+- Description must accurately represent what the app does
+- No malicious code or security vulnerabilities
+
+## For agencies and consulting firms
+
+The App Store is designed for agencies that build apps for multiple clients:
+
+- **Build once, sell many times** — create a client portal template, price it on the store, earn recurring revenue from every business that uses it
+- **White-label friendly** — businesses use your app at its own URL
+- **No infrastructure management** — Varity handles hosting, auth, database, and scaling for every user of your app
+- **Focus on your clients** — spend time on features, not DevOps
+
+## Next steps
+
+- [Deploy Your App](/deploy/deploy-your-app) — Get a live URL first
+- [How Varity Works](/getting-started/how-varity-works) — The full platform overview
+- [MCP Server](/ai-tools/mcp-server-spec) — Set up your AI coding tool

--- a/src/content/docs/getting-started/how-varity-works.mdx
+++ b/src/content/docs/getting-started/how-varity-works.mdx
@@ -1,0 +1,123 @@
+---
+title: How Varity Works
+description: The complete picture — how consulting firms and agencies use Varity to build, deploy, and monetize enterprise apps for their clients.
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+import PageMeta from '../../../components/PageMeta.astro';
+
+<PageMeta
+  author="Varity Team"
+  authorRole="Core Contributors"
+  lastUpdated="March 2026"
+  stability="stable"
+/>
+
+Varity gives developers everything they need to build, deploy, and monetize production apps — auth, database, hosting, and an app store — in one platform. No infrastructure to manage, no DevOps, 70-85% cheaper than AWS.
+
+## Who Varity is for
+
+Varity is built for **developers and agencies that create business applications** for clients:
+
+- **Consulting firms** building client portals, dashboards, and internal tools
+- **Agencies** delivering SaaS products for enterprises
+- **Freelance developers** shipping production apps quickly
+- **Startups** that want to launch without hiring a DevOps team
+
+If you build apps for businesses, Varity handles the infrastructure so you focus on the product.
+
+## The platform
+
+Varity has four parts:
+
+| Site | What it does | Who uses it |
+|------|-------------|-------------|
+| [**varity.so**](https://www.varity.so) | Marketing site — learn what Varity is | Everyone |
+| [**docs.varity.so**](https://docs.varity.so) | Documentation — tutorials, API reference, guides | Developers |
+| [**store.varity.so**](https://store.varity.so) | App Store — end users browse and use apps | Businesses and end users |
+| [**developer.store.varity.so**](https://developer.store.varity.so) | Developer Portal — submit and manage your apps | Developers |
+
+## The developer flow
+
+Here is how you go from idea to revenue:
+
+<Steps>
+
+1. **Set up your environment**
+
+   Install the Varity MCP server in your AI coding tool (Cursor, Claude Code, VS Code). Run `varity_doctor` to verify everything is ready.
+
+   ```bash
+   claude mcp add varity -- npx -y @varity-labs/mcp
+   ```
+
+2. **Create your app**
+
+   Ask your AI coding tool: "Create a new Varity app called client-dashboard". The `varity_init` tool scaffolds a production-ready project with auth, database, and a full dashboard already wired up.
+
+3. **Build your features**
+
+   Describe what you want to your AI coding tool. The scaffolded template includes authentication (email, Google, GitHub), a database, settings pages, and 20+ UI components. Your AI tool customizes everything to match your client's needs.
+
+4. **Deploy to production**
+
+   Ask: "Deploy this app". The `varity_deploy` tool builds your project and deploys it to a live URL at `varity.app`. Auth, database, and hosting are configured automatically — zero setup.
+
+5. **Submit to the App Store**
+
+   Ask: "Submit this to the app store at $99/month". The `varity_submit_to_store` tool generates a submission link to the Developer Portal where you review and confirm your listing.
+
+6. **Get paid**
+
+   Your app is listed on the Varity App Store. Businesses discover and purchase it. Revenue split: **90% to you, 10% to Varity**.
+
+</Steps>
+
+## What's included — zero configuration
+
+Every app deployed on Varity automatically gets:
+
+- **Authentication** — Email, Google, GitHub, Discord, Apple login. Users see a normal login screen.
+- **Database** — Document database for storing app data. No setup, no connection strings.
+- **Hosting** — Global CDN with custom `varity.app` subdomain. Live in under 2 minutes.
+- **App Store listing** — Submit your app for businesses to discover and purchase.
+
+You never configure infrastructure. It just works.
+
+## Cost comparison
+
+For a typical business app with 500 users:
+
+| | AWS | Vercel | Varity |
+|---|---|---|---|
+| Monthly cost | ~$125 | ~$75 | ~$13 |
+| Auth included | No | No | Yes |
+| Database included | No | No | Yes |
+| App Store | No | No | Yes |
+
+Use the `varity_cost_calculator` MCP tool to get an exact estimate for your project.
+
+## The MCP advantage
+
+The Varity MCP server gives your AI coding tool 9 tools that handle the entire workflow:
+
+| Tool | What it does |
+|------|-------------|
+| `varity_doctor` | Check if your environment is ready |
+| `varity_search_docs` | Search documentation |
+| `varity_cost_calculator` | Compare costs vs AWS/Vercel |
+| `varity_init` | Scaffold a new app |
+| `varity_create_repo` | Create a GitHub repo with template |
+| `varity_deploy` | Deploy to production |
+| `varity_deploy_status` | Check deployment status |
+| `varity_deploy_logs` | View build logs |
+| `varity_submit_to_store` | Submit to the App Store |
+
+[Set up the MCP server](/ai-tools/mcp-server-spec) to get started.
+
+## Next steps
+
+- [Quick Start](/getting-started/quickstart) — Deploy your first app in 5 minutes
+- [MCP Server Setup](/ai-tools/mcp-server-spec) — Connect your AI coding tool
+- [App Store Guide](/deploy/app-store) — Learn how the App Store works
+- [SaaS Starter Template](/templates/saas-starter) — What's in the template


### PR DESCRIPTION
## Summary
Two new pages for beta tester onboarding:

1. **How Varity Works** (`getting-started/how-varity-works.mdx`) — The big picture for agency decision-makers: what the platform is, the 4 websites, the full idea-to-revenue developer flow, cost comparison, MCP tools overview
2. **App Store & Developer Portal** (`deploy/app-store.mdx`) — How to submit apps, pricing, 90/10 revenue split, review process, Developer Portal features, agency use case

## Why
Beta testers (consulting firms/agencies) had no page explaining what the App Store or Developer Portal are, or why an agency would use Varity. These pages fill that gap.

## Test plan
- [ ] Both pages render correctly after deploy
- [ ] All internal links resolve
- [ ] Zero blockchain jargon
- [ ] Payments correctly marked "coming soon"

🤖 Generated with [Claude Code](https://claude.com/claude-code)