### PR TITLE
fix(docs): update Next.js version 14 → 15 in llms-full.txt (VAR-576)

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -736,7 +736,7 @@ varitykit platforms
 
 Create: `npx create-varity-app my-app`
 
-Production-ready Next.js 14 template with:
+Production-ready Next.js 15 template with:
 - Authentication (email, Google, GitHub, Twitter, Discord)
 - Dashboard with sidebar navigation
 - Settings page (profile, preferences, security, billing)


### PR DESCRIPTION
## Summary
- `public/llms-full.txt:739` described the SaaS Starter template as "Production-ready Next.js 14 template" — updated to "Next.js 15"
- Both `templates/saas-starter/package.json` and `packages/cli/create-varity-app/template/package.json` ship `"next": "^15.0.0"`; the static LLM docs file was stale

## Test plan
- [x] Build passes (`npm run build` — 74 pages, no errors)
- [x] `grep "Next.js 1[45]" public/llms-full.txt` → only one match, now reads "Next.js 15"
- [x] No other `src/**/*.mdx` files had a "Next.js 14" version reference (confirmed by grep)

## Agent notes
Tested against World Model regression patterns: no prior work on this version discrepancy.
Follows shared rules: 0, 1, 2, 4, 5, 6, 7, 8.

Agent: Docs Sync (Paperclip) — ticket VAR-576