### PR TITLE
fix(docs): update Next.js quickstart — PrivyStack → AuthProvider, fix template info (VAR-577)

### DIFF
--- a/src/content/docs/getting-started/quickstart-nextjs.mdx
+++ b/src/content/docs/getting-started/quickstart-nextjs.mdx
@@ -56,19 +56,15 @@ Build a full-stack Next.js app with authentication, database, and deployment in 
 
 </Steps>
 
-## Available Templates
+## What Gets Scaffolded
 
-The `varitykit init` picker shows these templates:
+`varitykit init` creates a `saas-starter` project with auth, database, and a full dashboard pre-configured. The template includes:
 
-| Template | Description |
-|----------|-------------|
-| `finance-dashboard` | Financial services dashboard with fraud detection and AML monitoring |
-| `healthcare-dashboard` | Healthcare management with HIPAA compliance |
-| `retail-dashboard` | Retail management with inventory and sales analytics |
-| `iso-merchant-dashboard` | ISO merchant services with payment processing |
-| `generic-dashboard` | Generic business dashboard |
-
-Each template includes auth, database, and a full dashboard pre-configured.
+- **Landing page** — hero, features, pricing, CTA sections
+- **Auth** — email + Google sign-in, zero-config dev credentials
+- **Dashboard** — KPI cards, projects, tasks, team, settings
+- **Database** — Varity DB with full CRUD hooks pre-wired
+- **UI components** — from `@varity-labs/ui-kit`
 
 ## Project Structure
 
@@ -98,20 +94,16 @@ my-app/
 
 ### Authentication (already configured)
 
-The root layout wraps everything with the auth provider:
+The login and dashboard layouts wrap their pages with the auth provider:
 
-```tsx title="src/app/layout.tsx"
-import { PrivyStack } from '@varity-labs/ui-kit';
+```tsx title="src/app/login/page.tsx (simplified)"
+import { AuthProvider, useAuth } from '@varity-labs/ui-kit';
 
-export default function RootLayout({ children }) {
+export default function LoginPage() {
   return (
-    <html>
-      <body>
-        <PrivyStack appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID}>
-          {children}
-        </PrivyStack>
-      </body>
-    </html>
+    <AuthProvider appId={process.env.NEXT_PUBLIC_VARITY_AUTH_APP_ID}>
+      <LoginContent />
+    </AuthProvider>
   );
 }
 ```
@@ -166,7 +158,7 @@ export function useProjects() {
 Edit `src/lib/constants.ts` to change your app name and navigation:
 
 ```typescript title="src/lib/constants.ts"
-export const APP_NAME = 'TaskFlow';
+export const APP_NAME = 'My App';  // set to your project name
 
 export const NAVIGATION_ITEMS = [
   { label: 'Dashboard', icon: 'dashboard', path: '/dashboard' },

--- a/src/content/docs/getting-started/quickstart-nextjs.mdx
+++ b/src/content/docs/getting-started/quickstart-nextjs.mdx
@@ -9,7 +9,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="March 2026"
+  lastUpdated="April 2026"
   stability="stable"
 />
 
@@ -28,7 +28,7 @@ Build a full-stack Next.js app with authentication, database, and deployment in 
 1. **Install the CLI**
 
    ```bash
-   pip install varitykit
+   pipx install varitykit
    ```
 
 2. **Scaffold a new project**
@@ -43,13 +43,13 @@ Build a full-stack Next.js app with authentication, database, and deployment in 
 3. **Install dependencies**
 
    ```bash
-   npm install
+   pnpm install
    ```
 
 4. **Start the dev server**
 
    ```bash
-   npm run dev
+   pnpm dev
    ```
 
    Open [http://localhost:3000](http://localhost:3000). You should see the landing page.
@@ -184,7 +184,7 @@ export const NAVIGATION_ITEMS = [
 1. **Build your app**
 
    ```bash
-   npm run build
+   pnpm build
    ```
 
 2. **Deploy to Varity**


### PR DESCRIPTION
## Summary

- Replaces PrivyStack code example with AuthProvider/useAuth from @varity-labs/ui-kit
- Renames NEXT_PUBLIC_PRIVY_APP_ID → NEXT_PUBLIC_VARITY_AUTH_APP_ID in the auth code example
- Replaces inaccurate 5-template picker table with accurate saas-starter feature list
- Updates APP_NAME = 'TaskFlow' code example → APP_NAME = 'My App'

## Test plan

- [ ] Docs build succeeds (pnpm build)
- [ ] Auth code example matches actual template code
- [ ] No Privy / PrivyStack references remain in the page

Generated with Claude Code