### PR TITLE
fix(docs): em-dash purge + payments audit + content rewrites (VAR-424)

### DIFF
--- a/src/content/docs/ai-tools/mcp-server-spec.mdx
+++ b/src/content/docs/ai-tools/mcp-server-spec.mdx
@@ -106,7 +106,7 @@ Authenticate with Varity using a deploy key or browser-based login. Required bef
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `method` | `"deploy-key"` \| `"browser"` | No | `"browser"` | Authentication method |
-| `deploy_key` | string | No | — | Deploy key (required when `method` is `"deploy-key"`) |
+| `deploy_key` | string | No | none | Deploy key (required when `method` is `"deploy-key"`) |
 
 **Annotations:** `destructiveHint: true` (writes credentials to local config)
 
@@ -120,7 +120,7 @@ Search Varity docs for guides, API references, and tutorials.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `query` | string | Yes | — | Search query (e.g., "database setup", "how to deploy") |
+| `query` | string | Yes | none | Search query (e.g., "database setup", "how to deploy") |
 | `maxResults` | number | No | 3 | Maximum results to return |
 
 **Annotations:** `readOnlyHint: true`
@@ -135,7 +135,7 @@ Compare Varity hosting costs against AWS, Vercel, and other platforms.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `users` | number | Yes | — | Estimated monthly active users |
+| `users` | number | Yes | none | Estimated monthly active users |
 | `storage_gb` | number | No | 10 | Storage needed in GB |
 | `has_database` | boolean | No | true | Whether the app uses a database |
 | `has_auth` | boolean | No | true | Whether the app uses authentication |
@@ -152,7 +152,7 @@ Scaffold a production-ready app with auth, database, and payments.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `name` | string | Yes | — | Project name (lowercase, hyphens allowed) |
+| `name` | string | Yes | none | Project name (lowercase, hyphens allowed) |
 | `template` | `"saas-starter"` | No | `"saas-starter"` | Template to use |
 | `path` | string | No | Current directory | Directory to create the project in |
 
@@ -169,7 +169,7 @@ Install dependencies for a Varity project. Runs `npm install` for all packages o
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `path` | string | No | Current directory | Project directory to install dependencies in |
-| `packages` | string[] | No | — | Specific packages to install (e.g., `["axios", "lodash"]`). If omitted, installs all dependencies. |
+| `packages` | string[] | No | none | Specific packages to install (e.g., `["axios", "lodash"]`). If omitted, installs all dependencies. |
 
 **Example prompt:** "Install dependencies for my project" or "Install axios and lodash"
 
@@ -181,8 +181,8 @@ Add a new database collection to your project. Creates the TypeScript type, coll
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `name` | string | Yes | — | Collection name (lowercase, e.g., "invoices", "team_members") |
-| `fields` | array | Yes | — | Field definitions: `[{name: "amount", type: "number"}, {name: "status", type: "string"}]` |
+| `name` | string | Yes | none | Collection name (lowercase, e.g., "invoices", "team_members") |
+| `fields` | array | Yes | none | Field definitions: `[{name: "amount", type: "number"}, {name: "status", type: "string"}]` |
 | `path` | string | No | Current directory | Project directory |
 | `add_page` | boolean | No | false | Scaffold a dashboard page with DataTable and Dialog |
 
@@ -200,7 +200,7 @@ Start, stop, or check the status of your local development server. Returns the l
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `action` | `"start"` \| `"stop"` \| `"status"` | Yes | — | Action to perform |
+| `action` | `"start"` \| `"stop"` \| `"status"` | Yes | none | Action to perform |
 | `path` | string | No | Current directory | Project directory |
 | `port` | number | No | 3000 | Port to run the dev server on. If busy, auto-selects next available port and persists to `varity.config.json`. |
 
@@ -226,7 +226,7 @@ Open a URL in the user's default browser. Use after deploying to show the live a
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `url` | string | Yes | — | URL to open in the default browser |
+| `url` | string | Yes | none | URL to open in the default browser |
 
 **Example prompt:** "Open the deployment in my browser"
 
@@ -234,15 +234,15 @@ Open a URL in the user's default browser. Use after deploying to show the live a
 
 ### `varity_create_repo`: Create GitHub repository
 
-Create a new GitHub repository with the Varity SaaS template. Useful for browser-based workflows — create a repo, open in Gitpod/StackBlitz, and deploy.
+Create a new GitHub repository with the Varity SaaS template. Useful for browser-based workflows: create a repo, open it in Gitpod or StackBlitz, and deploy.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `name` | string | Yes | — | Repository name (lowercase, hyphens allowed) |
-| `description` | string | No | — | Short description for the repo |
+| `name` | string | Yes | none | Repository name (lowercase, hyphens allowed) |
+| `description` | string | No | none | Short description for the repo |
 | `template` | `"saas-starter"` | No | `"saas-starter"` | Template to use |
 | `visibility` | `"public"` \| `"private"` | No | `"public"` | Repository visibility |
-| `github_token` | string | No | — | GitHub personal access token with `repo` scope |
+| `github_token` | string | No | none | GitHub personal access token with `repo` scope |
 
 **Annotations:** `destructiveHint: true` (creates an external GitHub repository)
 
@@ -271,7 +271,7 @@ List all deployments or get status of a specific one. Shows URL, status, framewo
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `deployment_id` | string | No | — | Specific deployment ID (omit to list all) |
+| `deployment_id` | string | No | none | Specific deployment ID (omit to list all) |
 
 **Annotations:** `readOnlyHint: true`
 
@@ -285,7 +285,7 @@ Get build and deployment logs for debugging failed or recent deployments.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `deployment_id` | string | Yes | — | The deployment ID to get logs for |
+| `deployment_id` | string | Yes | none | The deployment ID to get logs for |
 | `limit` | number | No | 100 | Maximum log lines to return |
 
 **Annotations:** `readOnlyHint: true`
@@ -300,7 +300,7 @@ Migrate a Vercel project to Varity in one step: clone the GitHub repository, rem
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `github_url` | string | Yes | — | GitHub repository URL to migrate (e.g. `https://github.com/user/my-app`) |
+| `github_url` | string | Yes | none | GitHub repository URL to migrate (e.g. `https://github.com/user/my-app`) |
 | `dry_run` | boolean | No | `false` | Preview what would change without deploying |
 
 **Annotations:** `destructiveHint: true` (clones a repo and deploys infrastructure)
@@ -355,7 +355,7 @@ Here's the full build-to-monetize flow using the MCP tools:
 
 1. **"Check if my environment is ready"** → `varity_doctor`
 2. **"Migrate my Vercel app at https://github.com/user/my-app"** → `varity_migrate`
-3. *(Done — the app is live and on Varity infrastructure)*
+3. *(Done. The app is live on Varity infrastructure.)*
 
 ## Troubleshooting
 
