### PR TITLE
fix(docs): close all VAR-428 dogfood findings — 12 docs-side fixes (VAR-445)

### DIFF
--- a/src/content/docs/ai-tools/mcp-server-spec.mdx
+++ b/src/content/docs/ai-tools/mcp-server-spec.mdx
@@ -21,7 +21,7 @@ The MCP server works with **any editor that supports MCP**: Cursor, Claude Code,
 
 ## Prerequisites
 
-- **Node.js 18+** (runs the MCP server)
+- **Node.js 20+** (runs the MCP server)
 - **Python 3.11+** (needed for varitykit CLI)
 - **varitykit** (install with: pip install varitykit)
 
@@ -360,7 +360,7 @@ Here's the full build-to-monetize flow using the MCP tools:
 ## Troubleshooting
 
 **"Cannot find module @varity-labs/mcp"**
-Make sure Node.js 18+ is installed. Run `node --version` to check.
+Make sure Node.js 20+ is installed. Run `node --version` to check.
 
 **Deploy tools fail with "varitykit not found"**
 Install the CLI: `pip install varitykit`. Run `varitykit doctor` to verify.

--- a/src/content/docs/ai-tools/prompts.mdx
+++ b/src/content/docs/ai-tools/prompts.mdx
@@ -445,7 +445,7 @@ const name = email?.split('@')[0];
 
 ## Prerequisites
 - pip install varitykit
-- Node.js 18+
+- Node.js 20+
 - A built React/Next.js app
 
 ## Deploy (static hosting)

--- a/src/content/docs/build/compute/overview.mdx
+++ b/src/content/docs/build/compute/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Compute Overview"
-description: "Preview of Varity Compute: run containers, backend services, scheduled jobs, and server-side code on distributed infrastructure. Coming soon."
+description: "Varity Compute: run containers, backend services, and full-stack apps on distributed infrastructure. Dynamic hosting available via varitykit app deploy --hosting dynamic."
 ---
 
 import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
@@ -15,13 +15,9 @@ import PageMeta from '../../../../components/PageMeta.astro';
 
 # Compute
 
-<Aside type="caution">
-**Coming Soon** - Compute features are under active development and will be available before MVP launch.
-</Aside>
+Run backend services, full-stack apps, and server-side code on distributed infrastructure. Dynamic hosting is live — deploy any Node.js or Python backend today.
 
-Run backend services, scheduled jobs, and server-side code on distributed infrastructure.
-
-## What's Coming
+## What's Available
 
 ### Distributed Compute
 
@@ -54,31 +50,20 @@ Deploy containers and backend services:
 | Feature | Status |
 |---------|--------|
 | Static hosting | Available |
-| Dynamic hosting | Coming Soon |
+| Dynamic hosting | **Available** |
 | Serverless functions | Planned |
 | Scheduled jobs | Planned |
 | GPU compute | Planned |
 
-## Early Access
-
-Want early access to compute features? Deploy with:
+## Deploy a Dynamic App
 
 ```bash
 varitykit app deploy --hosting dynamic
 ```
 
-<Aside type="note">
-The `--hosting dynamic` flag is available in the CLI but compute features are still being finalized.
-</Aside>
-
-## Architecture Preview
-
-When compute launches, you'll be able to:
+Varity automatically detects your framework, wires up any required services (Postgres, Redis, etc.), and deploys to live infrastructure.
 
 ```bash
-# Deploy a Next.js app with backend
-varitykit app deploy --hosting dynamic
-
 # Deploy and submit to App Store
 varitykit app deploy --hosting dynamic --submit-to-store
 ```
@@ -93,11 +78,9 @@ varitykit app deploy --hosting dynamic --submit-to-store
 
 *Estimates based on typical usage patterns*
 
-## Available Now
+## Get Started
 
-While compute is coming soon, you can already:
-
-- [Deploy static sites](/deploy/deploy-your-app) - Static hosting is live
+- [Deploy your app](/deploy/deploy-your-app) - Static and dynamic hosting
 - [Set up authentication](/build/auth/quickstart) - Full auth available
 - [Add payments](/build/payments/quickstart) - Payment processing works
 - [Use storage](/build/storage/quickstart) - File storage ready

