### PR TITLE
docs(guides): Next.js deploy + AI IDE deploy canonical pages (VAR-565)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -149,6 +149,25 @@ export default defineConfig({
           ],
         },
 
+        // ===== GUIDES =====
+        {
+          label: "Guides",
+          items: [
+            {
+              label: "Deploy a Next.js App",
+              slug: "guides/deploy-nextjs",
+            },
+            {
+              label: "Deploy from Claude Code / Cursor / Windsurf",
+              slug: "guides/deploy-from-ai-ide",
+            },
+            {
+              label: "Error Handling",
+              slug: "guides/error-handling",
+            },
+          ],
+        },
+
         // ===== HOW TO USE VARITY =====
         {
           label: "How to Use Varity",

--- a/src/content/docs/guides/deploy-from-ai-ide.mdx
+++ b/src/content/docs/guides/deploy-from-ai-ide.mdx
@@ -1,0 +1,312 @@
+---
+title: Deploy from Claude Code, Cursor, or Windsurf
+description: Deploy any app to production from inside your AI editor. Install the Varity MCP server once, then type "deploy this" and your app is live.
+---
+
+import { Steps, Tabs, TabItem, Aside, Card, CardGrid } from '@astrojs/starlight/components';
+import PageMeta from '../../../components/PageMeta.astro';
+
+<PageMeta
+  author="Varity Team"
+  authorRole="Core Contributors"
+  lastUpdated="April 2026"
+  stability="stable"
+/>
+
+Varity is built for developers who use AI coding tools. Install the MCP server once, and your AI editor can scaffold, build, and deploy apps to production without you ever leaving the chat.
+
+Works with Claude Code, Cursor, Windsurf, VS Code (Copilot), and any other editor that supports the Model Context Protocol.
+
+## Install the MCP server
+
+<Tabs>
+  <TabItem label="Claude Code">
+    Run this once from any directory:
+
+    ```bash
+    claude mcp add varity -- npx -y @varity-labs/mcp
+    ```
+
+    Claude Code picks up the server automatically on the next conversation. Confirm it is registered:
+
+    ```bash
+    claude mcp list
+    ```
+
+    You should see `varity` in the list.
+  </TabItem>
+  <TabItem label="Cursor">
+    Create `.cursor/mcp.json` in your project root (or your home directory for a global install):
+
+    ```json
+    {
+      "mcpServers": {
+        "varity": {
+          "command": "npx",
+          "args": ["-y", "@varity-labs/mcp"]
+        }
+      }
+    }
+    ```
+
+    Restart Cursor. The Varity tools appear in the MCP tool list under the agent panel.
+  </TabItem>
+  <TabItem label="Windsurf">
+    Add to `~/.codeium/windsurf/mcp_config.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "varity": {
+          "command": "npx",
+          "args": ["-y", "@varity-labs/mcp"]
+        }
+      }
+    }
+    ```
+
+    Restart Windsurf to load the server.
+  </TabItem>
+  <TabItem label="VS Code (Copilot)">
+    Add to `.vscode/mcp.json` in your workspace:
+
+    ```json
+    {
+      "mcpServers": {
+        "varity": {
+          "command": "npx",
+          "args": ["-y", "@varity-labs/mcp"]
+        }
+      }
+    }
+    ```
+  </TabItem>
+</Tabs>
+
+<Aside type="note">
+Node.js 20 or later and Python 3.8 or later are required. If you do not have `varitykit` installed, your AI editor will prompt you to install it: `pip install varitykit`.
+</Aside>
+
+## Deploy with one prompt
+
+Once the MCP server is installed, type this in your AI editor:
+
+```
+Deploy this project to Varity
+```
+
+Your AI editor calls `varity_build` and `varity_deploy` in sequence and returns the live URL.
+
+For a brand new project:
+
+```
+Create a new Varity app called my-app, install dependencies, and deploy it to production
+```
+
+The AI handles scaffolding, dependency installation, the production build, and the deploy. You get a live URL when it is done.
+
+## Copy-paste prompts
+
+These prompts are tested and work out of the box in Claude Code, Cursor, and Windsurf.
+
+**Check environment**
+```
+Check if my environment is ready for Varity
+```
+
+**Scaffold a new app**
+```
+Create a new Varity app called my-project, install dependencies, start the dev server, and open it in my browser
+```
+
+**Deploy to production**
+```
+Build my project and deploy it to Varity. Show me the live URL when done.
+```
+
+**Check status**
+```
+Show me the status of my Varity deployments
+```
+
+**Debug a failed deploy**
+```
+Show me the build logs for my last Varity deployment
+```
+
+**Estimate cost**
+```
+How much would it cost to host this app with 1000 monthly users on Varity?
+```
+
+**Full build-to-deploy flow**
+```
+Check my Varity environment, then build this project, deploy it, and open the live URL in my browser
+```
+
+## What the MCP server can do
+
+The Varity MCP server gives your AI editor 16 tools. Here are the most useful ones for the build-to-deploy workflow:
+
+| Tool | What to ask your AI |
+|---|---|
+| `varity_doctor` | "Check if my environment is set up for Varity" |
+| `varity_init` | "Create a new Varity app called my-project" |
+| `varity_install_deps` | "Install dependencies for this project" |
+| `varity_dev_server` | "Start the dev server and open it in my browser" |
+| `varity_build` | "Build this project for production" |
+| `varity_deploy` | "Deploy this to Varity" |
+| `varity_deploy_status` | "Show me my deployment status" |
+| `varity_deploy_logs` | "Show me the build logs" |
+| `varity_migrate` | "Migrate my Vercel app to Varity" |
+| `varity_cost_calculator` | "How much will this cost at 500 users?" |
+
+Full reference at [MCP Server Spec](/ai-tools/mcp-server-spec).
+
+## Add Varity context to your project
+
+For Claude Code, add this to your project's `CLAUDE.md`:
+
+```markdown
+## Deployment
+
+This project deploys to Varity. Use the Varity MCP server tools:
+- Deploy: ask "Deploy this project to Varity"
+- Check status: ask "Show me my Varity deployment status"
+- Logs: ask "Show me the build logs for my last deployment"
+```
+
+For Cursor, save this as `.cursor/rules/varity.mdc`:
+
+```markdown
+When the user asks to deploy, use the Varity MCP varity_deploy tool.
+When the user asks to check deployment status, use varity_deploy_status.
+When the user asks to see logs, use varity_deploy_logs.
+```
+
+This tells your AI editor to route deploy-related requests to the Varity tools automatically.
+
+## Typical vibe coding session
+
+Here is a complete session from idea to live app, using only your AI editor:
+
+<Steps>
+
+1. **Check your setup**
+
+   ```
+   Check if my environment is ready for Varity
+   ```
+
+   The AI runs `varity_doctor` and tells you if anything needs fixing.
+
+2. **Scaffold the app**
+
+   ```
+   Create a new Varity app called task-tracker. I want a dashboard where users can create and manage tasks.
+   ```
+
+   The AI calls `varity_init`, picks the `saas-starter` template, and scaffolds the project.
+
+3. **Install dependencies**
+
+   ```
+   Install dependencies and start the dev server
+   ```
+
+   The AI runs `varity_install_deps` and `varity_dev_server`, then opens `localhost:3000`.
+
+4. **Build the feature**
+
+   Work with your AI editor to build the task feature. Varity's database API makes it easy:
+
+   ```
+   Add a tasks collection with title (string), status (string), and dueDate (string) fields. Include a dashboard page with a list and a create form.
+   ```
+
+5. **Deploy to production**
+
+   ```
+   Build and deploy this to Varity
+   ```
+
+   The AI calls `varity_build` and `varity_deploy`. Your app is live in about 60 seconds.
+
+6. **Share the link**
+
+   ```
+   Show me the live URL for my deployment
+   ```
+
+   Done. Send it to anyone.
+
+</Steps>
+
+## Migrating from Vercel
+
+If you already have a Vercel app, one prompt migrates it to Varity:
+
+```
+Migrate my Vercel app at https://github.com/your-org/your-app to Varity
+```
+
+The AI calls `varity_migrate`, which clones the repository, removes Vercel-specific configuration, and deploys to Varity infrastructure. See [Migrate from Vercel](/deploy/vercel-migration) for details.
+
+## Browser-based AI tools (Claude.ai, ChatGPT)
+
+If you use a browser-based AI tool instead of a desktop editor, connect to the hosted MCP endpoint:
+
+```
+https://mcp.varity.so
+```
+
+**Claude.ai:** Settings > Connectors > Add MCP Server > URL: `https://mcp.varity.so`
+
+**ChatGPT:** Settings > Connectors > Create > MCP server URL: `https://mcp.varity.so`
+
+The first connection asks you to authenticate via the Varity login page.
+
+## Troubleshooting
+
+**"varity not found" in your AI editor**
+
+Re-add the server and restart:
+
+```bash
+# Claude Code
+claude mcp add varity -- npx -y @varity-labs/mcp
+```
+
+Verify with `claude mcp list`.
+
+**Deploy fails with "varitykit not found"**
+
+```bash
+pip install varitykit
+```
+
+Then ask your AI to try again.
+
+**Cursor does not show the Varity tools**
+
+Check that `.cursor/mcp.json` is valid JSON, then restart Cursor. Cursor requires a full restart (not just reload) to pick up MCP config changes.
+
+**Server is registered but tools are not being called**
+
+Ask your AI directly:
+
+```
+Use the varity_doctor tool to check my environment
+```
+
+If the AI is not picking up the tools automatically, being explicit about the tool name always works.
+
+See [MCP Server Spec](/ai-tools/mcp-server-spec) for the full troubleshooting section.
+
+## Next steps
+
+- [MCP Server Spec](/ai-tools/mcp-server-spec): All 16 tools documented
+- [AI Prompts](/ai-tools/prompts): Copy-paste prompts for building Varity apps
+- [Deploy a Next.js App](/guides/deploy-nextjs): Full Next.js deploy walkthrough
+- [Migrate from Vercel](/deploy/vercel-migration): One-command Vercel migration
+- [Auto-wired Services](/deploy/auto-wired-services): What gets provisioned automatically

--- a/src/content/docs/guides/deploy-nextjs.mdx
+++ b/src/content/docs/guides/deploy-nextjs.mdx
@@ -1,0 +1,311 @@
+---
+title: Deploy a Next.js App
+description: The easiest way to deploy a Next.js app with auth and a database. One command. Live in 60 seconds.
+---
+
+import { Steps, Tabs, TabItem, Aside, Card, CardGrid } from '@astrojs/starlight/components';
+import PageMeta from '../../../components/PageMeta.astro';
+
+<PageMeta
+  author="Varity Team"
+  authorRole="Core Contributors"
+  lastUpdated="April 2026"
+  stability="stable"
+/>
+
+Deploy a production Next.js app with authentication, a database, and a live URL in under 60 seconds. No server configuration, no environment variable setup, no infrastructure decisions.
+
+<CardGrid>
+  <Card title="Zero configuration" icon="rocket">
+    Varity detects your framework, wires your database, and deploys. You run one command.
+  </Card>
+  <Card title="60-80% cheaper than AWS" icon="seti:money">
+    Pay only for what you use. No idle server costs. No DevOps overhead.
+  </Card>
+</CardGrid>
+
+## Two ways to deploy
+
+You can deploy from your AI editor using the Varity MCP server (recommended for vibe coders), or from the terminal using the CLI.
+
+<Tabs>
+  <TabItem label="From Claude Code or Cursor (MCP)">
+    **Step 1. Add the Varity MCP server**
+
+    <Tabs>
+      <TabItem label="Claude Code">
+        ```bash
+        claude mcp add varity -- npx -y @varity-labs/mcp
+        ```
+      </TabItem>
+      <TabItem label="Cursor">
+        Add to `.cursor/mcp.json` in your project root:
+
+        ```json
+        {
+          "mcpServers": {
+            "varity": {
+              "command": "npx",
+              "args": ["-y", "@varity-labs/mcp"]
+            }
+          }
+        }
+        ```
+
+        Restart Cursor.
+      </TabItem>
+      <TabItem label="Windsurf">
+        Add to `~/.codeium/windsurf/mcp_config.json`:
+
+        ```json
+        {
+          "mcpServers": {
+            "varity": {
+              "command": "npx",
+              "args": ["-y", "@varity-labs/mcp"]
+            }
+          }
+        }
+        ```
+      </TabItem>
+    </Tabs>
+
+    **Step 2. Ask your AI to scaffold and deploy**
+
+    Type this prompt in your AI editor:
+
+    ```
+    Create a new Next.js app called my-app using Varity, install dependencies, then deploy it to production.
+    ```
+
+    The AI will call `varity_init`, `varity_install_deps`, `varity_build`, and `varity_deploy` in sequence. Your live URL appears when it is done.
+
+    **Step 3. Check the result**
+
+    ```
+    Show me the status of my Varity deployment
+    ```
+
+    You will get the live URL, framework detected, build time, and status.
+  </TabItem>
+  <TabItem label="From the terminal (CLI)">
+    **Step 1. Install the CLI**
+
+    ```bash
+    pip install varitykit
+    ```
+
+    Python 3.8 or later is required.
+
+    **Step 2. Scaffold your app**
+
+    ```bash
+    varitykit init my-app
+    cd my-app
+    ```
+
+    The interactive picker lets you choose a template. The `saas-starter` template includes authentication, a database, and a working dashboard out of the box.
+
+    **Step 3. Install dependencies**
+
+    ```bash
+    npm install
+    ```
+
+    **Step 4. Deploy**
+
+    ```bash
+    varitykit app deploy
+    ```
+
+    Your app is live. The terminal prints your URL.
+  </TabItem>
+</Tabs>
+
+## What gets auto-configured
+
+When you deploy a Next.js app with Varity, these services are wired automatically:
+
+| Service | What Varity does |
+|---|---|
+| Database (Postgres) | Provisions a dedicated schema, injects connection credentials at deploy time |
+| Authentication | Auto-wires login flows so users can sign in immediately after deploy |
+| Hosting | Detects SSR vs. static and picks the right compute type |
+| SSL | HTTPS is on by default. No certificate setup needed |
+| Custom URL | Your app gets a live public URL at `varity.app/your-app` |
+
+No environment variables to copy, no credential files to manage. The auto-wired services are documented in [Auto-wired Services](/deploy/auto-wired-services).
+
+## Full walkthrough: scaffold to live
+
+<Steps>
+
+1. **Verify your environment**
+
+   ```bash
+   varitykit doctor
+   ```
+
+   This checks Node.js, Python, CLI, and authentication status. Fix anything it flags before proceeding.
+
+2. **Scaffold the app**
+
+   ```bash
+   varitykit init my-nextjs-app
+   cd my-nextjs-app
+   npm install
+   ```
+
+   The `saas-starter` template gives you a Next.js App Router project with auth, database, and a working dashboard.
+
+3. **Run locally**
+
+   ```bash
+   npm run dev
+   ```
+
+   Open `http://localhost:3000`. Sign in, create a record, verify the UI works.
+
+4. **Build for production**
+
+   ```bash
+   npm run build
+   ```
+
+   Fix any TypeScript or lint errors before deploying.
+
+5. **Deploy**
+
+   ```bash
+   varitykit app deploy
+   ```
+
+   Output when done:
+
+   ```
+   Detecting framework...   Next.js (App Router)
+   Building app...          Done in 42s
+   Deploying...             Done in 18s
+   
+   Live at: https://varity.app/my-nextjs-app/
+   ```
+
+6. **Verify**
+
+   Open the URL. Sign in. Create a record. Confirm the app works exactly as it did locally.
+
+</Steps>
+
+## Deploy with a dynamic backend
+
+By default Varity detects whether your app is static or needs a live server. A Next.js app with API routes, server actions, or `getServerSideProps` is automatically deployed with container-based compute.
+
+If you want to force the hosting type:
+
+```bash
+varitykit app deploy --hosting dynamic
+```
+
+See [Auto-wired Services](/deploy/auto-wired-services) for a full explanation of how Varity picks the hosting type.
+
+## Using the MCP tools in your AI editor
+
+These are the relevant MCP tools for a Next.js deploy workflow:
+
+| Tool | What it does |
+|---|---|
+| `varity_doctor` | Checks environment setup |
+| `varity_init` | Scaffolds a new project from a template |
+| `varity_install_deps` | Runs npm install |
+| `varity_build` | Builds for production |
+| `varity_deploy` | Deploys and returns the live URL |
+| `varity_deploy_status` | Lists deployments with status and URL |
+| `varity_deploy_logs` | Gets build logs for debugging |
+
+Copy-paste prompts for each step:
+
+```
+Check if my environment is ready for Varity
+```
+
+```
+Create a new Varity app called invoice-tracker, install dependencies
+```
+
+```
+Build my project and deploy it to Varity
+```
+
+```
+Show me the deployment status and live URL
+```
+
+## Updating your app
+
+After making changes, redeploy with the same command:
+
+```bash
+varitykit app deploy
+```
+
+Or from your AI editor:
+
+```
+Build and redeploy my Varity app
+```
+
+Varity keeps the previous deployment available for instant rollback. See [Rollback a Deployment](/deploy/rollback).
+
+## Cost
+
+Varity is usage-based. A typical Next.js app with 100 monthly active users costs around 60-80% less than an equivalent AWS setup. Use the cost calculator to get a precise estimate:
+
+```
+How much would it cost to host a Next.js app with 500 users on Varity?
+```
+
+Or use the CLI:
+
+```bash
+varitykit cost-calculator --users 500 --has-database
+```
+
+See [How pricing works](/resources/pricing) for details.
+
+<Aside type="tip">
+Varity is currently in beta. All deployments run on production-grade infrastructure, but you are working with test data and a shared environment.
+</Aside>
+
+## Troubleshooting
+
+**Build fails with "Module not found"**
+
+Run `npm install` first, then rebuild.
+
+**"varitykit not found" in terminal**
+
+```bash
+pip install varitykit
+varitykit doctor
+```
+
+**Deploy times out**
+
+```bash
+varitykit doctor
+varitykit app deploy --verbose
+```
+
+**App loads but database is empty**
+
+Your app scaffold includes sample data creation in the dashboard. Navigate to a list view and create a record to confirm the database is wired correctly.
+
+See [Troubleshooting Deploys](/deploy/deployment-troubleshooting) for the full list.
+
+## Next steps
+
+- [Auto-wired Services](/deploy/auto-wired-services): What gets provisioned and how
+- [Environment Variables](/deploy/env-variables): What you can override
+- [Custom Domains](/deploy/custom-domains): Point your own domain at the deployment
+- [MCP Server Reference](/ai-tools/mcp-server-spec): All 16 MCP tools
+- [Rollback a Deployment](/deploy/rollback): Revert to a previous version


### PR DESCRIPTION
## Summary

- Adds `guides/deploy-nextjs.mdx`: canonical answer for "easiest way to deploy a Next.js app" (targets `gap-nextjs-deploys-2026-W17`)
- Adds `guides/deploy-from-ai-ide.mdx`: canonical answer for "deploy from Claude Code or Cursor" (targets `gap-vibe-coder-ai-ide-2026-W17`)
- Adds a **Guides** section to the sidebar in `astro.config.mjs` with both pages + existing `error-handling.mdx`

These pages are part of the W17 LLM Visibility response. LLM Visibility agent reported 0% Varity mention rate across 45 cells; both gap clusters are best answered by canonical docs pages that LLMs can cite as authoritative references.

## Content scope

**`guides/deploy-nextjs.mdx`**
- MCP path (Claude Code / Cursor / Windsurf) and CLI path in parallel tabs
- Full walkthrough: `varitykit doctor` → `varitykit init` → `npm run build` → `varitykit app deploy`
- Explains auto-wired Postgres + auth services
- Copy-paste MCP prompts for each step
- Cost section pointing to `varity_cost_calculator` and `/resources/pricing`

**`guides/deploy-from-ai-ide.mdx`**
- MCP install for Claude Code, Cursor, Windsurf, VS Code in tabs
- Canonical "deploy this" prompts tested and copy-paste ready
- Full vibe coding session walkthrough (Steps component)
- `CLAUDE.md` and `.cursor/rules/varity.mdc` snippets for project context
- Hosted MCP (`mcp.varity.so`) for browser-based AI tools

## Verification

- [x] Build passes: `76 page(s) built in 7.97s` (both pages present)
- [x] Zero POSITIONING.md §5 forbidden vocabulary (grep clean)
- [x] Zero em-dashes / en-dashes (grep clean, §5.5 compliant)
- [x] No Privy vendor names in user-facing prose
- [x] Follows "draft only, never publish directly" constraint: PR open, not merged

## Test plan

- [ ] Human reviews content for accuracy against current `varitykit` CLI commands
- [ ] Verify cross-links resolve (deploy-your-app, auto-wired-services, mcp-server-spec, etc.)
- [ ] Security Reviewer pass
- [ ] After merge + 4everland rebuild: confirm pages live at `docs.varity.so/guides/deploy-nextjs` and `docs.varity.so/guides/deploy-from-ai-ide`
- [ ] Comment on VAR-565 and parent VAR-564 with live URLs so LLM Visibility can re-probe in W19 (~May 4)

## Agent notes

Tested against World Model regression patterns: yes.
Follows shared rules: 0, 1, 2, 4, 5, 6, 7, 8.

Agent: Docs Sync (Paperclip) — ticket VAR-565