### PR TITLE
fix(docs): add missing index pages for 10 paths returning IPFS errors (VAR-353)

### DIFF
--- a/src/content/docs/build/auth/index.mdx
+++ b/src/content/docs/build/auth/index.mdx
@@ -1,0 +1,12 @@
+---
+title: Authentication
+description: Add user authentication to your app with Varity.
+---
+
+import { LinkCard } from '@astrojs/starlight/components';
+
+<script>{"window.location.replace('/build/auth/quickstart/');"}</script>
+
+<LinkCard title="Quick Start" href="/build/auth/quickstart/" description="Add auth to your app in minutes." />
+<LinkCard title="Email Login" href="/build/auth/email-login/" description="Set up email/password authentication." />
+<LinkCard title="Social Login" href="/build/auth/social-login/" description="Add Google, GitHub, and other OAuth providers." />

--- a/src/content/docs/build/storage/index.mdx
+++ b/src/content/docs/build/storage/index.mdx
@@ -1,0 +1,12 @@
+---
+title: File Storage
+description: Upload, store, and retrieve files with Varity's built-in storage.
+---
+
+import { LinkCard } from '@astrojs/starlight/components';
+
+<script>{"window.location.replace('/build/storage/quickstart/');"}</script>
+
+<LinkCard title="Quick Start" href="/build/storage/quickstart/" description="Start uploading files in minutes." />
+<LinkCard title="Upload Files" href="/build/storage/upload/" description="Upload files from your app." />
+<LinkCard title="Retrieve Files" href="/build/storage/retrieve/" description="Access and serve stored files." />

--- a/src/content/docs/cli/index.mdx
+++ b/src/content/docs/cli/index.mdx
@@ -1,0 +1,12 @@
+---
+title: CLI
+description: The Varity CLI — deploy and manage apps from the terminal.
+---
+
+import { LinkCard } from '@astrojs/starlight/components';
+
+<script>{"window.location.replace('/cli/overview/');"}</script>
+
+<LinkCard title="CLI Overview" href="/cli/overview/" description="What the Varity CLI can do." />
+<LinkCard title="Installation" href="/cli/installation/" description="Install the Varity CLI." />
+<LinkCard title="Commands" href="/cli/commands/deploy/" description="Browse all CLI commands." />

--- a/src/content/docs/deploy/index.mdx
+++ b/src/content/docs/deploy/index.mdx
@@ -1,0 +1,12 @@
+---
+title: Deploy
+description: Deploy your app with Varity — one command, live in minutes.
+---
+
+import { LinkCard } from '@astrojs/starlight/components';
+
+<script>{"window.location.replace('/deploy/deploy-your-app/');"}</script>
+
+<LinkCard title="Deploy Your App" href="/deploy/deploy-your-app/" description="Step-by-step guide to deploying with Varity." />
+<LinkCard title="Custom Domains" href="/deploy/custom-domains/" description="Connect your own domain to your deployment." />
+<LinkCard title="Environment Variables" href="/deploy/env-variables/" description="Configure environment variables for your app." />

--- a/src/content/docs/getting-started/index.mdx
+++ b/src/content/docs/getting-started/index.mdx
@@ -1,0 +1,12 @@
+---
+title: Getting Started
+description: Get started with Varity — build, deploy, and monetize apps with one command.
+---
+
+import { LinkCard } from '@astrojs/starlight/components';
+
+<script>{"window.location.replace('/getting-started/introduction/');"}</script>
+
+<LinkCard title="Introduction" href="/getting-started/introduction/" description="Learn what Varity is and how it works." />
+<LinkCard title="Quick Start" href="/getting-started/quickstart/" description="Deploy your first app in minutes." />
+<LinkCard title="Installation" href="/getting-started/installation/" description="Install the CLI and SDK packages." />

--- a/src/pages/build/database/index.astro
+++ b/src/pages/build/database/index.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/build/databases/quickstart/', 301);
+---

--- a/src/pages/build/deploy/index.astro
+++ b/src/pages/build/deploy/index.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/deploy/deploy-your-app/', 301);
+---

--- a/src/pages/introduction/index.astro
+++ b/src/pages/introduction/index.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/getting-started/introduction/', 301);
+---

--- a/src/pages/sdk/auth/index.astro
+++ b/src/pages/sdk/auth/index.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/build/auth/quickstart/', 301);
+---

--- a/src/pages/sdk/storage/index.astro
+++ b/src/pages/sdk/storage/index.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/build/storage/quickstart/', 301);
+---


### PR DESCRIPTION
## Summary
- 10 docs pages at `docs.varity.so` were returning raw IPFS error text (`failed to resolve /ipfs/bafybei...`) because no `index.html` existed at those paths in the deployed bundle
- Root cause: Starlight only generates HTML for files that exist in `src/content/docs/` — section root paths like `/deploy/`, `/cli/`, `/getting-started/` had no `index.mdx`, and old/renamed paths like `/introduction/`, `/sdk/auth/` had no redirects
- Fix: created 5 Starlight section-root pages (with JS redirect + LinkCard navigation) and 5 Astro redirect pages (meta-refresh to current URLs)

## Pages fixed

| Path | Type | Redirects to |
|------|------|-------------|
| `/getting-started/` | Starlight + JS redirect | `/getting-started/introduction/` |
| `/deploy/` | Starlight + JS redirect | `/deploy/deploy-your-app/` |
| `/cli/` | Starlight + JS redirect | `/cli/overview/` |
| `/build/auth/` | Starlight + JS redirect | `/build/auth/quickstart/` |
| `/build/storage/` | Starlight + JS redirect | `/build/storage/quickstart/` |
| `/introduction/` | Astro meta-refresh | `/getting-started/introduction/` |
| `/build/database/` | Astro meta-refresh | `/build/databases/quickstart/` |
| `/build/deploy/` | Astro meta-refresh | `/deploy/deploy-your-app/` |
| `/sdk/auth/` | Astro meta-refresh | `/build/auth/quickstart/` |
| `/sdk/storage/` | Astro meta-refresh | `/build/storage/quickstart/` |

## Test plan
- [x] `npm run build` passes — 74 pages, zero errors
- [x] All 10 previously-missing paths confirmed present in `dist/`
- [x] All redirect targets verified in generated HTML
- [x] No blockchain jargon in any new file (Rule 4 compliant)
- [ ] Human: rebuild and redeploy to IPFS — verify all 10 URLs return 200 instead of IPFS error text

## Agent notes
Checked `world_model_recent_activity` — no other agents working on docs. No related prior work found in WM for IPFS docs errors. Build verification confirmed all 10 paths present.
Follows shared rules: 0, 1, 2, 3, 4.

Agent: Docs Sync (Paperclip) — ticket VAR-353