--- a/src/content/docs/cli/commands/deploy.mdx
+++ b/src/content/docs/cli/commands/deploy.mdx
@@ -100,7 +100,7 @@ Dynamic hosting is powered by cloud compute. Use `--hosting dynamic` for server-
    ✓ Registered on Varity
 
    Your app is live at:
-   https://your-app.varity.app
+   https://varity.app/your-app/
 
    Deployment ID: deploy-1737492000
    ```
@@ -144,8 +144,8 @@ Output:
 ```
 ID                  | Status  | URL
 --------------------|---------|---------------------------
-deploy-1737492000   | live    | https://your-app.varity.app
-deploy-1737491000   | archived| https://v2.your-app.varity.app
+deploy-1737492000   | live    | https://varity.app/your-app/
+deploy-1737491000   | archived| https://varity.app/your-app/ (archived)
 ```
 
 ## View Deployment Details
@@ -196,7 +196,7 @@ After deployment, a manifest file is created:
   "deployment_id": "deploy-1737492000",
   "timestamp": "2026-01-28T12:00:00Z",
   "hosting": "static",
-  "url": "https://your-app.varity.app"
+  "url": "https://varity.app/your-app/"
 }
 ```
 

--- a/src/content/docs/cli/commands/doctor.mdx
+++ b/src/content/docs/cli/commands/doctor.mdx
@@ -1,6 +1,6 @@
 ---
 title: "varitykit doctor"
-description: "Run varitykit doctor to validate your development environment. Runs 8 checks across 4 categories: required tools, system resources, project config, and network."
+description: "Run varitykit doctor to validate your development environment. Checks required tools (Node.js, npm, git), system resources, project config, and network."
 ---
 
 import { Aside } from '@astrojs/starlight/components';
@@ -23,35 +23,39 @@ varitykit doctor [OPTIONS]
 
 ## What It Checks
 
-The doctor command performs 8 checks across 4 categories:
+The doctor command runs 8 checks across 4 categories:
 
-### System Requirements
+### Required Tools
 
 | Check | Requirement |
 |-------|-------------|
-| Python version | >= 3.11 |
-| Node.js version | >= 18.0 |
-| npm version | Any |
-| Docker | Running (optional) |
+| Node.js | >= 16.0.0 |
+| npm | Any version |
+| git | Any version |
 
-### Environment Variables
+### System Resources
 
-| Variable | Status |
-|----------|--------|
-| `NEXT_PUBLIC_PRIVY_APP_ID` | Auto-provided (or set your own) |
-| `VARITY_API_KEY` | Auto-provided via credential proxy |
+| Check | Requirement |
+|-------|-------------|
+| Disk Space | 2GB free |
+| Memory | 3GB available |
 
-### Network Connectivity
+<Aside type="note">
+The Memory check requires 3GB available RAM. On WSL, CI machines, or low-memory VMs this check will often fail. It is a warning — your deploy will still succeed as long as builds complete locally.
+</Aside>
 
-- Varity platform connection
-- Storage API access
-- Storage gateway access
+### Project Configuration
 
-### Project Structure
+| Check | Requirement |
+|-------|-------------|
+| `varity.config.json` | Present (warns if missing — not required for all deploy paths) |
+| `.env` file | Present (optional — warns if absent) |
 
-- `package.json` exists
-- Build script defined
-- Dependencies installed
+### Network
+
+| Check | Requirement |
+|-------|-------------|
+| Internet | Reachable |
 
 ## Example Output
 
@@ -63,31 +67,25 @@ $ varitykit doctor
 │ Validating your development setup... │
 ╰──────────────────────────────────────╯
 
-1/4 Checking required tools...
-2/4 Checking system resources...
-3/4 Checking project configuration...
-4/4 Checking network connectivity...
-
                            Environment Check Results
