### PR TITLE
fix(docs): Next.js Quick Start — pipx, pnpm, date (VAR-577)

### DIFF
--- a/src/content/docs/getting-started/quickstart-nextjs.mdx
+++ b/src/content/docs/getting-started/quickstart-nextjs.mdx
@@ -9,7 +9,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="March 2026"
+  lastUpdated="April 2026"
   stability="stable"
 />
 
@@ -28,7 +28,7 @@ Build a full-stack Next.js app with authentication, database, and deployment in 
 1. **Install the CLI**
 
    ```bash
-   pip install varitykit
+   pipx install varitykit
    ```
 
 2. **Scaffold a new project**
@@ -43,13 +43,13 @@ Build a full-stack Next.js app with authentication, database, and deployment in 
 3. **Install dependencies**
 
    ```bash
-   npm install
+   pnpm install
    ```
 
 4. **Start the dev server**
 
    ```bash
-   npm run dev
+   pnpm dev
    ```
 
    Open [http://localhost:3000](http://localhost:3000). You should see the landing page.
@@ -184,7 +184,7 @@ export const NAVIGATION_ITEMS = [
 1. **Build your app**
 
    ```bash
-   npm run build
+   pnpm build
    ```
 
 2. **Deploy to Varity**


### PR DESCRIPTION
## Summary
- Fixes 3 bugs in `quickstart-nextjs.mdx` found by Dogfood Frontier E2E Round 1 (VAR-571)
- `pip install varitykit` → `pipx install varitykit` (Bug 2 — matches main Quick Start page, recommended installer)
- `npm install/run dev/run build` → `pnpm install/dev/build` (Bug 3 — avoids PostCSS hoisting HTTP 500 tracked in VAR-573)
- `lastUpdated` March → April 2026 (Bug 4 — accurate date after recent updates)

**Note on Bug 1** (`varitykit deploy logs` on live quick start page): the local `quickstart.mdx` source is already correct (`varitykit app status` only). Bug 1 will resolve automatically when PR #42 (VAR-561 CDN rebuild) merges and 4everland rebuilds.

**Note on Node.js version (Bug 4b):** local file already says "Node.js 20 or later" — no change needed.

## Test plan
- [x] Build: 74 pages, 0 errors
- [x] Diff: only `quickstart-nextjs.mdx`, 5 line changes, no unintended modifications
- [ ] After merge + CDN rebuild: `https://docs.varity.so/getting-started/quickstart-nextjs` shows `pipx`, `pnpm`, `April 2026`

## Agent notes
Tested against World Model regression patterns: yes — no prior regression patterns for these pages.
Follows shared rules: 0, 1, 2, 4, 5, 6, 7, 8.

Agent: Docs Sync (Paperclip) — ticket VAR-577