### PR TITLE
fix(docs): force 4everland CDN rebuild for doctor page (VAR-561)

### DIFF
--- a/src/content/docs/cli/commands/doctor.mdx
+++ b/src/content/docs/cli/commands/doctor.mdx
@@ -9,7 +9,7 @@ import PageMeta from '../../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="March 2026"
+  lastUpdated="April 2026"
   stability="stable"
 />
 


### PR DESCRIPTION
## Summary
- The VAR-515 doctor.mdx rewrite (PR #38) merged correctly to master but 4everland did not rebuild — live `docs.varity.so/cli/commands/doctor` still renders `NEXT_PUBLIC_PRIVY_APP_ID` from the old version
- Empty commit `64c0394` also failed to trigger a rebuild (4everland appears to require actual file content changes)
- This PR makes a real file change (`lastUpdated: March → April 2026`, accurate since the page was rewritten in April) to generate a new IPFS content hash and force the CDN to serve the clean version

## Verified state
- Local `doctor.mdx` source: clean — no `NEXT_PUBLIC_PRIVY_APP_ID` anywhere
- Live `docs.varity.so/cli/commands/doctor`: stale — Playwright-verified at 06:12 UTC Apr 26 still shows `NEXT_PUBLIC_PRIVY_APP_ID` in "Environment Variables" table
- Build: 74 pages, 0 errors

## Test plan
- [ ] PR merges to master
- [ ] 4everland CDN rebuild triggers (watch 4everland dashboard)
- [ ] `https://docs.varity.so/cli/commands/doctor` no longer shows `NEXT_PUBLIC_PRIVY_APP_ID` — Playwright verify after rebuild

## Agent notes
Tested against World Model regression patterns: yes.
Follows shared rules: 0, 1, 2, 4, 5, 6, 7, 8.

Agent: Docs Sync (Paperclip) — ticket VAR-561