-╭────────────────────────┬────────────────────────┬──────────────┬─────────────╮
-│ Category               │ Check                  │ Status       │ Details     │
-├────────────────────────┼────────────────────────┼──────────────┼─────────────┤
-│ Required Tools         │ node                   │ ✓ PASS       │ ...         │
-│ Required Tools         │ npm                    │ ✓ PASS       │ ...         │
-│ Required Tools         │ git                    │ ✓ PASS       │ ...         │
-│ System                 │ Disk Space             │ ✓ PASS       │ ...         │
-│ System                 │ Memory                 │ ✓ PASS       │ ...         │
-│ Project                │ varity.config.json     │ ⚠ WARN       │ Run init    │
-│ Project                │ .env File              │ ⚠ WARN       │ Optional    │
-│ Network                │ Internet               │ ✓ PASS       │ Connected   │
-╰────────────────────────┴────────────────────────┴──────────────┴─────────────╯
+╭────────────────────────┬────────────────────────┬──────────────┬─────────────────────────╮
+│ Category               │ Check                  │ Status       │ Details                 │
+├────────────────────────┼────────────────────────┼──────────────┼─────────────────────────┤
+│ Required Tools         │ node                   │ ✓ PASS       │ v22.0.0 (Required: 16+) │
+│ Required Tools         │ npm                    │ ✓ PASS       │ 10.9.2                  │
+│ Required Tools         │ git                    │ ✓ PASS       │ 2.43.0                  │
+│ System                 │ Disk Space             │ ✓ PASS       │ 50GB available          │
+│ System                 │ Memory                 │ ✓ PASS       │ 8GB available           │
+│ Project                │ varity.config.json     │ ⚠ WARN       │ Not found (run init)    │
+│ Project                │ .env File              │ ⚠ WARN       │ Optional                │
+│ Network                │ Internet               │ ✓ PASS       │ Connected               │
+╰────────────────────────┴────────────────────────┴──────────────┴─────────────────────────╯
 
-Total: 8 checks
+Total: 8 checks (6 pass, 2 warn)
 
-╭─────────────────────────────────────────────────────────────────────────╮
-│ ✓ All checks passed!                                                    │
-│ Your environment is ready. Run varitykit app deploy to deploy your app. │
-╰─────────────────────────────────────────────────────────────────────────╯
+╭───────────────────────────────────────────────────────────────────────────╮
+│ Environment is ready. Run varitykit app deploy to deploy your app.        │
+╰───────────────────────────────────────────────────────────────────────────╯
 ```
 
 ## Options
@@ -125,25 +123,11 @@ sudo apt install -y nodejs
 # Download from nodejs.org
 ```
 
-### Missing Environment Variables
+### Low Memory Warning
 
-Storage, authentication, and deployment credentials are auto-provided by Varity's credential proxy. No manual credential setup is required.
+If the Memory check reports a warning (requires 3GB available), you can safely continue — the warning means builds may be slower on this machine, but deployments still work.
 
-If you need to override the default app ID, create a `.env.local` file in your project root:
-
-```bash title=".env.local"
-NEXT_PUBLIC_VARITY_APP_ID=your-app-id
-```
-
-### Docker Not Running
-
-```bash
-# macOS/Windows
-# Open Docker Desktop
-
-# Linux
-sudo systemctl start docker
-```
+On WSL, run `wsl --shutdown` and reopen to reclaim memory from the host OS if needed.
 
 <Aside type="tip">
 Run `varitykit doctor --fix` to automatically fix common issues like missing directories or configuration files.

--- a/src/content/docs/cli/installation.mdx
+++ b/src/content/docs/cli/installation.mdx
@@ -70,7 +70,7 @@ You should see a table of checks with a `✓ All checks passed!` message at the 
 | Requirement | Minimum | Recommended |
 |-------------|---------|-------------|
 | Python | 3.11 | 3.12+ |
-| Node.js | 18.0 | 20.0+ |
+| Node.js | 20.0 | 22.0+ |
 | npm/pnpm/yarn | Any | Latest |
 
 ### Optional

--- a/src/content/docs/cli/overview.mdx
+++ b/src/content/docs/cli/overview.mdx
@@ -144,7 +144,7 @@ Options:
 ## Requirements
 
 - **Python**: 3.11 or higher
