### PR TITLE
Add create-varity-app to quickstart, fix CLI command

### DIFF
--- a/src/content/docs/deploy/managed-credentials.mdx
+++ b/src/content/docs/deploy/managed-credentials.mdx
@@ -31,7 +31,7 @@ When you deploy with Varity, credentials are handled automatically at every stag
 </Steps>
 
 ```
-Developer runs: varitykit deploy
+Developer runs: varitykit app deploy
     |
 CLI fetches credentials from Varity's credential proxy
     |

--- a/src/content/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/getting-started/quickstart.mdx
@@ -16,6 +16,20 @@ import PageMeta from '../../../components/PageMeta.astro';
 
 Get your first Varity app running in 5 minutes.
 
+## Starting from scratch?
+
+If you don't have an existing project, scaffold one with everything included:
+
+```bash
+npx create-varity-app my-app
+cd my-app
+npm run dev
+```
+
+This creates a production-ready app with auth, database, dashboard, and 20+ components. Skip to [Deploy](#deploy) when ready.
+
+---
+
 ## Prerequisites
 
 - Node.js 18 or later


### PR DESCRIPTION
## Summary
- Added a "Starting from scratch?" section at the top of the quickstart page (`getting-started/quickstart.mdx`) that directs developers to `npx create-varity-app` for scaffolding a new project with auth, database, dashboard, and 20+ components built in.
- Fixed `varitykit deploy` to `varitykit app deploy` in `deploy/managed-credentials.mdx` (the only remaining instance of the old command across all docs pages).

## Test plan
- [ ] Verify quickstart page renders the new section correctly with the code block
- [ ] Verify the "Skip to Deploy" anchor link works
- [ ] Confirm managed-credentials diagram shows `varitykit app deploy`