### PR TITLE
fix(docs): remove Privy env var + fix Python version to 3.8 (VAR-515)

### DIFF
--- a/src/content/docs/ai-tools/mcp-server-spec.mdx
+++ b/src/content/docs/ai-tools/mcp-server-spec.mdx
@@ -22,7 +22,7 @@ The MCP server works with **any editor that supports MCP**: Cursor, Claude Code,
 ## Prerequisites
 
 - **Node.js 20+** (runs the MCP server)
-- **Python 3.11+** (needed for varitykit CLI)
+- **Python 3.8+** (needed for varitykit CLI)
 - **varitykit** (install with: pip install varitykit)
 
 ## Setup

--- a/src/content/docs/cli/installation.mdx
+++ b/src/content/docs/cli/installation.mdx
@@ -69,7 +69,7 @@ You should see a table of checks with a `✓ All checks passed!` message at the 
 
 | Requirement | Minimum | Recommended |
 |-------------|---------|-------------|
-| Python | 3.11 | 3.12+ |
+| Python | 3.8 | 3.12+ |
 | Node.js | 20.0 | 22.0+ |
 | npm/pnpm/yarn | Any | Latest |
 

--- a/src/content/docs/cli/overview.mdx
+++ b/src/content/docs/cli/overview.mdx
@@ -143,7 +143,7 @@ Options:
 
 ## Requirements
 
-- **Python**: 3.11 or higher
+- **Python**: 3.8 or higher
 - **Node.js**: 20+ (for building JavaScript projects)
 
 <Aside type="tip">

--- a/src/content/docs/deploy/env-variables.mdx
+++ b/src/content/docs/deploy/env-variables.mdx
@@ -183,19 +183,3 @@ This checks:
 
 Run `varitykit doctor` to diagnose. Credentials are auto-provided. If they fail, check your network connection.
 
-<Accordion title="Advanced: Using Your Own Auth Credentials">
-
-**Varity manages these credentials automatically. Only use this if you need custom configuration.**
-
-Override the managed authentication credential by setting this variable:
-
-```bash title=".env.local"
-# Authentication — get from https://dashboard.privy.io
-NEXT_PUBLIC_PRIVY_APP_ID=your_privy_app_id
-```
-
-Storage is handled automatically by Varity. No credentials needed.
-
-When this variable is set, the SDK uses your own authentication app instead of the managed one.
-
-</Accordion>

--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -18,7 +18,7 @@ Install the Varity tools that fit how you work. The MCP server is the primary pa
 ## System Requirements
 
 - **Node.js** 20.0 or later
-- **Python** 3.11 or later (for the CLI)
+- **Python** 3.8 or later (for the CLI)
 - **npm**, **pnpm**, or **yarn**
 - A modern browser (Chrome, Firefox, Safari, Edge)
 

--- a/src/content/docs/getting-started/quickstart-nextjs.mdx
+++ b/src/content/docs/getting-started/quickstart-nextjs.mdx
@@ -19,7 +19,7 @@ Build a full-stack Next.js app with authentication, database, and deployment in 
 
 - Node.js 20 or later
 - npm, pnpm, or yarn
-- Python 3.11+ (for the CLI)
+- Python 3.8+ (for the CLI)
 
 ## Create Your App
 

--- a/src/content/docs/getting-started/quickstart-nodejs.mdx
+++ b/src/content/docs/getting-started/quickstart-nodejs.mdx
@@ -23,7 +23,7 @@ Build a REST API with Express and Varity's zero-config database. No database set
 
 - Node.js 20 or later
 - npm or pnpm
-- Python 3.11+ (for the CLI, needed at deploy time)
+- Python 3.8+ (for the CLI, needed at deploy time)
 
 ## Set Up Your Project
 

--- a/src/content/docs/getting-started/quickstart-react.mdx
+++ b/src/content/docs/getting-started/quickstart-react.mdx
@@ -23,7 +23,7 @@ Set up a React app with Vite and add Varity authentication and database.
 
 - Node.js 20 or later
 - npm, pnpm, or yarn
-- Python 3.11+ (for the CLI)
+- Python 3.8+ (for the CLI)
 
 ## Set Up Your Project
 