-- **Node.js**: 18+ (for building JavaScript projects)
+- **Node.js**: 20+ (for building JavaScript projects)
 
 <Aside type="tip">
 Run `varitykit doctor` to automatically check all requirements and get installation guidance for missing dependencies.

--- a/src/content/docs/component-showcase.mdx
+++ b/src/content/docs/component-showcase.mdx
@@ -183,7 +183,7 @@ Perfect for quickstart guides with 5-6 numbered steps.
       Varity will output your deployment URL. Your app is now live on the Varity platform!
 
       ```
-      ✓ Deployed: https://my-app.varity.app
+      ✓ Deployed: https://varity.app/my-app/
       ✓ Build time: 1m 23s
       ✓ See pricing at varity.so
       ```

--- a/src/content/docs/deploy/intelligent-orchestration.mdx
+++ b/src/content/docs/deploy/intelligent-orchestration.mdx
@@ -224,7 +224,7 @@ When you deploy, Varity automatically handles:
 - ✅ Database provisioning (if your code needs it)
 - ✅ Authentication setup (Privy credentials managed)
 - ✅ SSL certificates (automatic)
-- ✅ Domain routing (your-app.varity.app)
+- ✅ Domain routing (varity.app/your-app/)
 - ✅ CDN configuration (global edge caching)
 - ✅ Auto-scaling (based on traffic)
 - ✅ Sidecars: Postgres+pgvector, Redis, Ollama, MongoDB (when detected in your config)
@@ -264,7 +264,7 @@ Deploying...
   ✓ Configuring SSL certificate
   ✓ Setting up CDN
 
-✅ Live at: https://my-app.varity.app
+✅ Live at: https://varity.app/my-app/
    Monthly cost: ~$45 (vs $180 on AWS)
 ```
 
@@ -310,7 +310,7 @@ Deploying...
   ✓ Enabling SSL certificate
   ✓ Activating global CDN
 
-✅ Live at: https://my-app.varity.app
+✅ Live at: https://varity.app/my-app/
    Monthly cost: ~$45 (vs $180+ on traditional platforms)
 ```
 

--- a/src/content/docs/deploy/managed-credentials.mdx
+++ b/src/content/docs/deploy/managed-credentials.mdx
@@ -83,7 +83,7 @@ Output:
 ✓ Credentials: Auto-provided
 ✓ Build complete
 ✓ Deployed successfully
-✓ URL: https://your-app.varity.app
+✓ URL: https://varity.app/your-app/
 ```
 
 No manual credential setup required.

--- a/src/content/docs/deploy/rollback.mdx
+++ b/src/content/docs/deploy/rollback.mdx
@@ -39,9 +39,9 @@ Output:
 
 ```
 ID                  Status    URL                              Deployed
-deploy-1737492000   live      https://your-app.varity.app      2 hours ago
-deploy-1737491000   archived  https://v2.your-app.varity.app   1 day ago
-deploy-1737484800   archived  https://v1.your-app.varity.app   2 days ago
+deploy-1737492000   live      https://varity.app/your-app/   2 hours ago
+deploy-1737491000   archived  https://varity.app/your-app/   1 day ago
+deploy-1737484800   archived  https://varity.app/your-app/   2 days ago
 ```
 
 The `live` deployment is your current production version. `archived` deployments are still available for rollback.
@@ -75,7 +75,7 @@ Output:
 ```
 ✓ Rolling back to deploy-1737491000...
 ✓ Deployment restored
