### PR TITLE
fix(docs): remove Privy vendor name from user-facing docs (VAR-387)

### DIFF
--- a/src/content/docs/deploy/intelligent-orchestration.mdx
+++ b/src/content/docs/deploy/intelligent-orchestration.mdx
@@ -222,7 +222,7 @@ When you deploy, Varity automatically handles:
 - ✅ Build configuration (Nixpacks auto-detection)
 - ✅ Container creation (no Docker install required)
 - ✅ Database provisioning (if your code needs it)
-- ✅ Authentication setup (Privy credentials managed)
+- ✅ Authentication setup (managed automatically)
 - ✅ SSL certificates (automatic)
 - ✅ Domain routing (varity.app/your-app/)
 - ✅ CDN configuration (global edge caching)

--- a/src/content/docs/deploy/managed-credentials.mdx
+++ b/src/content/docs/deploy/managed-credentials.mdx
@@ -115,11 +115,10 @@ Checking environment variables...
 
 You can override the managed authentication credential with your own provider configuration:
 
-### Authentication (Privy)
+### Authentication Override
 
-1. Create an account at [dashboard.privy.io](https://dashboard.privy.io)
-2. Create a new app and copy your App ID
-3. Add to your `.env.local`:
+1. Set up your authentication provider and obtain your App ID
+2. Add to your `.env.local`:
 
 ```bash title=".env.local"
 NEXT_PUBLIC_PRIVY_APP_ID=your_privy_app_id

--- a/src/content/docs/resources/faq.mdx
+++ b/src/content/docs/resources/faq.mdx
@@ -100,15 +100,7 @@ No special knowledge required for users.
 
 ### Do I need to set up authentication myself?
 
-No. Add `PrivyStack` to your app and authentication works automatically:
-
-```tsx
-import { PrivyStack } from '@varity-labs/ui-kit';
-
-<PrivyStack appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID}>
-  {children}
-</PrivyStack>
-```
+No. Varity authentication is configured automatically when you deploy. Add the auth provider from `@varity-labs/ui-kit` to your app root and users can log in immediately. See the [UI Kit components](/packages/ui-kit/components) for the setup guide.
 
 ### What user data can I access?
 
@@ -117,7 +109,7 @@ import { PrivyStack } from '@varity-labs/ui-kit';
 - Profile picture (from social login)
 - Linked accounts (Google, Twitter, etc.)
 
-All data is accessible via the `usePrivy()` hook.
+All data is accessible via the auth hooks in `@varity-labs/ui-kit`.
 
 ## Costs and Pricing
 
@@ -178,7 +170,7 @@ All packages support tree-shaking for smaller bundles.
 
 ### Authentication is not working
 
-1. Ensure `PrivyStack` wraps your app
+1. Ensure the `@varity-labs/ui-kit` auth provider wraps your app root
 2. Check browser console for errors
 3. Contact [support@varity.so](mailto:support@varity.so) if your domain needs to be allowed
 

--- a/tests/test-positioning-static.cjs
+++ b/tests/test-positioning-static.cjs
@@ -25,6 +25,7 @@ const HIGH_SEVERITY_PATTERNS = [
   { pattern: /\bdapp\b/gi, term: 'dapp', fix: 'Use "application" or "app" instead' },
   { pattern: /\bweb3\b/gi, term: 'web3', fix: 'Use "next-generation infrastructure" instead' },
   { pattern: /\bon-chain\b/gi, term: 'on-chain', fix: 'Use "tamper-proof" or "verifiable" instead' },
+  { pattern: /\bprivy\b/gi, term: 'privy', fix: 'Use "auth provider" or "@varity-labs/ui-kit" instead — Privy is a hidden vendor name' },
 ];
 
 // Paths where technical jargon is acceptable (deep API reference / architecture docs).
@@ -38,6 +39,7 @@ const TECHNICAL_PATHS = [
   'build/compute',
   'resources/glossary',
   'ai-tools/mcp-server-spec',
+  'ai-tools/prompts',
 ];
 
 // Collect all .mdx and .md files under docs src


### PR DESCRIPTION
## Summary
- Remove all instances of "Privy" from user-facing docs prose per POSITIONING.md §5 zero-tolerance vocabulary policy
- 4 files fixed: `faq.mdx`, `intelligent-orchestration.mdx`, `managed-credentials.mdx`, `tests/test-positioning-static.cjs`

## Changes

| File | Before | After |
|------|--------|-------|
| `resources/faq.mdx` | `Add \`PrivyStack\`...`, `usePrivy()`, `PrivyStack wraps your app` | Generic auth provider descriptions |
| `deploy/intelligent-orchestration.mdx` | `Authentication setup (Privy credentials managed)` | `Authentication setup (managed automatically)` |
| `deploy/managed-credentials.mdx` | `### Authentication (Privy)` + `dashboard.privy.io` link | `### Authentication Override` + generic step |
| `tests/test-positioning-static.cjs` | No "privy" check | Added `privy` to HIGH_SEVERITY_PATTERNS; excluded `ai-tools/prompts` (technical SDK reference) |

## Test plan
- [x] Build passes: `npm run build` — 74 pages, 0 errors
- [x] Static positioning checker passes: `node tests/test-positioning-static.cjs` — all 68 files clean
- [x] No "privy" in prose of any non-technical docs file
- [x] Code blocks with `NEXT_PUBLIC_PRIVY_APP_ID` (env var names) preserved — stripped by test

## Agent notes
Tested against World Model regression patterns: yes.
Follows shared rules: 0, 1, 2, 4, 5, 6, 7, 8.

Note: `packages/sdk`, `packages/ui-kit`, and `ai-tools/prompts` are in TECHNICAL_PATHS exclusion because they document real SDK exports that use Privy names (e.g. `PrivyStack` component). Full fix requires renaming SDK exports post-beta per RULE 0.5.

Agent: Bug Squasher (Paperclip) — ticket VAR-387