### PR TITLE
fix(docs): update stale SDK/CLI versions and deploy URL in llms.txt (VAR-325)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -12,7 +12,7 @@ Varity is a developer platform that provides open-source packages and a CLI for 
 
 ## Packages
 
-### @varity-labs/sdk (v2.0.0-beta.2)
+### @varity-labs/sdk (v2.0.0-beta.14)
 Core SDK for database, storage, and app configuration.
 
 ```typescript
@@ -28,7 +28,7 @@ await users.delete('user-id');
 Key exports: `db`, `Database`, `Collection`, `createApp`, `resolveCredentials`, `logCredentialUsage`, `VERSION`
 Database: `.get()` returns all docs — filter client-side. No server-side queries or `.where()`.
 
-### @varity-labs/ui-kit (v2.0.0-beta.3)
+### @varity-labs/ui-kit (v2.0.0-beta.15)
 React components for auth, dashboards, and UI.
 
 ```typescript
@@ -46,10 +46,10 @@ const email = user?.email?.address;
 
 Components: PrivyStack, PrivyLoginButton, PrivyProtectedRoute, PrivyUserProfile, PrivyReadyGate, VarityDashboardProvider, ThemeProvider, ToastProvider, DashboardLayout, DashboardHeader, DashboardSidebar, DashboardFooter, Button, Input, Textarea, Select, Card, Dialog, ConfirmDialog, Toast, DataTable, Toggle, Checkbox, RadioGroup, Avatar, ProgressBar, Skeleton, Breadcrumb, DropdownMenu, CommandPalette, Sidebar, KPICard, AnalyticsCard, ChartContainer, MetricDisplay, Sparkline, EnhancedKPICard, StatusBadge, IntegrationStatus, EmptyState, LoadingSkeleton, PaymentWidget, PaymentGate
 
-### @varity-labs/types (v2.0.0-beta.2)
+### @varity-labs/types (v2.0.0-beta.8)
 TypeScript type definitions for all Varity interfaces: DatabaseConfig, QueryOptions, Document, CollectionResponse, CredentialConfig.
 
-## CLI: varitykit (v1.1.4)
+## CLI: varitykit (v1.2.9)
 
 Install: `pip install varitykit`
 
@@ -112,7 +112,7 @@ const { user, authenticated, logout } = usePrivy();
 ```bash
 npm run build
 varitykit app deploy
-# App is live at https://your-app.varity.app
+# App is live at https://varity.app/my-app/
 ```
 
 Static hosting and dynamic hosting auto-detected.
@@ -174,7 +174,7 @@ Full docs: https://docs.varity.so
 ## MCP Server
 
 Install: `npx -y @varity-labs/mcp`
-7 tools: varity_search_docs, varity_cost_calculator, varity_init, varity_deploy, varity_deploy_status, varity_deploy_logs, varity_submit_to_store
+15 tools: varity_search_docs, varity_cost_calculator, varity_doctor, varity_login, varity_init, varity_install_deps, varity_build, varity_add_collection, varity_create_repo, varity_deploy, varity_deploy_status, varity_deploy_logs, varity_submit_to_store, varity_migrate, varity_open_browser
 
 Setup for Cursor (.cursor/mcp.json):
 ```json


### PR DESCRIPTION
## Summary

- **Root cause of VAR-325**: `llms.txt` is fetched live by `varity_search_docs` at runtime — stale content here caused the MCP to serve wrong version info to AI coding tools.
- Fixed all 5 stale data points identified in the bug report.

## Changes

| Field | Was | Now |
|-------|-----|-----|
| `@varity-labs/sdk` | v2.0.0-beta.2 | v2.0.0-beta.14 |
| `@varity-labs/ui-kit` | v2.0.0-beta.3 | v2.0.0-beta.15 |
| `@varity-labs/types` | v2.0.0-beta.2 | v2.0.0-beta.8 |
| `varitykit` CLI | v1.1.4 | v1.2.9 |
| Deploy URL | `https://your-app.varity.app` | `https://varity.app/my-app/` |
| MCP tool count | 7 tools | 15 tools (full list) |

## Test plan

- [ ] Verify `https://docs.varity.so/llms.txt` reflects updated versions after deploy
- [ ] Run `varity_search_docs("install")` and confirm no old beta versions appear
- [ ] Run `varity_search_docs("deploy")` and confirm URL format shows `varity.app/my-app/`

## Agent notes

Tested against World Model regression patterns: yes (no conflicts with regressions.md).
Follows shared rules: 0, 1, 2, 4, 5, 6, 7, 8.

Agent: DX Fixer (bd29e23e) — ticket VAR-325