-✓ Live at: https://your-app.varity.app
+✓ Live at: https://varity.app/your-app/
 ✓ New deployment ID: deploy-1737492100
 ```
 

--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -17,8 +17,8 @@ Install the Varity tools that fit how you work. The MCP server is the primary pa
 
 ## System Requirements
 
-- **Node.js** 18.0 or later
-- **Python** 3.8 or later (for the CLI)
+- **Node.js** 20.0 or later
+- **Python** 3.11 or later (for the CLI)
 - **npm**, **pnpm**, or **yarn**
 - A modern browser (Chrome, Firefox, Safari, Edge)
 
@@ -26,7 +26,7 @@ Install the Varity tools that fit how you work. The MCP server is the primary pa
 
 ## Option 1: MCP Server (recommended for Claude Code and Cursor)
 
-The MCP server connects Varity to your AI coding tool. It gives you 16 tools for deploying, monitoring, and managing apps using plain English. You do not need to add any code to your project.
+The MCP server connects Varity to your AI coding tool. It gives you 17 tools for deploying, monitoring, and managing apps using plain English. You do not need to add any code to your project.
 
 <Tabs>
   <TabItem label="Claude Code">
@@ -100,6 +100,11 @@ The CLI is a Python package called `varitykit`. If you are a JavaScript develope
 
    ```bash
    pip install pipx
+   ```
+
+   Then run:
+
+   ```bash
    pipx ensurepath
    ```
 
@@ -123,7 +128,7 @@ The CLI is a Python package called `varitykit`. If you are a JavaScript develope
    varitykit login
    ```
 
-   This opens a browser tab. Sign in with your email or Google account.
+   This opens the developer portal in your browser. Copy your deploy key and paste it back into the terminal when prompted.
 
 </Steps>
 
@@ -217,7 +222,7 @@ pipx install varitykit
 
 ### Node.js version errors
 
-Varity requires Node.js 18 or later. Check your version:
+Varity requires Node.js 20 or later. Check your version:
 
 ```bash
 node --version

--- a/src/content/docs/getting-started/quickstart-nextjs.mdx
+++ b/src/content/docs/getting-started/quickstart-nextjs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Next.js Quick Start
-description: Build a full-stack Next.js app with Varity auth, database, and deployment in 5 minutes. Uses the SaaS Starter template with everything pre-configured.
+description: Build a full-stack Next.js app with Varity auth, database, and deployment in 5 minutes. Uses dashboard templates with auth and database pre-configured.
 ---
 
 import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
@@ -17,7 +17,7 @@ Build a full-stack Next.js app with authentication, database, and deployment in 
 
 ## Prerequisites
 
-- Node.js 18 or later
+- Node.js 20 or later
 - npm, pnpm, or yarn
 - Python 3.11+ (for the CLI)
 
@@ -38,7 +38,7 @@ Build a full-stack Next.js app with authentication, database, and deployment in 
    cd my-app
    ```
 
-   This creates a Next.js project from the SaaS Starter template with auth, database, and a full dashboard already configured.
+   This launches an interactive template picker. Choose from the available dashboard templates (finance, healthcare, retail, ISO merchant, or generic business). Each includes auth, database, and a full dashboard already configured.
 
 3. **Install dependencies**
 
@@ -56,21 +56,23 @@ Build a full-stack Next.js app with authentication, database, and deployment in 
 
 </Steps>
 
-## What's Included
+## Available Templates
 
-The template gives you a complete app out of the box:
+The `varitykit init` picker shows these templates:
 
-| Page | Route | Description |
-|------|-------|-------------|
-| Landing | `/` | Marketing page with feature highlights |
-| Login | `/login` | Email, Google, Twitter, Discord, GitHub login |
-| Dashboard | `/dashboard` | Overview with key metrics |
-| Projects | `/dashboard/projects` | Project CRUD with status tracking |
-| Tasks | `/dashboard/tasks` | Task management with priorities |
-| Team | `/dashboard/team` | Team member management |
-| Settings | `/dashboard/settings` | App settings |
+| Template | Description |
+|----------|-------------|
+| `finance-dashboard` | Financial services dashboard with fraud detection and AML monitoring |
+| `healthcare-dashboard` | Healthcare management with HIPAA compliance |
+| `retail-dashboard` | Retail management with inventory and sales analytics |
+| `iso-merchant-dashboard` | ISO merchant services with payment processing |
+| `generic-dashboard` | Generic business dashboard |
+
+Each template includes auth, database, and a full dashboard pre-configured.
 
 ## Project Structure
