### PR TITLE
chore: remove claude code config from public repo

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "WebFetch(domain:docs.varity.so)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ Thumbs.db
 
 # Editor directories
 .idea/
+.claude/
 *.swp
 *.swo
 *~


### PR DESCRIPTION
## Summary
- Removes `.claude/` directory (contained `settings.local.json` — local Claude Code config)
- Adds `.claude/` to `.gitignore` to prevent it from being committed in the future

## Why
Local development tool configuration should not be tracked in a public repository.