--- a/src/content/docs/tutorials/build-saas-app.mdx
+++ b/src/content/docs/tutorials/build-saas-app.mdx
@@ -27,7 +27,7 @@ A project management app with:
 ## Prerequisites
 
 - Node.js 20+
-- Python 3.11+
+- Python 3.8+
 - npm, pnpm, or yarn
 
 ## Step-by-Step
@@ -48,7 +48,7 @@ A project management app with:
 
    You should see all checks passing:
    ```
-   ✓ Python version: 3.11.0
+   ✓ Python version: 3.8.0
    ✓ Node.js version: 20.0.0
    ✓ npm version: 10.0.0
    ✓ All checks passed!

--- a/src/content/docs/tutorials/build-with-ai.mdx
+++ b/src/content/docs/tutorials/build-with-ai.mdx
@@ -36,7 +36,7 @@ Install the following (one-time setup):
 
 1. **Cursor** or **Claude Code** (AI editor with MCP support)
 2. **Node.js 20+**: [download here](https://nodejs.org)
-3. **Python 3.11+**: [download here](https://python.org)
+3. **Python 3.8+**: [download here](https://python.org)
 4. **Varity MCP**: install with:
 
    ```bash

--- a/src/content/docs/tutorials/deploy-ai-agent.mdx
+++ b/src/content/docs/tutorials/deploy-ai-agent.mdx
@@ -21,7 +21,7 @@ If your agent uses a local language model (via the `ollama` package), Varity det
 
 ## Prerequisites
 
-- Python 3.11+ or Node.js 20+
+- Python 3.8+ or Node.js 20+
 - `varitykit` CLI installed:
 
   ```bash


### PR DESCRIPTION
## Summary
- Removed `NEXT_PUBLIC_PRIVY_APP_ID` from the "Advanced: Using Your Own Auth Credentials" accordion in `deploy/env-variables.mdx` — user-facing instruction exposing the Privy vendor name (RULE 4 violation)
- Fixed Python minimum version from `3.11` → `3.8` across 11 docs files — source of truth is `cli/pyproject.toml` which sets `requires-python = ">=3.8"`

## Files changed
| File | Change |
|---|---|
| `deploy/env-variables.mdx` | Remove Advanced accordion with `NEXT_PUBLIC_PRIVY_APP_ID` and `dashboard.privy.io` link |
| `cli/installation.mdx` | Python 3.11 → 3.8 in Requirements table |
| `cli/overview.mdx` | Python 3.11 → 3.8 in Requirements section |
| `getting-started/installation.mdx` | Python 3.11 → 3.8 in System Requirements |
| `getting-started/quickstart-nextjs.mdx` | Python 3.11+ → 3.8+ in Prerequisites |
| `getting-started/quickstart-nodejs.mdx` | Python 3.11+ → 3.8+ in Prerequisites |
| `getting-started/quickstart-react.mdx` | Python 3.11+ → 3.8+ in Prerequisites |
| `ai-tools/mcp-server-spec.mdx` | Python 3.11+ → 3.8+ in Prerequisites |
| `tutorials/build-saas-app.mdx` | Python 3.11+ → 3.8+ in Prerequisites + example output |
| `tutorials/build-with-ai.mdx` | Python 3.11+ → 3.8+ in Prerequisites |
| `tutorials/deploy-ai-agent.mdx` | Python 3.11+ → 3.8+ in Prerequisites |

## Notes
Remaining `NEXT_PUBLIC_PRIVY_APP_ID` references in SDK package docs are preserved per RULE 0.5 (SDK code-path references — pending post-beta SDK rename). Build verified: 74 pages, 0 errors.

## Test plan
- [x] Build passes (`npm run build` — 74 pages, no errors)
- [x] No Python 3.11 references remain in `src/content/`
- [x] `NEXT_PUBLIC_PRIVY_APP_ID` removed from user-facing env setup pages
- [x] Remaining references in SDK technical code examples only (RULE 0.5)

## Agent notes
Tested against World Model regression patterns: yes.
Follows shared rules: 0, 1, 2, 4, 5, 6, 7, 8.

Agent: Docs Sync (Paperclip) — ticket VAR-515