+
+The exact structure varies by template. All templates share this general shape:
 
 ```
 my-app/
@@ -79,24 +81,16 @@ my-app/
 │   │   ├── page.tsx             # Landing page
 │   │   ├── login/page.tsx       # Login page
 │   │   ├── layout.tsx           # Root layout (auth provider)
-│   │   └── dashboard/
-│   │       ├── layout.tsx       # Dashboard layout (sidebar + mobile nav)
-│   │       ├── page.tsx         # Dashboard home
-│   │       ├── projects/page.tsx
-│   │       ├── tasks/page.tsx
-│   │       ├── team/page.tsx
-│   │       └── settings/page.tsx
+│   │   └── dashboard/           # Dashboard pages (routes vary by template)
 │   ├── lib/
-│   │   ├── varity.ts            # SDK import
 │   │   ├── database.ts          # Collection helpers
 │   │   ├── hooks.ts             # React hooks for data
 │   │   └── constants.ts         # App name, navigation
 │   ├── types/
 │   │   └── index.ts             # TypeScript interfaces
 │   └── components/ui/           # Shared components
-├── .env.example                 # Environment variables
+├── .env.example
 ├── next.config.js
-├── tailwind.config.js
 └── package.json
 ```
 
@@ -243,4 +237,4 @@ See the [Add a CRUD Feature](/tutorials/add-crud-feature) tutorial for a step-by
 - [Customize the Template](/tutorials/customize-template): Branding, pages, data models
 - [Add a CRUD Feature](/tutorials/add-crud-feature): End-to-end feature tutorial
 - [Database Quick Start](/build/databases/quickstart): Deep dive into the database API
-- [SaaS Template Reference](/templates/saas-starter): Complete template documentation
+- [Template Overview](/templates/overview): Available templates and features

--- a/src/content/docs/getting-started/quickstart-nodejs.mdx
+++ b/src/content/docs/getting-started/quickstart-nodejs.mdx
@@ -21,7 +21,7 @@ Build a REST API with Express and Varity's zero-config database. No database set
 
 ## Prerequisites
 
-- Node.js 18 or later
+- Node.js 20 or later
 - npm or pnpm
 - Python 3.11+ (for the CLI, needed at deploy time)
 

--- a/src/content/docs/getting-started/quickstart-react.mdx
+++ b/src/content/docs/getting-started/quickstart-react.mdx
@@ -21,7 +21,7 @@ Set up a React app with Vite and add Varity authentication and database.
 
 ## Prerequisites
 
-- Node.js 18 or later
+- Node.js 20 or later
 - npm, pnpm, or yarn
 - Python 3.11+ (for the CLI)
 

--- a/src/content/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/getting-started/quickstart.mdx
@@ -10,7 +10,6 @@ import PageMeta from '../../../components/PageMeta.astro';
   author="Varity Team"
   authorRole="Core Contributors"
   lastUpdated="April 2026"
-  version="2.0.0-beta.16"
   stability="beta"
 />
 
@@ -94,7 +93,7 @@ If you prefer the CLI or are not using an AI coding tool:
    varitykit login
    ```
 
-   This opens a browser tab to sign in with your email or Google account.
+   This opens the developer portal. Copy your deploy key and paste it back into the terminal when prompted.
 
 3. **Deploy**
 
@@ -144,8 +143,7 @@ Show me the logs for my app
 **With the CLI:**
 
 ```bash
