### PR TITLE
fix(docs): correct URL format in tutorial output examples (VAR-389)

### DIFF
--- a/src/content/docs/tutorials/build-saas-app.mdx
+++ b/src/content/docs/tutorials/build-saas-app.mdx
@@ -113,7 +113,7 @@ A project management app with:
      ████████████████████ 100%
 
    ✓ Deployed successfully!
-   ✓ Live at: https://your-app-url.varity.app
+   ✓ Live at: https://varity.app/your-app-url/
    ```
 
    Your app is now live. Share the URL with anyone.

--- a/src/content/docs/tutorials/build-with-ai.mdx
+++ b/src/content/docs/tutorials/build-with-ai.mdx
@@ -187,7 +187,7 @@ That's it. No cloud provider accounts, no credit card, no complex setup.
    ✓ Deploying invoice-manager...
    ✓ Build: 100%
    ✓ Upload: 100%
-   ✓ Live at: https://invoice-manager-abc123.varity.app
+   ✓ Live at: https://varity.app/invoice-manager-abc123/
    ```
 
    Your app is now live on the internet. Anyone can access it.
@@ -203,7 +203,7 @@ That's it. No cloud provider accounts, no credit card, no complex setup.
    **Expected output:**
    ```
    Deployment: abc123
-     URL: https://invoice-manager-abc123.varity.app
+     URL: https://varity.app/invoice-manager-abc123/
      Status: active
      Framework: Next.js
      Size: 2.4 MB

--- a/tests/test-positioning-static.cjs
+++ b/tests/test-positioning-static.cjs
@@ -87,6 +87,19 @@ for (const file of files) {
   }
 }
 
+// VAR-389: ensure tutorial code examples use path-prefix format, not subdomain format.
+// db.varity.app is a legitimate subdomain (SDK technical docs) and is already excluded via TECHNICAL_PATHS.
+const SUBDOMAIN_URL_RE = /https?:\/\/[a-zA-Z0-9][a-zA-Z0-9-]*\.varity\.app/i;
+for (const file of files) {
+  if (isTechnicalFile(file)) continue;
+  const rel = path.relative(DOCS_SRC, file);
+  const fullSrc = fs.readFileSync(file, 'utf8');
+  if (SUBDOMAIN_URL_RE.test(fullSrc)) {
+    console.error(`FAIL [${rel}] uses subdomain URL format (*.varity.app) — use path-prefix format https://varity.app/{name}/ instead (VAR-389)`);
+    totalViolations++;
+  }
+}
+
 // VAR-506: ensure _redirects exists so 4everland CDN never falls through to raw IPFS gateway
 const REDIRECTS_PATH = path.join(__dirname, '../public/_redirects');
 if (!fs.existsSync(REDIRECTS_PATH)) {


### PR DESCRIPTION
## Summary
- Tutorial code blocks showed `{name}.varity.app` (subdomain format) but actual deployed URLs use path-prefix format `https://varity.app/{name}/`
- 3 occurrences fixed in `build-with-ai.mdx` (2) and `build-saas-app.mdx` (1)
- Added regression test in `test-positioning-static.cjs` to catch subdomain format URLs in future

## Changes
| File | Old | New |
|---|---|---|
| `tutorials/build-with-ai.mdx:190` | `https://invoice-manager-abc123.varity.app` | `https://varity.app/invoice-manager-abc123/` |
| `tutorials/build-with-ai.mdx:206` | `https://invoice-manager-abc123.varity.app` | `https://varity.app/invoice-manager-abc123/` |
| `tutorials/build-saas-app.mdx:116` | `https://your-app-url.varity.app` | `https://varity.app/your-app-url/` |
| `tests/test-positioning-static.cjs` | (no check) | Added `SUBDOMAIN_URL_RE` regression guard |

## Note
`db.varity.app` in `packages/sdk/api-reference.mdx` is a legitimate database proxy subdomain and is correctly excluded via `TECHNICAL_PATHS` — the regression test does not flag it.

`deploy-your-app.mdx` was already correct (uses `varity.app/{name}/` throughout) — no change needed there.

Pre-existing lint errors in `Accordion.astro`, `CodeBlock.astro`, `Tabs.astro` (13 TypeScript errors) are not related to this change and existed before this branch.

## Test plan
- [x] `node tests/test-positioning-static.cjs` passes (68 files clean)
- [x] New SUBDOMAIN_URL_RE regression check passes
- [x] `astro check` pre-existing errors unchanged (0 new errors introduced)

## Agent notes
Tested against World Model regression patterns: yes — no prior URL format regression in regressions.md.
Follows shared rules: 0, 1, 2, 3, 4, 5, 6, 7, 8.

Agent: Bug Squasher (Paperclip) — ticket VAR-389