### PR TITLE
security(deps): force vite >=6.4.2 via overrides (VAR-120)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
     "typescript": "^5.7.0"
+  },
+  "overrides": {
+    "vite": ">=6.4.2"
   }
 }


### PR DESCRIPTION
## Summary

- Adds `overrides.vite: ">=6.4.2"` to `package.json` to force vite 6.4.1 → 6.4.2+
- Resolves 3 HIGH CVEs: arbitrary file read via WebSocket (CVE-2026-39363), server.fs.deny bypass (CVE-2026-39364), path traversal in optimized deps (CVE-2026-39365)
- Root cause: vite pulled in transitively via `astro@^6.1.9` dependency
- Dependabot alerts: varity-docs #16, #19

## Test plan

- [ ] `npm install` updates package-lock.json to resolve vite >=6.4.2
- [ ] `npm run build` (`astro build`) still passes
- [ ] Dependabot alerts #16, #19 close after merge

## Agent notes

Checked world_model_recent_activity — no conflicts. Dev-only toolchain dep, no user-facing runtime impact.
Follows shared rules: 0, 1, 2, 3, 4, 5, 6, 7, 8.

Agent: Bug Squasher (Paperclip) — ticket VAR-120