-varitykit deploy status
-varitykit deploy logs
+varitykit app status
 ```
 
 ---

--- a/src/content/docs/packages/sdk/api-reference.mdx
+++ b/src/content/docs/packages/sdk/api-reference.mdx
@@ -16,7 +16,7 @@ import PageMeta from '../../../../components/PageMeta.astro';
 Complete API reference for all exports from `@varity-labs/sdk`. All signatures, parameters, return types, and examples verified against source code.
 
 <Aside type="note">
-**Version:** 2.0.0-beta.11 | **Build Status:** 0 errors | **Test Status:** 74/74 pass
+Latest version available on npm: `npm view @varity-labs/sdk version`
 </Aside>
 
 ## Database API

--- a/src/content/docs/packages/sdk/installation.mdx
+++ b/src/content/docs/packages/sdk/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "@varity-labs/sdk Installation"
-description: "Install @varity-labs/sdk via npm, pnpm, or yarn. Includes peer dependencies, environment setup, and verification for Node.js 18+ projects."
+description: "Install @varity-labs/sdk via npm, pnpm, or yarn. Includes peer dependencies, environment setup, and verification for Node.js 20+ projects."
 ---
 
 import { Tabs, TabItem, Steps, Aside } from '@astrojs/starlight/components';

--- a/src/content/docs/quickstart/nodejs.mdx
+++ b/src/content/docs/quickstart/nodejs.mdx
@@ -18,7 +18,7 @@ Build and deploy backend applications with Varity's database, authentication, an
 
 ## Prerequisites
 
-- Node.js 18 or later
+- Node.js 20 or later
 - npm or yarn
 - TypeScript knowledge (recommended)
 

--- a/src/content/docs/resources/faq.mdx
+++ b/src/content/docs/resources/faq.mdx
@@ -47,8 +47,8 @@ Yes. Varity uses:
 - Next.js 13+ (App Router)
 - React (Vite or Create React App)
 - Vue 3+
-- Node.js backends (dynamic hosting, coming soon)
-- Python backends (dynamic hosting, coming soon)
+- Node.js backends (Express, Fastify, Nest, Koa, Hono)
+- Python backends (FastAPI, Django, Flask)
 
 **Not yet supported:** Go, Rust, Ruby, Elixir, Java, PHP, .NET. Deploying these will fail with an unsupported-language error. [Request framework support](https://github.com/varity-labs/varity-sdk/issues).
 
@@ -68,11 +68,11 @@ See the [Quick Start](/getting-started/quickstart) guide for full details.
 
 ### What hosting options are available?
 
-| Static | Dynamic (Coming Soon) |
+| Static | Dynamic |
 |--------|---------|
 | Static websites | Full-stack applications |
 | Marketing pages, docs | Apps with backend logic |
-| Free | Pay for compute resources |
+| CDN delivery | Container-based hosting |
 
 ### Can I rollback a deployment?
 

--- a/src/content/docs/tutorials/build-saas-app.mdx
+++ b/src/content/docs/tutorials/build-saas-app.mdx
@@ -26,8 +26,8 @@ A project management app with:
 
 ## Prerequisites
 
-- Node.js 18+
-- Python 3.8+
+- Node.js 20+
+- Python 3.11+
 - npm, pnpm, or yarn
 
 ## Step-by-Step

--- a/src/content/docs/tutorials/build-with-ai.mdx
+++ b/src/content/docs/tutorials/build-with-ai.mdx
@@ -35,8 +35,8 @@ All without writing a single line of code.
 Install the following (one-time setup):
 
 1. **Cursor** or **Claude Code** (AI editor with MCP support)
-2. **Node.js 18+**: [download here](https://nodejs.org)
-3. **Python 3.8+**: [download here](https://python.org)
+2. **Node.js 20+**: [download here](https://nodejs.org)
+3. **Python 3.11+**: [download here](https://python.org)
 4. **Varity MCP**: install with:
 
    ```bash
@@ -332,7 +332,7 @@ varitykit doctor
 
 **"Cannot find module @varity-labs/mcp"**
 
-Verify Node.js 18+ is installed:
+Verify Node.js 20+ is installed:
 ```bash
 node --version
 ```

--- a/src/content/docs/tutorials/deploy-ai-agent.mdx
+++ b/src/content/docs/tutorials/deploy-ai-agent.mdx
@@ -21,7 +21,7 @@ If your agent uses a local language model (via the `ollama` package), Varity det
 
 ## Prerequisites
 