@@ -375,8 +375,8 @@ Run `claude mcp list` to verify the server is registered. Re-add with `claude mc
 
 The MCP server supports two transports:
 
-- **stdio** (default) — for desktop editors like Cursor, Claude Code, VS Code, Windsurf
-- **HTTP** — for browser-based AI tools like Claude.ai and ChatGPT
+- **stdio** (default): for desktop editors like Cursor, Claude Code, VS Code, Windsurf
+- **HTTP**: for browser-based AI tools like Claude.ai and ChatGPT
 
 ### Hosted MCP
 
@@ -416,5 +416,5 @@ For LLMs without MCP support, use the docs context files:
 ## Support
 
 - [Documentation](https://docs.varity.so/ai-tools/overview)
-- [Discord](https://discord.gg/7vWsdwa2Bg) — ask in #general
+- [Discord](https://discord.gg/7vWsdwa2Bg): ask in #general
 - [GitHub Issues](https://github.com/varity-labs/varity-sdk/issues)

--- a/src/content/docs/ai-tools/overview.mdx
+++ b/src/content/docs/ai-tools/overview.mdx
@@ -30,7 +30,7 @@ Varity provides AI tooling to help you build faster. Copy a prompt into your AI 
     Machine-readable documentation for AI assistants. Available in two formats: `/llms.txt` (summary) and `/llms-full.txt` (detailed).
   </Card>
   <Card title="MCP Server" icon="rocket">
-    Model Context Protocol server for Cursor, Claude Code, VS Code, and Windsurf — deploy, search docs, and manage apps from your AI editor.
+    Model Context Protocol server for Cursor, Claude Code, VS Code, and Windsurf. Deploy, search docs, and manage apps from your AI editor.
 
     [View Spec →](/ai-tools/mcp-server-spec)
   </Card>
@@ -59,7 +59,7 @@ The fastest way to get AI assistance with Varity is to copy one of our [AI Promp
 
 The Varity MCP server lets your AI editor create, deploy, and manage Varity apps directly.
 
-**For Cursor** — add to `.cursor/mcp.json`:
+**For Cursor:** add to `.cursor/mcp.json`:
 
 ```json
 {
@@ -78,17 +78,17 @@ The Varity MCP server lets your AI editor create, deploy, and manage Varity apps
 claude mcp add varity -- npx -y @varity-labs/mcp
 ```
 
-Then ask your AI to "create a Varity app" or "deploy this project" — it has 15 tools for the full build-to-monetize workflow. See the [MCP Server Spec](/ai-tools/mcp-server-spec) for the complete tool reference, or check out the [Build with AI (No Code)](/tutorials/build-with-ai/) tutorial to get started.
+Then ask your AI to "create a Varity app" or "deploy this project." It has 15 tools for the full build-to-monetize workflow. See the [MCP Server Spec](/ai-tools/mcp-server-spec) for the complete tool reference, or check out the [Build with AI (No Code)](/tutorials/build-with-ai/) tutorial to get started.
 
 ## Cursor Rules
 
 Pre-configured rules that teach Cursor IDE how to write Varity code correctly.
 
 **Available rules:**
-- **Varity App Development** — SDK patterns, database queries, auth setup
-- **Deployment** — CLI commands, environment variables, hosting options
-- **Authentication** — Auth setup, protected routes, user data
-- **Database** — Collections, typed queries, CRUD hooks
+- **Varity App Development**: SDK patterns, database queries, auth setup
+- **Deployment**: CLI commands, environment variables, hosting options
+- **Authentication**: Auth setup, protected routes, user data
+- **Database**: Collections, typed queries, CRUD hooks
 
 **Install:**
 
@@ -105,8 +105,8 @@ AI assistants can reference our documentation in machine-readable formats:
 
 | File | URL | Use Case |
 |------|-----|----------|
-| `llms.txt` | `https://docs.varity.so/llms.txt` | Summary — what Varity is, key APIs, common patterns |
-| `llms-full.txt` | `https://docs.varity.so/llms-full.txt` | Detailed — full documentation content for deep context |
+| `llms.txt` | `https://docs.varity.so/llms.txt` | Summary: what Varity is, key APIs, common patterns |
+| `llms-full.txt` | `https://docs.varity.so/llms-full.txt` | Detailed: full documentation content for deep context |
 
 Point any AI tool at one of these URLs for instant Varity context. Use `llms.txt` for quick context in chat-based LLMs (ChatGPT, Gemini), and `llms-full.txt` when the AI needs comprehensive documentation.
 
@@ -119,7 +119,7 @@ Our tools teach AI assistants these patterns:
 AI assistants are trained to use developer-friendly language:
 
 - "Deploy your application" (not "upload to IPFS")
-- "Sign in" (not "connect wallet")
+- "Sign in" (the user just sees a normal login screen)
 - "Usage fees are covered" (not "gasless transactions")
 
 ### Type Safety
@@ -158,5 +158,5 @@ try {
 
 ## What's Next
 
-- **[AI Prompts](/ai-tools/prompts)** — Ready-to-use prompts for every AI tool
-- **[MCP Server Spec](/ai-tools/mcp-server-spec)** — Setup guide and tool reference
+- **[AI Prompts](/ai-tools/prompts)**: Ready-to-use prompts for every AI tool
+- **[MCP Server Spec](/ai-tools/mcp-server-spec)**: Setup guide and tool reference

--- a/src/content/docs/ai-tools/prompts.mdx
+++ b/src/content/docs/ai-tools/prompts.mdx
@@ -13,7 +13,7 @@ import PageMeta from '../../../components/PageMeta.astro';
   stability="stable"
 />
 
-Copy these prompts into your AI assistant to build Varity apps faster. Each prompt gives your AI the full context it needs — SDK patterns, database API, authentication setup, and deployment commands.
+Copy these prompts into your AI assistant to build Varity apps faster. Each prompt gives your AI the full context it needs: SDK patterns, database API, authentication setup, and deployment commands.
 
 ## How to Use
 
@@ -21,7 +21,7 @@ Copy these prompts into your AI assistant to build Varity apps faster. Each prom
   <TabItem label="Cursor">
     1. Save the prompt as `.cursor/rules/varity.mdc` in your project root
     2. Cursor automatically loads the rules for every file in the project
-    3. Start asking Cursor to build features — it knows Varity patterns
+    3. Start asking Cursor to build features. It knows Varity patterns
   </TabItem>
   <TabItem label="Claude Code">
     1. Copy the prompt content below
@@ -538,13 +538,13 @@ Available icons: dashboard, folder, list, people, settings, star
 
 All prompts are available as plain text files you can download directly:
 
-- [Varity App Development (Full)](/prompts/varity-app-development.md) — Complete development context
-- [Database Schema Design](/prompts/database-schema-design.md) — Database patterns
-- [Deployment Guide](/prompts/deployment-guide.md) — CLI and deploy commands
-- [Customize Template](/prompts/customize-template.md) — Template customization
+- [Varity App Development (Full)](/prompts/varity-app-development.md) : Complete development context
+- [Database Schema Design](/prompts/database-schema-design.md) : Database patterns
+- [Deployment Guide](/prompts/deployment-guide.md) : CLI and deploy commands
+- [Customize Template](/prompts/customize-template.md) : Template customization
 
 ## Next Steps
 
-- [Quick Start](/getting-started/quickstart) — Build your first app
-- [SaaS Starter Template](/templates/saas-starter) — Explore the template
-- [AI Tools Overview](/ai-tools/overview) — All AI integrations
+- [Quick Start](/getting-started/quickstart) : Build your first app
+- [SaaS Starter Template](/templates/saas-starter) : Explore the template
+- [AI Tools Overview](/ai-tools/overview) : All AI integrations

--- a/src/content/docs/build/auth/quickstart.mdx
+++ b/src/content/docs/build/auth/quickstart.mdx
@@ -17,11 +17,11 @@ Add authentication to your app in under 5 minutes. No configuration required for
 
 ## What you get
 
-- **Email login** — passwordless magic links
-- **Social login** — Google, Twitter, Discord, GitHub
-- **Automatic accounts** — created on first sign-in
-- **Session management** — persistent sessions, handled for you
-- **Protected routes** — restrict pages to signed-in users
+- **Email login**: passwordless magic links
+- **Social login**: Google, Twitter, Discord, GitHub
+- **Automatic accounts**: created on first sign-in
+- **Session management**: persistent sessions, handled for you
+- **Protected routes**: restrict pages to signed-in users
 
 ## Install
 
@@ -147,7 +147,7 @@ function Profile() {
 
 ## Next steps
 
-- [Email Login](/build/auth/email-login) — configure magic link options
-- [Social Login](/build/auth/social-login) — Google, Twitter, Discord setup
-- [Protected Routes](/packages/ui-kit/components#privyprotectedroute) — route protection API
-- [Storage Guide](/build/storage/quickstart) — upload and retrieve files
+- [Email Login](/build/auth/email-login): configure magic link options
+- [Social Login](/build/auth/social-login): Google, Twitter, Discord setup
+- [Protected Routes](/packages/ui-kit/components#privyprotectedroute): route protection API
+- [Storage Guide](/build/storage/quickstart): upload and retrieve files

--- a/src/content/docs/build/auth/social-login.mdx
+++ b/src/content/docs/build/auth/social-login.mdx
@@ -13,7 +13,7 @@ import PageMeta from '../../../../components/PageMeta.astro';
   stability="stable"
 />
 
-Let users sign in with accounts they already have. No new passwords, no email verification—just one click.
+Let users sign in with accounts they already have. No new passwords, no email verification. Just one click.
 
 ## Supported Providers
 

--- a/src/content/docs/build/databases/quickstart.mdx
+++ b/src/content/docs/build/databases/quickstart.mdx
@@ -13,7 +13,7 @@ import PageMeta from '../../../../components/PageMeta.astro';
   stability="stable"
 />
 
-Varity includes a zero-config database. Import `db` from the SDK and start querying immediately — no database setup, no connection strings, no ORM configuration.
+Varity includes a zero-config database. Import `db` from the SDK and start querying immediately: no database setup, no connection strings, no ORM configuration.
 
 ## Installation
 
@@ -53,7 +53,7 @@ export interface Task {
 ```
 
 <Aside type="tip">
-The `id` field is optional — Varity generates one automatically when you insert a document.
+The `id` field is optional. Varity generates one automatically when you insert a document.
 </Aside>
 
 ## Create Collection Helpers
@@ -339,23 +339,23 @@ export function useTasks(projectId?: string) {
 </Tabs>
 
 <Aside type="tip">
-**Don't have credentials?** When you deploy with `varitykit app deploy`, the CLI detects database usage in your code and automatically generates credentials (app ID, JWT token, proxy URL). These are injected into your build at deploy time — no manual setup needed for production. During local development, you can set these env vars manually or build your UI with mock data first.
+**Don't have credentials?** When you deploy with `varitykit app deploy`, the CLI detects database usage in your code and automatically generates credentials (app ID, JWT token, proxy URL). These are injected into your build at deploy time. No manual setup needed for production. During local development, you can set these env vars manually or build your UI with mock data first.
 </Aside>
 
 ## The Pattern: Collection, Hook, Page
 
 Every feature in a Varity app follows the same 3-step pattern:
 
-1. **Type** — Define a TypeScript interface in `types/index.ts`
-2. **Collection** — Create a typed collection accessor in `database.ts`
-3. **Hook** — Build a React hook with CRUD + optimistic updates
-4. **Page** — Use the hook in a page component
+1. **Type**: Define a TypeScript interface in `types/index.ts`
+2. **Collection**: Create a typed collection accessor in `database.ts`
+3. **Hook**: Build a React hook with CRUD + optimistic updates
+4. **Page**: Use the hook in a page component
 
 This pattern is used throughout the [SaaS Starter Template](/templates/saas-starter) for projects, tasks, and team members.
 
 ## Next Steps
 
-- [Authentication](/build/auth/quickstart) — Add user login to protect data
-- [SaaS Starter Template](/templates/saas-starter) — See a full working app with database integration
-- [Add a CRUD Feature](/tutorials/add-crud-feature) — Step-by-step guide to add a new data model
-- [Deploy](/deploy/deploy-your-app) — Go live
+- [Authentication](/build/auth/quickstart): Add user login to protect data
+- [SaaS Starter Template](/templates/saas-starter): See a full working app with database integration
+- [Add a CRUD Feature](/tutorials/add-crud-feature): Step-by-step guide to add a new data model
+- [Deploy](/deploy/deploy-your-app): Go live

--- a/src/content/docs/build/payments/credit-card.mdx
+++ b/src/content/docs/build/payments/credit-card.mdx
@@ -136,5 +136,5 @@ Revenue is tracked in the [Developer Portal](https://developer.store.varity.so).
 
 ## Next Steps
 
-- [Free Operations](/build/payments/gasless) - Users never pay usage fees
-- [Authentication Quick Start](/build/auth/quickstart) - Set up user accounts
+- [Deploy Your App](/deploy/deploy-your-app): Submit your app to the store
+- [Authentication Quick Start](/build/auth/quickstart): Set up user accounts

--- a/src/content/docs/build/payments/quickstart.mdx
+++ b/src/content/docs/build/payments/quickstart.mdx
@@ -16,7 +16,7 @@ import PageMeta from '../../../../components/PageMeta.astro';
 # Payments Quick Start
 
 <Aside type="note">
-Payments are processed via the App Store checkout. Credit card payments via Stripe are also available — users can purchase deploy keys and subscriptions at [varity.so](https://varity.so).
+Payments are processed via the App Store checkout. Credit card payments via Stripe are also available: users can purchase deploy keys and subscriptions at [varity.so](https://varity.so).
 </Aside>
 
 Monetize your app through the Varity App Store. Set your price, deploy, and earn revenue automatically.
@@ -47,13 +47,13 @@ This is handled automatically. No payment integration code required on your end.
 3. **Set your pricing** in the [Developer Portal](https://developer.store.varity.so)
 
    Choose from:
-   - **Free** — no charge, great for building an audience
-   - **One-time purchase** — users pay once for lifetime access
-   - **Monthly subscription** — recurring revenue
+   - **Free**: no charge, great for building an audience
+   - **One-time purchase**: users pay once for lifetime access
+   - **Monthly subscription**: recurring revenue
 
 4. **Users discover and purchase** your app on [store.varity.so](https://store.varity.so)
 
-5. **You earn revenue** — 90% of every payment, deposited monthly
+5. **You earn revenue**: 90% of every payment, deposited monthly
 
 </Steps>
 
@@ -134,5 +134,5 @@ Users pay in their local currency using familiar payment methods. No special set
 
 ## Next Steps
 
-- [Free Operations](/build/payments/gasless) — Users never pay usage fees
-- [Deploy Your App](/deploy/deploy-your-app) — Submit to the App Store
+- [Deploy Your App](/deploy/deploy-your-app): Submit to the App Store
+- [FAQ](/resources/faq): Pricing and billing questions

--- a/src/content/docs/build/storage/quickstart.mdx
+++ b/src/content/docs/build/storage/quickstart.mdx
@@ -18,10 +18,10 @@ Store and retrieve structured data with zero configuration. The Varity SDK provi
 
 ## What You Get
 
-- **Zero config** — works immediately with shared dev credentials
-- **Simple API** — `add`, `get`, `update`, `delete` on collections
-- **Type-safe** — full TypeScript generics support
-- **Auto-provisioned** — deploy with `varitykit app deploy` and get your own private database
+- **Zero config**: works immediately with shared dev credentials
+- **Simple API**: `add`, `get`, `update`, `delete` on collections
+- **Type-safe**: full TypeScript generics support
+- **Auto-provisioned**: deploy with `varitykit app deploy` and get your own private database
 
 ## Installation
 
@@ -282,6 +282,6 @@ When you deploy with `varitykit app deploy`, these are set automatically.
 
 ## Next Steps
 
-- [Storing Data](/build/storage/upload) — Create and update records
-- [Retrieving Data](/build/storage/retrieve) — Query and filter records
-- [Authentication](/build/auth/quickstart) — Set up user login
+- [Storing Data](/build/storage/upload): Create and update records
+- [Retrieving Data](/build/storage/retrieve): Query and filter records
+- [Authentication](/build/auth/quickstart): Set up user login

--- a/src/content/docs/build/storage/retrieve.mdx
+++ b/src/content/docs/build/storage/retrieve.mdx
@@ -257,6 +257,6 @@ try {
 
 ## Next Steps
 
-- [Storing Data](/build/storage/upload) — Create and update records
-- [Data Storage Quick Start](/build/storage/quickstart) — Overview and setup
-- [Payments](/build/payments/quickstart) — Accept payments
+- [Storing Data](/build/storage/upload): Create and update records
+- [Data Storage Quick Start](/build/storage/quickstart): Overview and setup
+- [Payments](/build/payments/quickstart): Accept payments

--- a/src/content/docs/build/storage/upload.mdx
+++ b/src/content/docs/build/storage/upload.mdx
@@ -261,6 +261,6 @@ async function safeUpdate(collectionName: string, id: string, data: any) {
 
 ## Next Steps
 
-- [Retrieving Data](/build/storage/retrieve) — Query and display records
-- [Data Storage Quick Start](/build/storage/quickstart) — Overview and setup
-- [Payments](/build/payments/quickstart) — Accept payments
+- [Retrieving Data](/build/storage/retrieve): Query and display records
+- [Data Storage Quick Start](/build/storage/quickstart): Overview and setup
+- [Payments](/build/payments/quickstart): Accept payments

--- a/src/content/docs/cli/commands/deploy.mdx
+++ b/src/content/docs/cli/commands/deploy.mdx
@@ -42,7 +42,7 @@ varitykit app deploy
 - Global CDN distribution
 - Permanent deployment URLs
 - Automatic SSL
-- Usage-based pricing — pay only for what you serve
+- Usage-based pricing: pay only for what you serve
 
 ### Dynamic Apps
 

--- a/src/content/docs/cli/overview.mdx
+++ b/src/content/docs/cli/overview.mdx
@@ -99,7 +99,7 @@ VarityKit is a Python-based CLI that helps you build, test, and deploy applicati
 | `varitykit migrate --path <path>` | Migrate a local Vercel project directory |
 | `varitykit migrate --dry-run` | Preview what would change without modifying files |
 | `varitykit migrate --no-deploy` | Apply codemods only, skip deployment |
-| `varitykit migrate analyze <path>` | Scan for Vercel artifacts — read-only preview |
+| `varitykit migrate analyze <path>` | Scan for Vercel artifacts (read-only preview) |
 | `varitykit migrate apply <path>` | Apply codemods without deploying |
 | `varitykit migrate rollback <path>` | Restore files from `.vercel-migration-backup/` |
 
@@ -188,8 +188,8 @@ Varity currently auto-detects and deploys the following frameworks:
 | React (Vite) | ✅ | ✅ |
 | React (CRA) | ✅ | ✅ |
 | Vue 3+ | ✅ | ✅ |
-| Express, Fastify, Nest, Koa, Hono | — | ✅ |
-| FastAPI, Django, Flask | — | ✅ |
+| Express, Fastify, Nest, Koa, Hono | N/A | ✅ |
+| FastAPI, Django, Flask | N/A | ✅ |
 
 **Not yet supported:** Go, Rust, Ruby, Elixir, Java, PHP, .NET. These will not be auto-detected and deployment will fail with an unsupported-language error. [Request support for your framework](https://github.com/varity-labs/varity-sdk/issues).
 

--- a/src/content/docs/deploy/app-store.mdx
+++ b/src/content/docs/deploy/app-store.mdx
@@ -19,8 +19,8 @@ import PageMeta from '../../../components/PageMeta.astro';
 
 The Varity App Store is where businesses discover and purchase apps built by developers. The Developer Portal is where you manage your listings.
 
-- **App Store** — [store.varity.so](https://store.varity.so) — for end users and businesses (post-beta)
-- **Developer Portal** — [developer.store.varity.so](https://developer.store.varity.so) — for developers
+- **App Store** at [store.varity.so](https://store.varity.so) for end users and businesses (post-beta)
+- **Developer Portal** at [developer.store.varity.so](https://developer.store.varity.so) for developers
 
 ## Revenue split
 
@@ -46,10 +46,10 @@ Payment processing is coming soon. During beta, you can submit and list apps on 
 2. **Submit to the store**
 
    Use the `varity_submit_to_store` MCP tool or visit the Developer Portal directly. You'll provide:
-   - **App name** — what users see on the store
-   - **Description** — what your app does
-   - **Price** — monthly price in USD (or free)
-   - **Deployment ID** — links to your deployed app
+   - **App name**: what users see on the store
+   - **Description**: what your app does
+   - **Price**: monthly price in USD (or free)
+   - **Deployment ID**: links to your deployed app
 
 3. **Review**
 
@@ -65,8 +65,8 @@ Payment processing is coming soon. During beta, you can submit and list apps on 
 
 You have full control over pricing:
 
-- **Free** — great for open-source tools or lead generation
-- **Monthly subscription** — recurring revenue per user, set at any price you choose
+- **Free**: great for open-source tools or lead generation
+- **Monthly subscription**: recurring revenue per user, set at any price you choose
 
 The platform takes a 10% share of subscription revenue; you keep 90%.
 
@@ -74,10 +74,10 @@ The platform takes a 10% share of subscription revenue; you keep 90%.
 
 The Developer Portal at [developer.store.varity.so](https://developer.store.varity.so) is where you:
 
-- **Submit new apps** — fill in details, link to your deployment
-- **Manage listings** — update descriptions, pricing, screenshots
-- **View analytics** — see how your apps are performing (coming soon)
-- **Track revenue** — monitor earnings across all your apps (coming soon)
+- **Submit new apps**: fill in details, link to your deployment
+- **Manage listings**: update descriptions, pricing, screenshots
+- **View analytics**: see how your apps are performing (coming soon)
+- **Track revenue**: monitor earnings across all your apps (coming soon)
 
 Log in with the same account you use for `varitykit auth login`.
 
@@ -100,13 +100,13 @@ This calls the `varity_submit_to_store` tool, which generates a pre-filled submi
 
 The App Store is designed for agencies that build apps for multiple clients:
 
-- **Build once, sell many times** — create a client portal template, price it on the store, earn recurring revenue from every business that uses it
-- **White-label friendly** — businesses use your app at its own URL
-- **No infrastructure management** — Varity handles hosting, auth, database, and scaling for every user of your app
-- **Focus on your clients** — spend time on features, not DevOps
+- **Build once, sell many times**: create a client portal template, price it on the store, and earn recurring revenue from every business that uses it
+- **White-label friendly**: businesses use your app at its own URL
+- **No infrastructure management**: Varity handles hosting, auth, database, and scaling for every user of your app
+- **Focus on your clients**: spend time on features, not DevOps
 
 ## Next steps
 
-- [Deploy Your App](/deploy/deploy-your-app) — Get a live URL first
-- [How Varity Works](/getting-started/how-varity-works) — The full platform overview
-- [MCP Server](/ai-tools/mcp-server-spec) — Set up your AI coding tool
+- [Deploy Your App](/deploy/deploy-your-app): Get a live URL first
+- [How Varity Works](/getting-started/how-varity-works): The full platform overview
+- [MCP Server](/ai-tools/mcp-server-spec): Set up your AI coding tool

--- a/src/content/docs/deploy/custom-domains.mdx
+++ b/src/content/docs/deploy/custom-domains.mdx
@@ -46,8 +46,8 @@ https://varity.app/my-app/
 ### Naming rules
 
 - Lowercase letters, numbers, and hyphens only
-- 3–48 characters
-- Must be unique across all Varity apps — first to register a name owns it
+- 3-48 characters
+- Must be unique across all Varity apps (first to register a name owns it)
 - Cannot start or end with a hyphen
 
 <Aside type="tip">
@@ -80,7 +80,7 @@ You must be logged in to list your domains. Run `varitykit login` first if you s
 
 ## Redeploy Under the Same Name
 
-Redeploying with the same `--name` updates the existing deployment at that URL — your domain stays the same:
+Redeploying with the same `--name` updates the existing deployment at that URL. Your domain stays the same:
 
 ```bash
 # First deploy
@@ -119,6 +119,6 @@ Watch the [changelog](https://docs.varity.so) for availability.
 
 ## Related
 
-- [Deploy Your App](/deploy/deploy-your-app) — full deployment guide
-- [App Store & Developer Portal](/deploy/app-store) — publish your app for discovery
-- [CLI Reference: deploy](/cli/commands/deploy) — all `app deploy` flags
+- [Deploy Your App](/deploy/deploy-your-app): full deployment guide
+- [App Store & Developer Portal](/deploy/app-store): publish your app for discovery
+- [CLI Reference: deploy](/cli/commands/deploy): all `app deploy` flags

--- a/src/content/docs/deploy/deployment-troubleshooting.mdx
+++ b/src/content/docs/deploy/deployment-troubleshooting.mdx
@@ -15,7 +15,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 
 When a deployment fails, the fastest path to recovery is: **get the logs → identify the error → fix or rollback**. This page walks through each step.
 
-## Step 1 — Get the Build Logs
+## Step 1: Get the Build Logs
 
 Every deployment produces a build log. Always read it before guessing at a cause.
 
@@ -116,7 +116,7 @@ For dynamic deployments (`--hosting dynamic`), the compute infrastructure must a
 
 | Cause | What to check |
 |-------|--------------|
-| No available compute capacity | Try deploying again — capacity fluctuates |
+| No available compute capacity | Try deploying again (capacity fluctuates) |
 | Container image too large | Optimize your Docker layer or reduce dependencies |
 | Resource request too high | Check your compute config in `varity.config.json` |
 
@@ -144,11 +144,11 @@ The lease was acquired but the container exited immediately after launch.
 
 **Common causes:**
 
-1. **Missing environment variables** — the app crashed on startup because a required env var is absent. Check [Environment Variables](/deploy/env-variables).
+1. **Missing environment variables**: the app crashed on startup because a required env var is absent. Check [Environment Variables](/deploy/env-variables).
 
-2. **Port mismatch** — the container isn't listening on the expected port. Confirm your app listens on `0.0.0.0`, not `127.0.0.1`.
+2. **Port mismatch**: the container isn't listening on the expected port. Confirm your app listens on `0.0.0.0`, not `127.0.0.1`.
 
-3. **Out-of-memory (OOM)** — the process was killed by the kernel during startup. Check your `package.json` for memory-intensive build steps.
+3. **Out-of-memory (OOM)**: the process was killed by the kernel during startup. Check your `package.json` for memory-intensive build steps.
 
 **Get more detail from logs:**
 
@@ -167,14 +167,14 @@ The deployment didn't become healthy within the expected window.
 **Typical causes:**
 
 - Long-running migrations that block app startup
-- Slow cold-start on first container launch (normal for first deploy — retry once)
+- Slow cold-start on first container launch (normal for first deploy; retry once)
 - App not responding to health check on the expected port
 
 **Fix:**
 
 1. Check logs for slow startup output
 2. Move database migrations out of the startup path if possible
-3. Retry — first-launch cold-starts often succeed on the second attempt:
+3. Retry: first-launch cold-starts often succeed on the second attempt:
    ```bash
    varitykit app deploy --hosting dynamic
    ```
@@ -262,9 +262,9 @@ This checks:
 
 If you're still stuck after reading logs and running diagnostics:
 
-1. **Discord** — [#support channel](https://discord.gg/7vWsdwa2Bg) — fastest response
-2. **GitHub Issues** — [varity-labs/varity-sdk](https://github.com/varity-labs/varity-sdk/issues) — attach the output of `varitykit app info <deployment-id>`
-3. **Email** — [support@varity.so](mailto:support@varity.so)
+1. **Discord**: [#support channel](https://discord.gg/7vWsdwa2Bg) (fastest response)
+2. **GitHub Issues**: [varity-labs/varity-sdk](https://github.com/varity-labs/varity-sdk/issues). Include the output of `varitykit app info <deployment-id>`
+3. **Email**: [support@varity.so](mailto:support@varity.so)
 
 When reporting an issue, include:
 - Full output of `varitykit app info <deployment-id>`
@@ -273,8 +273,8 @@ When reporting an issue, include:
 
 ## Related
 
-- [Rollback a Deployment](/deploy/rollback) — revert to a previous version
-- [Deploy Your App](/deploy/deploy-your-app) — full deployment guide
-- [Environment Variables](/deploy/env-variables) — configure your app's environment
-- [MCP Server](/ai-tools/mcp-server-spec) — `varity_deploy_logs`, `varity_deploy_status`
-- [Troubleshooting](/resources/troubleshooting) — general CLI and SDK issues
+- [Rollback a Deployment](/deploy/rollback): revert to a previous version
+- [Deploy Your App](/deploy/deploy-your-app): full deployment guide
+- [Environment Variables](/deploy/env-variables): configure your app's environment
+- [MCP Server](/ai-tools/mcp-server-spec): `varity_deploy_logs`, `varity_deploy_status`
+- [Troubleshooting](/resources/troubleshooting): general CLI and SDK issues

--- a/src/content/docs/deploy/env-variables.mdx
+++ b/src/content/docs/deploy/env-variables.mdx
@@ -14,7 +14,7 @@ import PageMeta from '../../../components/PageMeta.astro';
   stability="stable"
 />
 
-Varity manages most credentials automatically. You only need to set environment variables for services you manage yourself — like your own API keys for OpenAI, Stripe, SendGrid, and similar third-party services.
+Varity manages most credentials automatically. You only need to set environment variables for services you manage yourself, like your own API keys for OpenAI, Stripe, SendGrid, and similar third-party services.
 
 <Aside type="tip">
 **No credential setup required.** Authentication and storage credentials are provided automatically by Varity. See [Managed Credentials](/deploy/managed-credentials) for details.
@@ -22,9 +22,9 @@ Varity manages most credentials automatically. You only need to set environment 
 
 ## Custom Environment Variables
 
-If your app uses third-party APIs — OpenAI, Stripe, SendGrid, Resend, or any other service — you need to inject those API keys into your deployment. Varity reads them from a `.env` file during `varitykit app deploy` and passes them through to your running app.
+If your app uses third-party APIs (OpenAI, Stripe, SendGrid, Resend, or any other service), you need to inject those API keys into your deployment. Varity reads them from a `.env` file during `varitykit app deploy` and passes them through to your running app.
 
-### Step 1 — Create a `.env.varity` file
+### Step 1: Create a `.env.varity` file
 
 Create `.env.varity` in your project root with your custom keys:
 
@@ -41,7 +41,7 @@ MY_CUSTOM_VAR=some-value
 `.env.varity` is the recommended file for Varity-specific production secrets. It takes precedence over `.env.local` and `.env`. Add it to your `.gitignore`.
 </Aside>
 
-### Step 2 — Deploy
+### Step 2: Deploy
 
 ```bash
 varitykit app deploy
@@ -60,7 +60,7 @@ When multiple `.env` files are present, Varity reads the first match (highest pr
 
 | File | When to use |
 |------|-------------|
-| `.env.varity` | Varity production secrets — overrides all others |
+| `.env.varity` | Varity production secrets (overrides all others) |
 | `.env.local` | Local overrides / Next.js convention |
 | `.env` | Fallback for all environments |
 
@@ -181,7 +181,7 @@ This checks:
 
 ### Credentials not working
 
-Run `varitykit doctor` to diagnose. Credentials are auto-provided — if they fail, check your network connection.
+Run `varitykit doctor` to diagnose. Credentials are auto-provided. If they fail, check your network connection.
 
 <Accordion title="Advanced: Using Your Own Auth Credentials">
 
@@ -194,8 +194,8 @@ Override the managed authentication credential by setting this variable:
 NEXT_PUBLIC_PRIVY_APP_ID=your_privy_app_id
 ```
 
-Storage is handled automatically by Varity — no credentials needed.
+Storage is handled automatically by Varity. No credentials needed.
 
-When this variable is set, the SDK uses your own Privy app instead of the managed one.
+When this variable is set, the SDK uses your own authentication app instead of the managed one.
 
 </Accordion>

--- a/src/content/docs/deploy/managed-credentials.mdx
+++ b/src/content/docs/deploy/managed-credentials.mdx
@@ -22,11 +22,11 @@ When you deploy with Varity, credentials are handled automatically at every stag
 
 <Steps>
 
-1. **Development** — The SDK auto-uses shared development credentials. No `.env` setup needed to start building.
+1. **Development:** The SDK auto-uses shared development credentials. No `.env` setup needed to start building.
 
-2. **Production** — When you run `varitykit app deploy`, the CLI fetches production credentials from Varity's credential proxy and injects them into your build.
+2. **Production:** When you run `varitykit app deploy`, the CLI fetches production credentials from Varity's credential proxy and injects them into your build.
 
-3. **Runtime** — Your deployed app uses managed credentials. Users never see API keys or configuration prompts.
+3. **Runtime:** Your deployed app uses managed credentials. Users never see API keys or configuration prompts.
 
 </Steps>
 
@@ -90,10 +90,10 @@ No manual credential setup required.
 
 ## Security
 
-- **Rate-limited** — Credential proxy enforces per-app rate limits
-- **API key authenticated** — CLI uses embedded API keys to authenticate with the proxy
-- **Credentials never stored on disk** — Injected at build time only
-- **Isolated per app** — Each app receives its own credential scope
+- **Rate-limited**: Credential proxy enforces per-app rate limits
+- **API key authenticated**: CLI uses embedded API keys to authenticate with the proxy
+- **Credentials never stored on disk**: Injected at build time only
+- **Isolated per app**: Each app receives its own credential scope
 
 ## Verifying Credentials
 
@@ -113,7 +113,7 @@ Checking environment variables...
 
 **Varity manages these credentials automatically. Only use this if you need custom configuration.**
 
-You can override the managed authentication credential with your own Privy app:
+You can override the managed authentication credential with your own provider configuration:
 
 ### Authentication (Privy)
 
@@ -125,12 +125,12 @@ You can override the managed authentication credential with your own Privy app:
 NEXT_PUBLIC_PRIVY_APP_ID=your_privy_app_id
 ```
 
-Storage is handled automatically by Varity. When `NEXT_PUBLIC_PRIVY_APP_ID` is set, the SDK uses your own Privy app instead of the managed one.
+Storage is handled automatically by Varity. When `NEXT_PUBLIC_PRIVY_APP_ID` is set, the SDK uses your own authentication app instead of the managed one.
 
 </Accordion>
 
 ## Next Steps
 
-- [Environment Variables](/deploy/env-variables) — Variables you can customize
-- [Deploy Your App](/deploy/deploy-your-app) — Deploy with one command
-- [CLI Doctor](/cli/commands/doctor) — Verify your setup
+- [Environment Variables](/deploy/env-variables): Variables you can customize
+- [Deploy Your App](/deploy/deploy-your-app): Deploy with one command
+- [CLI Doctor](/cli/commands/doctor): Verify your setup

--- a/src/content/docs/deploy/rollback.mdx
+++ b/src/content/docs/deploy/rollback.mdx
@@ -27,7 +27,7 @@ deploy-1737484800
 
 The timestamp is when the deployment was created. You use this ID to reference specific deployments when rolling back, checking logs, or inspecting status.
 
-## Step 1 — Find Your Deployment History
+## Step 1: Find Your Deployment History
 
 List all deployments for the current app:
 
@@ -50,7 +50,7 @@ The `live` deployment is your current production version. `archived` deployments
 You can also use `varity_deploy_status` from the [MCP server](/ai-tools/mcp-server-spec) to list deployments directly from your AI editor.
 </Aside>
 
-## Step 2 — Inspect a Deployment (Optional)
+## Step 2: Inspect a Deployment (Optional)
 
 Before rolling back, confirm the version you want by checking its details:
 
@@ -60,7 +60,7 @@ varitykit app info deploy-1737491000
 
 This shows the build timestamp, hosting type, and URL for that deployment.
 
-## Step 3 — Run the Rollback
+## Step 3: Run the Rollback
 
 Revert to the chosen deployment:
 
@@ -68,7 +68,7 @@ Revert to the chosen deployment:
 varitykit app rollback deploy-1737491000
 ```
 
-Varity creates a new deployment using that version's configuration. Your app URL stays the same — users are automatically served the restored version.
+Varity creates a new deployment using that version's configuration. Your app URL stays the same. Users are automatically served the restored version.
 
 Output:
 
@@ -117,7 +117,7 @@ Check the URL in your browser and confirm the expected behavior is restored.
 
 ## Related
 
-- [Deploy Your App](/deploy/deploy-your-app) — full deployment guide
-- [Debugging Failed Deployments](/deploy/deployment-troubleshooting) — diagnose the problem before you rollback
-- [CLI Reference: deploy](/cli/commands/deploy) — all deploy command options
-- [MCP Server](/ai-tools/mcp-server-spec) — `varity_deploy_status`, `varity_deploy_logs`
+- [Deploy Your App](/deploy/deploy-your-app): full deployment guide
+- [Debugging Failed Deployments](/deploy/deployment-troubleshooting): diagnose the problem before you rollback
+- [CLI Reference: deploy](/cli/commands/deploy): all deploy command options
+- [MCP Server](/ai-tools/mcp-server-spec): `varity_deploy_status`, `varity_deploy_logs`

--- a/src/content/docs/deploy/vercel-migration.mdx
+++ b/src/content/docs/deploy/vercel-migration.mdx
@@ -17,11 +17,11 @@ Move your existing Vercel app to Varity in under 3 minutes. The migration tool r
 
 ## What gets migrated automatically
 
-- `vercel.json` — removed
-- `@vercel/*` npm packages — removed from `package.json`
-- Next.js image optimizer config (`unoptimized: true`) — set automatically
-- Vercel-specific environment variable names — renamed to Varity equivalents
-- Edge runtime declarations — updated
+- `vercel.json`: removed
+- `@vercel/*` npm packages: removed from `package.json`
+- Next.js image optimizer config (`unoptimized: true`): set automatically
+- Vercel-specific environment variable names: renamed to Varity equivalents
+- Edge runtime declarations: updated
 
 All changes are backed up to `.vercel-migration-backup/` so you can roll back.
 
@@ -100,7 +100,7 @@ varitykit migrate rollback ./my-app
 ## After migration
 
 - Your app runs on Varity infrastructure with auth, database, and hosting included
-- Environment variables are managed automatically — no manual configuration needed
+- Environment variables are managed automatically. No manual configuration needed
 - Review any warnings from the migration output and fix manually if needed
 - To monetize: submit to the [Varity App Store](/deploy/app-store)
 
@@ -125,6 +125,6 @@ This restores all files from `.vercel-migration-backup/`.
 
 ## Next steps
 
-- [Deploy your app](/deploy/deploy-your-app) — understand what happens during deploy
-- [Environment variables](/deploy/env-variables) — how credentials work
-- [Submit to App Store](/deploy/app-store) — monetize your migrated app
+- [Deploy your app](/deploy/deploy-your-app): understand what happens during deploy
+- [Environment variables](/deploy/env-variables): how credentials work
+- [Submit to App Store](/deploy/app-store): monetize your migrated app

--- a/src/content/docs/getting-started/quickstart-nextjs.mdx
+++ b/src/content/docs/getting-started/quickstart-nextjs.mdx
@@ -240,7 +240,7 @@ See the [Add a CRUD Feature](/tutorials/add-crud-feature) tutorial for a step-by
 
 ## Next Steps
 
-- [Customize the Template](/tutorials/customize-template) — Branding, pages, data models
-- [Add a CRUD Feature](/tutorials/add-crud-feature) — End-to-end feature tutorial
-- [Database Quick Start](/build/databases/quickstart) — Deep dive into the database API
-- [SaaS Template Reference](/templates/saas-starter) — Complete template documentation
+- [Customize the Template](/tutorials/customize-template): Branding, pages, data models
+- [Add a CRUD Feature](/tutorials/add-crud-feature): End-to-end feature tutorial
+- [Database Quick Start](/build/databases/quickstart): Deep dive into the database API
+- [SaaS Template Reference](/templates/saas-starter): Complete template documentation

--- a/src/content/docs/getting-started/quickstart-react.mdx
+++ b/src/content/docs/getting-started/quickstart-react.mdx
@@ -264,6 +264,6 @@ These are optional during development. The SDK uses shared credentials by defaul
 
 ## Next Steps
 
-- [Database Quick Start](/build/databases/quickstart) — Full database API reference
-- [Authentication](/build/auth/quickstart) — Advanced auth configuration
-- [Deploy](/deploy/deploy-your-app) — Deployment options and configuration
+- [Database Quick Start](/build/databases/quickstart): Full database API reference
+- [Authentication](/build/auth/quickstart): Advanced auth configuration
+- [Deploy](/deploy/deploy-your-app): Deployment options and configuration

--- a/src/content/docs/packages/sdk/api-reference.mdx
+++ b/src/content/docs/packages/sdk/api-reference.mdx
@@ -179,7 +179,7 @@ Adds a new document to the collection.
 |-----------|------|----------|-------------|
 | `data` | `Partial<T>` | Yes | Document data to add |
 
-**Returns:** `Promise<T & Document>` — The full inserted document with all fields at the top level.
+**Returns:** `Promise<T & Document>`: The full inserted document with all fields at the top level.
 
 **Example:**
 
@@ -219,7 +219,7 @@ interface QueryOptions {
 }
 ```
 
-**Returns:** `Promise<(T & Document)[]>` — Array of flat documents.
+**Returns:** `Promise<(T & Document)[]>`: Array of flat documents.
 
 **Document Type:**
 
@@ -232,10 +232,10 @@ interface Document {
 }
 ```
 
-Documents returned are `T & Document` — all user fields and system fields exist at the same level. Access `doc.name`, NOT `doc.data.name`.
+Documents returned are `T & Document`: all user fields and system fields exist at the same level. Access `doc.name`, NOT `doc.data.name`.
 
 <Aside type="caution">
-**No `.where()` Filtering** — The database returns all documents. Filter results client-side if needed.
+**No `.where()` Filtering**: The database returns all documents. Filter results client-side if needed.
 </Aside>
 
 **Example:**
@@ -275,7 +275,7 @@ Updates an existing document.
 | `id` | `string` | Yes | Document ID |
 | `data` | `Partial<T>` | Yes | Fields to update |
 
-**Returns:** `Promise<T & Document>` — The updated document.
+**Returns:** `Promise<T & Document>`: The updated document.
 
 **Example:**
 
@@ -307,7 +307,7 @@ Deletes a document from the collection.
 |-----------|------|----------|-------------|
 | `id` | `string` | Yes | Document ID |
 
-**Returns:** `Promise<boolean>` — `true` on success.
+**Returns:** `Promise<boolean>`: `true` on success.
 
 **Example:**
 
@@ -332,7 +332,7 @@ Automatically resolves credentials from environment variables with fallback to d
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `appId` | `string` | No | Privy App ID (falls back to dev credentials) |
+| `appId` | `string` | No | Authentication app ID (falls back to managed credentials) |
 
 **CredentialConfig Type:**
 
@@ -419,9 +419,9 @@ const users = await acmeDb.collection('users').get();
 <Aside type="caution">
 **Current Beta Limitations**
 
-1. **No `.where()` Filtering** — Database returns all documents. Filter client-side.
-2. **No Real-time Updates** — Polling required for live data.
-3. **Database Proxy URL** — Default fallback URL may be unreachable (set `NEXT_PUBLIC_VARITY_DB_URL`).
+1. **No `.where()` Filtering**: Database returns all documents. Filter client-side.
+2. **No Real-time Updates**: Polling required for live data.
+3. **Database Proxy URL**: Default fallback URL may be unreachable (set `NEXT_PUBLIC_VARITY_DB_URL`).
 
 See [Troubleshooting](/resources/troubleshooting) for workarounds.
 </Aside>

--- a/src/content/docs/packages/sdk/chains.mdx
+++ b/src/content/docs/packages/sdk/chains.mdx
@@ -19,7 +19,7 @@ import PageMeta from '../../../../components/PageMeta.astro';
 
 ## When you might land here
 
-You are building something unusual that requires direct access to low-level platform internals — for example, a custom integration that does not fit the SDK's high-level abstractions. In nearly every case, the public SDK API in [API Reference](/packages/sdk/api-reference/) covers what you need.
+You are building something unusual that requires direct access to low-level platform internals. For example, a custom integration that does not fit the SDK's high-level abstractions. In nearly every case, the public SDK API in [API Reference](/packages/sdk/api-reference/) covers what you need.
 
 If you have a specific use case the SDK does not cover, [open an issue](https://github.com/varity-labs/varity-sdk/issues) and we will help you find the right entry point.
 

--- a/src/content/docs/packages/types/overview.mdx
+++ b/src/content/docs/packages/types/overview.mdx
@@ -54,7 +54,7 @@ This package provides TypeScript interfaces and types for:
     Access keys, permissions, sessions, and policy management.
   </Card>
   <Card title="Varity L3 Types" icon="rocket">
-    Chain configuration, wallet setup, contract interactions, and gas estimation.
+    Advanced infrastructure types for custom integrations. Most apps do not need these.
   </Card>
 </CardGrid>
 
@@ -120,7 +120,7 @@ import type {
 } from '@varity-labs/types';
 
 import {
-  AuthProvider,       // aws-signature-v4, gcs-oauth2, browser-wallet
+  AuthProvider,       // aws-signature-v4, gcs-oauth2, browser
   PermissionEffect,   // allow, deny
   Action,             // storage:GetObject, admin:ViewMetrics, etc.
 } from '@varity-labs/types';

--- a/src/content/docs/packages/ui-kit/installation.mdx
+++ b/src/content/docs/packages/ui-kit/installation.mdx
@@ -53,7 +53,7 @@ npm install react react-dom
 ```
 
 <Aside type="tip">
-`@privy-io/react-auth` and `@tanstack/react-query` are included as regular dependencies — you don't need to install them separately.
+`@privy-io/react-auth` and `@tanstack/react-query` are included as regular dependencies. You don't need to install them separately.
 </Aside>
 
 ## Credentials

--- a/src/content/docs/resources/faq.mdx
+++ b/src/content/docs/resources/faq.mdx
@@ -125,7 +125,7 @@ All data is accessible via the `usePrivy()` hook.
 
 Varity is **pure usage-based**. There are no tiers, no seats, no subscriptions. You pay only for what you deploy.
 
-A typical personal app costs around $5/month. A standard SaaS or business tool typically lands at $10–$25/month. Heavier multi-app projects scale linearly with usage.
+A typical personal app costs around $5/month. A standard SaaS or business tool typically lands at $10-$25/month. Heavier multi-app projects scale linearly with usage.
 
 For specific numbers based on your app, use the [cost calculator](https://www.varity.so/beta#calculator).
 
@@ -133,7 +133,7 @@ For specific numbers based on your app, use the [cost calculator](https://www.va
 
 Vercel charges $20/seat/month plus overage fees for bandwidth, function invocations, and build minutes. Varity uses a different infrastructure model that passes lower compute costs to you directly. No seat fees, no per-function charges, bandwidth included up to a generous default.
 
-For most apps, Varity is **60–80% cheaper than AWS** and **70–80% cheaper than Vercel**.
+For most apps, Varity is **60-80% cheaper than AWS** and **70-80% cheaper than Vercel**.
 
 ### Is there a contract or commitment?
 

--- a/src/content/docs/templates/overview.mdx
+++ b/src/content/docs/templates/overview.mdx
@@ -41,7 +41,7 @@ This creates a new project directory with:
 - All source code (yours to modify)
 - Dependencies pre-configured
 - Auth, database, and deployment ready
-- No lock-in — it's a standard Next.js project
+- No lock-in. It's a standard Next.js project.
 
 ## Template vs. Manual Setup
 
@@ -62,10 +62,10 @@ Even if you plan to heavily customize, starting from the template saves time. It
 
 After scaffolding, the code is yours. Common customizations:
 
-1. **Branding** — Change app name, colors, logo
-2. **Data models** — Replace Project/Task with your domain objects
-3. **Pages** — Add, remove, or modify dashboard pages
-4. **Navigation** — Edit the sidebar items
+1. **Branding**: Change app name, colors, logo
+2. **Data models**: Replace Project/Task with your domain objects
+3. **Pages**: Add, remove, or modify dashboard pages
+4. **Navigation**: Edit the sidebar items
 
 See the [SaaS Starter](/templates/saas-starter) page for detailed customization guides, or follow the [Customize the Template](/tutorials/customize-template) tutorial.
 
@@ -73,8 +73,8 @@ See the [SaaS Starter](/templates/saas-starter) page for detailed customization 
 
 More templates are planned:
 
-- **E-commerce Starter** — Product catalog, cart, checkout
-- **Blog / Content** — CMS with markdown editor
-- **Admin Panel** — Data management dashboard
+- **E-commerce Starter**: Product catalog, cart, checkout
+- **Blog / Content**: CMS with markdown editor
+- **Admin Panel**: Data management dashboard
 
 Want to suggest a template? [Join our Discord](https://discord.gg/7vWsdwa2Bg).

--- a/src/content/docs/templates/saas-starter.mdx
+++ b/src/content/docs/templates/saas-starter.mdx
@@ -35,13 +35,13 @@ varitykit init my-app
 
 ### Built-in Features
 
-- **Authentication** — Built-in login (email magic link + social providers)
-- **Database** — Typed collections with CRUD operations and optimistic updates
-- **Dashboard layout** — Responsive sidebar with mobile hamburger menu
-- **Command palette** — Cmd+K / Ctrl+K to search projects, tasks, and team
-- **Confirmation dialogs** — Safe delete operations
-- **CSS variables** — Easy brand customization via `globals.css`
-- **Landing page** — Animated sections, social proof, testimonials
+- **Authentication**: Built-in login (email magic link + social providers)
+- **Database**: Typed collections with CRUD operations and optimistic updates
+- **Dashboard layout**: Responsive sidebar with mobile hamburger menu
+- **Command palette**: Cmd+K / Ctrl+K to search projects, tasks, and team
+- **Confirmation dialogs**: Safe delete operations
+- **CSS variables**: Easy brand customization via `globals.css`
+- **Landing page**: Animated sections, social proof, testimonials
 
 ## Data Models
 
@@ -117,10 +117,10 @@ Every data model follows the same 3-file pattern:
 types/index.ts → lib/database.ts → lib/hooks.ts → app/dashboard/page.tsx
 ```
 
-**1. Type** — Define a TypeScript interface
-**2. Collection** — Create a typed accessor: `db.collection<T>('name')`
-**3. Hook** — Build a React hook with loading/error states and optimistic updates
-**4. Page** — Use the hook in a component
+**1. Type:** Define a TypeScript interface
+**2. Collection:** Create a typed accessor: `db.collection<T>('name')`
+**3. Hook:** Build a React hook with loading/error states and optimistic updates
+**4. Page:** Use the hook in a component
 
 ### Hook Pattern
 
@@ -159,13 +159,13 @@ const { user, authenticated, logout } = usePrivy();
 
 <Steps>
 
-1. **App name** — Edit `APP_NAME` in `src/lib/constants.ts`
+1. **App name:** Edit `APP_NAME` in `src/lib/constants.ts`
 
    ```typescript
    export const APP_NAME = 'YourAppName';
    ```
 
-2. **Colors** — Edit CSS variables in `src/app/globals.css`
+2. **Colors:** Edit CSS variables in `src/app/globals.css`
 
    ```css
    :root {
@@ -177,7 +177,7 @@ const { user, authenticated, logout } = usePrivy();
 
    Four color presets are documented in the file: Blue (default), Purple, Green, Orange.
 
-3. **Logo** — Replace the logo file in `public/`
+3. **Logo:** Replace the logo file in `public/`
 
 </Steps>
 
@@ -299,7 +299,7 @@ varitykit app deploy --submit-to-store
 
 ## Next Steps
 
-- [Build & Deploy Tutorial](/tutorials/build-saas-app) — Step-by-step deployment guide
-- [Customize the Template](/tutorials/customize-template) — Branding and modifications
-- [Add a CRUD Feature](/tutorials/add-crud-feature) — Add a new data model end-to-end
-- [Database Quick Start](/build/databases/quickstart) — Database API deep dive
+- [Build & Deploy Tutorial](/tutorials/build-saas-app): Step-by-step deployment guide
+- [Customize the Template](/tutorials/customize-template): Branding and modifications
+- [Add a CRUD Feature](/tutorials/add-crud-feature): Add a new data model end-to-end
+- [Database Quick Start](/build/databases/quickstart): Database API deep dive

--- a/src/content/docs/tutorials/add-crud-feature.mdx
+++ b/src/content/docs/tutorials/add-crud-feature.mdx
@@ -13,7 +13,7 @@ import PageMeta from '../../../components/PageMeta.astro';
   stability="stable"
 />
 
-This tutorial walks through adding a completely new feature to your Varity app — from defining the data model to building a working page with create, read, update, and delete operations.
+This tutorial walks through adding a completely new feature to your Varity app: from defining the data model to building a working page with create, read, update, and delete operations.
 
 We'll add a **Notes** feature: a page where users can create, edit, and delete notes.
 
@@ -53,7 +53,7 @@ export interface Note {
 ```
 
 <Aside type="tip">
-`id` is always optional — Varity generates it automatically when you insert a document.
+`id` is always optional. Varity generates it automatically when you insert a document.
 </Aside>
 
 ## Step 2: Create the Collection
@@ -345,7 +345,7 @@ export const NAVIGATION_ITEMS = [
 1. Run `npm run dev`
 2. Navigate to `/dashboard/notes`
 3. Create a note, edit it, change its color, delete it
-4. Refresh the page — data persists
+4. Refresh the page. Data persists
 
 ## Step 7: Deploy
 
@@ -367,6 +367,6 @@ This pattern scales to any feature. Every page in the SaaS Starter template foll
 
 ## Next Steps
 
-- [Database Quick Start](/build/databases/quickstart) — Full database API reference
-- [SaaS Template Reference](/templates/saas-starter) — Complete template documentation
-- [Deploy](/deploy/deploy-your-app) — Deployment options
+- [Database Quick Start](/build/databases/quickstart): Full database API reference
+- [SaaS Template Reference](/templates/saas-starter): Complete template documentation
+- [Deploy](/deploy/deploy-your-app): Deployment options

--- a/src/content/docs/tutorials/build-saas-app.mdx
+++ b/src/content/docs/tutorials/build-saas-app.mdx
@@ -87,7 +87,7 @@ A project management app with:
    - **Team**: Add team members, assign roles
    - **Cmd+K**: Open the command palette to search across everything
 
-   All data operations use optimistic updates — the UI updates instantly, then syncs with the database.
+   All data operations use optimistic updates. The UI updates instantly, then syncs with the database.
 
 6. **Build for production**
 
@@ -150,6 +150,6 @@ Total time: about 60 seconds for the deploy step.
 
 Now that you have a live app, you can:
 
-- [Customize the template](/tutorials/customize-template) — Change branding, colors, and content
-- [Add a new feature](/tutorials/add-crud-feature) — Add a new data model with full CRUD
-- [Set up payments](/build/payments/quickstart) — Monetize your app with 90/10 revenue split
+- [Customize the template](/tutorials/customize-template): Change branding, colors, and content
+- [Add a new feature](/tutorials/add-crud-feature): Add a new data model with full CRUD
+- [Set up payments](/build/payments/quickstart): Monetize your app with 90/10 revenue split

--- a/src/content/docs/tutorials/build-with-ai.mdx
+++ b/src/content/docs/tutorials/build-with-ai.mdx
@@ -13,7 +13,7 @@ import PageMeta from '../../../components/PageMeta.astro';
   stability="stable"
 />
 
-This tutorial shows you how to build and deploy a production-ready SaaS app using only natural language prompts. No coding knowledge required—you'll use Varity's MCP server in Cursor or Claude Code to handle everything from scaffolding to deployment to monetization.
+This tutorial shows you how to build and deploy a production-ready SaaS app using only natural language prompts. No coding knowledge required. You'll use Varity's MCP server in Cursor or Claude Code to handle everything from scaffolding to deployment to monetization.
 
 <Aside type="tip">
 The entire workflow takes 10-15 minutes and costs ~70% less than AWS or Vercel.
@@ -35,9 +35,9 @@ All without writing a single line of code.
 Install the following (one-time setup):
 
 1. **Cursor** or **Claude Code** (AI editor with MCP support)
-2. **Node.js 18+** — [download here](https://nodejs.org)
-3. **Python 3.8+** — [download here](https://python.org)
-4. **Varity MCP** — install with:
+2. **Node.js 18+**: [download here](https://nodejs.org)
+3. **Python 3.8+**: [download here](https://python.org)
+4. **Varity MCP**: install with:
 
    ```bash
    claude mcp add varity -- npx -y @varity-labs/mcp
@@ -95,7 +95,7 @@ That's it. No cloud provider accounts, no credit card, no complex setup.
    ✓ Included: Auth, database, dashboard, landing page
    ```
 
-   You now have a fully working app—without writing any code.
+   You now have a fully working app, without writing any code.
 
 3. **Add your data model**
 
@@ -265,13 +265,13 @@ That's it. No cloud provider accounts, no credit card, no complex setup.
 
 ## What Just Happened?
 
-Let's recap what you accomplished—without writing code:
+Here is what you accomplished, without writing any code:
 
-1. ✅ **Created a production SaaS app** — Authentication, database, dashboard
-2. ✅ **Added a custom data model** — Invoice collection with TypeScript types
-3. ✅ **Deployed to production** — Live URL on distributed infrastructure
-4. ✅ **Listed on the App Store** — Users can subscribe and pay
-5. ✅ **Set up revenue stream** — 90% of subscription revenue goes to you
+1. ✅ **Created a production SaaS app**: Authentication, database, dashboard
+2. ✅ **Added a custom data model**: Invoice collection with TypeScript types
+3. ✅ **Deployed to production**: Live URL on distributed infrastructure
+4. ✅ **Listed on the App Store**: Users can subscribe and pay
+5. ✅ **Set up revenue stream**: 90% of subscription revenue goes to you
 
 **Total time:** 10-15 minutes  
 **Total cost:** 70% less than AWS/Vercel  
@@ -301,7 +301,7 @@ Now that you have a live, monetized app, you can:
 > "Deploy my latest changes to production"
 
 **Check revenue:**
-> "How many users have subscribed to my app?" (coming soon—App Store analytics)
+> "How many users have subscribed to my app?" (coming soon: App Store analytics)
 
 ## Behind the Scenes
 
@@ -318,7 +318,7 @@ When you prompt the AI, here's what Varity does:
 | "Show status" | `varity_deploy_status` | Fetches deployment info |
 | "Compare costs" | `varity_cost_calculator` | Calculates Varity vs AWS/Vercel |
 
-Every tool runs locally or via Varity's infrastructure—no manual configuration needed.
+Every tool runs locally or via Varity's infrastructure. No manual configuration needed.
 
 ## Troubleshooting
 
@@ -379,18 +379,18 @@ For a typical SaaS app with 500 users:
 - **Total: $75/month**
 - **Savings: $175/month (70%)**
 
-Plus, Varity handles all configuration—no DevOps engineer needed.
+Plus, Varity handles all configuration. No DevOps engineer needed.
 
 ## Support
 
 If you get stuck:
 
-- **Discord:** [discord.gg/7vWsdwa2Bg](https://discord.gg/7vWsdwa2Bg) — ask in #general
+- **Discord:** [discord.gg/7vWsdwa2Bg](https://discord.gg/7vWsdwa2Bg) (ask in #general)
 - **Docs:** [docs.varity.so](https://docs.varity.so)
 - **MCP Reference:** [MCP Server Spec](/ai-tools/mcp-server-spec)
 
 ## Related Tutorials
 
-- [Build a SaaS App (Traditional)](/tutorials/build-saas-app) — Step-by-step with CLI commands
-- [Customize the Template](/tutorials/customize-template) — Change colors, branding, data models
-- [Add a CRUD Feature](/tutorials/add-crud-feature) — Add new collections and pages
+- [Build a SaaS App (Traditional)](/tutorials/build-saas-app): Step-by-step with CLI commands
+- [Customize the Template](/tutorials/customize-template): Change colors, branding, data models
+- [Add a CRUD Feature](/tutorials/add-crud-feature): Add new collections and pages

--- a/src/content/docs/tutorials/customize-template.mdx
+++ b/src/content/docs/tutorials/customize-template.mdx
@@ -208,10 +208,10 @@ Let's replace the default "Project" model with a "Client" model.
 
 The landing page is at `src/app/page.tsx`. Key sections to update:
 
-- **Hero text** — Change the headline and subheading
-- **Features** — Update the feature cards
-- **Testimonials** — Add your own testimonials or remove the section
-- **CTA** — Change the call-to-action text and link
+- **Hero text**: Change the headline and subheading
+- **Features**: Update the feature cards
+- **Testimonials**: Add your own testimonials or remove the section
+- **CTA**: Change the call-to-action text and link
 
 ## 6. Deploy Your Changes
 
@@ -237,6 +237,6 @@ Your customized app is now live.
 
 ## Next Steps
 
-- [Add a CRUD Feature](/tutorials/add-crud-feature) — Add a completely new data model
-- [Database Quick Start](/build/databases/quickstart) — Deep dive into database operations
-- [Deploy](/deploy/deploy-your-app) — Deployment options
+- [Add a CRUD Feature](/tutorials/add-crud-feature): Add a completely new data model
+- [Database Quick Start](/build/databases/quickstart): Deep dive into database operations
+- [Deploy](/deploy/deploy-your-app): Deployment options


### PR DESCRIPTION
## Summary

- **Pass 1 — Em-dash purge**: 0 prose em/en-dashes remain across 33 files (249 replacements). Converted to colons, periods, commas, or hyphens per context. Code block contents preserved. 2 justified exceptions inside indented code fences (customize-template line 170, env-variables line 114).
- **Pass 2 — Payments audit**: Both `build/payments/quickstart.mdx` and `build/payments/credit-card.mdx` kept — both document Stripe/credit-card flows, not on-chain payments. Fixed broken `/build/payments/gasless` links in both files (target page deleted).
- **Pass 3 — 7 targeted rewrites**: Removed Privy-specific language in user-facing content; softened L3 types card copy; changed auth phrasing to be provider-agnostic.

## Before / After metrics

| Metric | Before | After |
|--------|--------|-------|
| Prose em/en-dashes | ~250 | **0** |
| Broken gasless links | 2 | **0** |
| "connect wallet" language | 1 | **0** |
| "Privy App ID" in user-facing table | 1 | **0** |
| "browser-wallet" in AuthProvider comment | 1 | **0** |

## Build

74 pages ✓ — `npm run build` passes with no errors.

## Justified exceptions (code block contents, not prose)

1. `tutorials/customize-template.mdx:170` — `// create, update, remove — same pattern` — inside a TypeScript code fence
2. `deploy/env-variables.mdx:114` — `# Varity SDK (optional — dev defaults...)` — inside a bash code fence

These are code block contents. The em-dash rule applies to prose only.

## Tickets

Closes VAR-424

🤖 Generated with [Claude Code](https://claude.com/claude-code)