### PR TITLE
fix(docs): remove non-existent varitykit app logs command (VAR-514)

### DIFF
--- a/src/content/docs/tutorials/deploy-ai-agent.mdx
+++ b/src/content/docs/tutorials/deploy-ai-agent.mdx
@@ -272,12 +272,11 @@ After deploying, check on your agent:
 ```bash
 # See if it is running
 varitykit app status
-
-# View live logs
-varitykit app logs
 ```
 
 Or ask your AI coding tool (if you have the Varity MCP installed):
+
+> "Check the status of my Varity deployment"
 
 > "Show me the logs for my last deployment"
 
@@ -289,11 +288,9 @@ Check that your project has a `requirements.txt` (Python) or `package.json` (Nod
 
 **Agent returns 502 after deploy**
 
-Your app may be taking a few extra seconds to start. Wait 30 seconds and try again. If it persists, check your logs:
+Your app may be taking a few extra seconds to start. Wait 30 seconds and try again. If it persists, check your logs by asking your AI coding tool:
 
-```bash
-varitykit app logs
-```
+> "Show me the logs for my last deployment"
 
 A common cause is the app binding to `localhost` instead of `0.0.0.0`. Make sure your server listens on `0.0.0.0`:
 


### PR DESCRIPTION
## Summary
- Removes two instances of `varitykit app logs` from `tutorials/deploy-ai-agent.mdx` — this CLI command does not exist
- The actual `app` subcommands are: `deploy`, `list`, `info`, `status`, `rollback` (confirmed in `cli/varitykit/commands/app_deploy.py`)
- Replaces with MCP natural language guidance (`"Show me the logs for my last deployment"`) matching the pattern already used in `quickstart.mdx`

## Test plan
- [x] `tests/test-positioning-static.cjs` passes — all 68 docs files clean
- [x] No `varitykit app logs` or `varitykit deploy logs` references remain in any `.mdx` file
- [x] `varitykit app status` (the correct CLI status command) is preserved

## Agent notes
Tested against World Model regression patterns: yes — no prior work on this ticket, no conflicts with other agents.
Follows shared rules: 0, 1, 2, 4, 5, 6, 7, 8.

Agent: Docs Sync (Paperclip) — ticket VAR-514