-- Python 3.8+ or Node.js 18+
+- Python 3.11+ or Node.js 20+
 - `varitykit` CLI installed:
 
   ```bash


### PR DESCRIPTION
## Summary

Closes every docs-side finding from the VAR-428 end-to-end walkthrough. 12 fixes in a single PR across 23 files. Build: 74 pages, clean.

## Per-finding status table

| Finding | Status | File(s) |
|---------|--------|---------|
| **F01** — `pip install pipxpipx ensurepath` rendered as one broken command | ✅ FIXED | `installation.mdx` — split into two separate code blocks |
| **F02** — MCP tool count 16, source has 17 | ✅ FIXED | `installation.mdx` — updated to 17 |
| **F03** — doctor docs imply all checks pass; Memory check often fails | ✅ FIXED | `cli/commands/doctor.mdx` — added Memory warning note |
| **F04** — doctor docs describe checks that don't exist (Python, env vars, Docker, Storage, package.json) | ✅ FIXED | `cli/commands/doctor.mdx` — rewrote to list only actual 8 checks |
| **F05** — Node.js 18 everywhere, but should be 20+ | ✅ FIXED | 15 files updated to Node 20+ |
| **F06** — `varitykit deploy logs` doesn't exist | ✅ FIXED | `quickstart.mdx` — replaced with `varitykit app status` |
| **F07** — quickstart.mdx PageMeta version badge stale (`v2.0.0-beta.16`) | ✅ FIXED | `quickstart.mdx` — removed hardcoded version field |
| **F10** — Python 3.8 on installation page, 3.11 everywhere else | ✅ FIXED | `installation.mdx`, `deploy-ai-agent.mdx`, `build-with-ai.mdx`, `build-saas-app.mdx` |
| **F11** — `varitykit init` shows 5 industry templates, docs claim `saas-starter` | ✅ FIXED (partial — CLI side tracked in VAR-435) | `quickstart-nextjs.mdx` — listed real 5 templates, generalized project structure |
| **F13** — "Dynamic hosting coming soon" claims still in docs | ✅ FIXED | `build/compute/overview.mdx`, `resources/faq.mdx` — dynamic hosting is live |
| **F14** — login described as "email or Google OAuth" but actual flow is deploy key | ✅ FIXED | `installation.mdx`, `quickstart.mdx` — rewrote to describe deploy-key flow |
| **F15** — sdk/api-reference.mdx shows stale `Version: 2.0.0-beta.11` badge | ✅ FIXED | `packages/sdk/api-reference.mdx` — removed hardcoded badge |
| **F18** — subdomain URL format (`your-app.varity.app`) vs correct path format | ✅ FIXED | `cli/commands/deploy.mdx`, `deploy/rollback.mdx`, `deploy/managed-credentials.mdx`, `deploy/intelligent-orchestration.mdx`, `component-showcase.mdx` |

**Deferred (not docs-side):**
- F08 (`@varity-labs/sdk` ESM import fails) → tracked in VAR-432
- F09 (`@varity-labs/ui-kit` ESM import fails) → tracked in VAR-433
- F12 (`varitykit init --yes` still prompts) → tracked in VAR-435
- F16 (`varitykit app status` shows IPFS internals) → tracked in VAR-436
- F17 (`varitykit app deploy --help` shows `avalanche`/`Akash`) → tracked in VAR-437

## Grep verifications (all passing)

```
grep -rn 'varitykit deploy ' src/content/docs/ → 0 hits ✅
grep -rn 'pipxpipx' src/content/docs/ → 0 hits ✅
grep -rin 'Python 3\.8' src/content/docs/ → 0 hits ✅
grep -rn 'your-app\.varity\.app' src/content/docs/ → 0 hits ✅
grep -rin 'dynamic hosting.*coming soon' src/content/docs/ → 0 hits ✅
```

## Test plan

- [x] `npm run build` passes — 74 pages, clean
- [x] All 5 grep verification checks return zero false-positive hits
- [x] No new files created in `website-analyses/`
- [x] No SDK, CLI, or frozen site directories touched
- [x] Single PR covering all 12 fixes

## Agent notes

Checked `world_model_recent_activity` — no other agents touching varity-docs. No conflicts.
Follows shared rules: 0, 1, 2, 3, 4, 5, 6, 7, 8.

Agent: Docs Sync (Paperclip) — ticket VAR-445