### PR TITLE
fix(docs): remove all Privy/PrivyStack references — use clean Varity API names (VAR-621)

### DIFF
--- a/src/content/docs/ai-tools/prompts.mdx
+++ b/src/content/docs/ai-tools/prompts.mdx
@@ -229,11 +229,11 @@ CLI: varitykit (Python, installed via pip)
 - `db.collection<T>('name')` — Returns typed collection with .get(), .add(), .update(id, partial), .delete(id)
 
 ### @varity-labs/ui-kit
-- `PrivyStack` — Auth provider wrapper. Wrap your app root.
-- `PrivyLoginButton` — Drop-in login button (email, Google, Twitter, Discord, GitHub)
-- `PrivyProtectedRoute` — Wrapper that redirects unauthenticated users
-- `PrivyUserProfile` — User profile display component
-- `usePrivy()` — Hook returning { user, authenticated, logout, ready }
+- `AuthProvider` — Auth provider wrapper. Wrap your app root.
+- `LoginButton` — Drop-in login button (email, Google, Twitter, Discord, GitHub)
+- `ProtectedRoute` — Wrapper that redirects unauthenticated users
+- `UserProfile` — User profile display component
+- `useAuth()` — Hook returning { user, authenticated, logout, ready }
 - `DashboardLayout` — Sidebar dashboard layout (desktop only, add mobile nav manually)
 
 ### @varity-labs/types
@@ -256,17 +256,17 @@ CLI: varitykit (Python, installed via pip)
 ## Auth Pattern
 ```tsx
 // Layout: Set up auth provider
-<PrivyStack appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID}>
+<AuthProvider appId={process.env.NEXT_PUBLIC_VARITY_AUTH_APP_ID}>
   {children}
-</PrivyStack>
+</AuthProvider>
 
 // Protected page: Wrap with route protection
-<PrivyProtectedRoute>
+<ProtectedRoute>
   <DashboardContent />
-</PrivyProtectedRoute>
+</ProtectedRoute>
 
 // Get user info
-const { user, authenticated, logout } = usePrivy();
+const { user, authenticated, logout } = useAuth();
 const email = user?.email?.address;
 ```
 
@@ -278,7 +278,7 @@ const email = user?.email?.address;
 
 ## Environment Variables (Next.js)
 ```
-NEXT_PUBLIC_PRIVY_APP_ID=         # Auth (optional for dev, shared creds used)
+NEXT_PUBLIC_VARITY_AUTH_APP_ID=   # Auth (optional for dev, shared creds used)
 NEXT_PUBLIC_VARITY_APP_ID=        # Your app ID (after deploy)
 ```
 
@@ -391,14 +391,14 @@ npm install @varity-labs/ui-kit
 
 ## 1. Set up auth provider (layout.tsx)
 ```tsx
-import { PrivyStack } from '@varity-labs/ui-kit';
+import { AuthProvider } from '@varity-labs/ui-kit';
 
 export default function RootLayout({ children }) {
   return (
     <html><body>
-      <PrivyStack appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID}>
+      <AuthProvider appId={process.env.NEXT_PUBLIC_VARITY_AUTH_APP_ID}>
         {children}
-      </PrivyStack>
+      </AuthProvider>
     </body></html>
   );
 }
@@ -407,30 +407,30 @@ No appId needed for development — shared credentials are used automatically.
 
 ## 2. Add login button
 ```tsx
-import { PrivyLoginButton } from '@varity-labs/ui-kit';
-<PrivyLoginButton />
+import { LoginButton } from '@varity-labs/ui-kit';
+<LoginButton />
 ```
 Supports: Email (magic link), Google, Twitter, Discord, GitHub
 
 ## 3. Protect routes
 ```tsx
-import { PrivyProtectedRoute } from '@varity-labs/ui-kit';
-<PrivyProtectedRoute>
+import { ProtectedRoute } from '@varity-labs/ui-kit';
+<ProtectedRoute>
   <DashboardPage />  {/* Only shown when authenticated */}
-</PrivyProtectedRoute>
+</ProtectedRoute>
 ```
 
 ## 4. Access user data
 ```tsx
-import { usePrivy } from '@varity-labs/ui-kit';
-const { user, authenticated, logout, ready } = usePrivy();
+import { useAuth } from '@varity-labs/ui-kit';
+const { user, authenticated, logout, ready } = useAuth();
 const email = user?.email?.address;
 const name = email?.split('@')[0];
 ```
 
 ## Rules
-- PrivyStack must wrap the entire app (in root layout)
-- usePrivy() only works inside PrivyStack
+- AuthProvider must wrap the entire app (in root layout)
+- useAuth() only works inside AuthProvider
 - Check `ready` before rendering auth-dependent UI
 - Check `authenticated` before showing protected content
 - `user?.email?.address` — the primary user identifier
@@ -463,7 +463,7 @@ varitykit app deploy --submit-to-store
 ## Environment Variables
 Set in .env.local for development. On deploy, credentials are injected automatically.
 ```
-NEXT_PUBLIC_PRIVY_APP_ID=         # Optional for dev
+NEXT_PUBLIC_VARITY_AUTH_APP_ID=   # Optional for dev
 NEXT_PUBLIC_VARITY_APP_ID=        # Set after first deploy
 ```
 

--- a/src/content/docs/build/auth/email-login.mdx
+++ b/src/content/docs/build/auth/email-login.mdx
@@ -31,15 +31,15 @@ No password storage, no forgotten password flows, no security vulnerabilities fr
 1. **Set up your auth provider**
 
    ```tsx title="app/layout.tsx"
-   import { PrivyStack } from '@varity-labs/ui-kit';
+   import { AuthProvider } from '@varity-labs/ui-kit';
 
    export default function RootLayout({ children }) {
      return (
        <html>
          <body>
-           <PrivyStack loginMethods={['email']}>
+           <AuthProvider loginMethods={['email']}>
              {children}
-           </PrivyStack>
+           </AuthProvider>
          </body>
        </html>
      );
@@ -49,13 +49,13 @@ No password storage, no forgotten password flows, no security vulnerabilities fr
 2. **Add the login button**
 
    ```tsx title="components/LoginButton.tsx"
-   import { PrivyLoginButton } from '@varity-labs/ui-kit';
+   import { LoginButton } from '@varity-labs/ui-kit';
 
    export function LoginButton() {
      return (
-       <PrivyLoginButton>
+       <LoginButton>
          Sign in with Email
-       </PrivyLoginButton>
+       </LoginButton>
      );
    }
    ```
@@ -64,13 +64,13 @@ No password storage, no forgotten password flows, no security vulnerabilities fr
 
 ## Custom Login Button
 
-Build your own login button using the `usePrivy` hook:
+Build your own login button using the `useAuth` hook:
 
 ```tsx title="components/CustomEmailLogin.tsx"
-import { usePrivy, useLogin } from '@varity-labs/ui-kit';
+import { useAuth, useLogin } from '@varity-labs/ui-kit';
 
 export function CustomEmailLogin() {
-  const { ready, authenticated } = usePrivy();
+  const { ready, authenticated } = useAuth();
   const { login } = useLogin();
 
   if (!ready) {
@@ -97,10 +97,10 @@ export function CustomEmailLogin() {
 After login, access the user's email from the `user` object:
 
 ```tsx title="components/UserProfile.tsx"
-import { usePrivy } from '@varity-labs/ui-kit';
+import { useAuth } from '@varity-labs/ui-kit';
 
 export function UserProfile() {
-  const { user } = usePrivy();
+  const { user } = useAuth();
 
   if (!user) return null;
 
@@ -135,7 +135,7 @@ The typical user experience:
 Execute custom logic when a user successfully logs in:
 
 ```tsx title="components/LoginWithCallback.tsx"
-import { PrivyLoginButton } from '@varity-labs/ui-kit';
+import { LoginButton } from '@varity-labs/ui-kit';
 
 export function LoginWithCallback() {
   const handleSuccess = (user) => {
@@ -155,12 +155,12 @@ export function LoginWithCallback() {
   };
 
   return (
-    <PrivyLoginButton
+    <LoginButton
       onSuccess={handleSuccess}
       onError={handleError}
     >
       Sign in with Email
-    </PrivyLoginButton>
+    </LoginButton>
   );
 }
 ```
@@ -170,10 +170,10 @@ export function LoginWithCallback() {
 Only show content to logged-in users:
 
 ```tsx title="pages/dashboard.tsx"
-import { PrivyProtectedRoute, usePrivy } from '@varity-labs/ui-kit';
+import { ProtectedRoute, useAuth } from '@varity-labs/ui-kit';
 
 function DashboardContent() {
-  const { user } = usePrivy();
+  const { user } = useAuth();
 
   return (
     <div>
@@ -185,9 +185,9 @@ function DashboardContent() {
 
 export default function Dashboard() {
   return (
-    <PrivyProtectedRoute>
+    <ProtectedRoute>
       <DashboardContent />
-    </PrivyProtectedRoute>
+    </ProtectedRoute>
   );
 }
 ```
@@ -197,9 +197,9 @@ export default function Dashboard() {
 To only allow email login (no social providers):
 
 ```tsx title="app/layout.tsx"
-<PrivyStack loginMethods={['email']}>
+<AuthProvider loginMethods={['email']}>
   {children}
-</PrivyStack>
+</AuthProvider>
 ```
 
 This simplifies the login modal to only show an email input field.

--- a/src/content/docs/build/auth/quickstart.mdx
+++ b/src/content/docs/build/auth/quickstart.mdx
@@ -49,18 +49,18 @@ Add authentication to your app in under 5 minutes. No configuration required for
 
 1. **Wrap your app with the auth provider**
 
-   Add `PrivyStack` to your root layout. This provides authentication context to your entire app.
+   Add `AuthProvider` to your root layout. This provides authentication context to your entire app.
 
    ```tsx title="app/layout.tsx"
-   import { PrivyStack } from '@varity-labs/ui-kit';
+   import { AuthProvider } from '@varity-labs/ui-kit';
 
    export default function RootLayout({ children }) {
      return (
        <html>
          <body>
-           <PrivyStack appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID}>
+           <AuthProvider appId={process.env.NEXT_PUBLIC_VARITY_AUTH_APP_ID}>
              {children}
-           </PrivyStack>
+           </AuthProvider>
          </body>
        </html>
      );
@@ -68,25 +68,25 @@ Add authentication to your app in under 5 minutes. No configuration required for
    ```
 
    <Aside type="tip">
-   **No API keys needed for development.** Shared development credentials are used automatically. Add your own `NEXT_PUBLIC_PRIVY_APP_ID` before going to production.
+   **No API keys needed for development.** Shared development credentials are used automatically. Add your own `NEXT_PUBLIC_VARITY_AUTH_APP_ID` before going to production.
    </Aside>
 
 2. **Add a login button**
 
-   Use `PrivyLoginButton` to render a ready-made sign-in button. Use the `usePrivy()` hook to check auth state and sign users out.
+   Use `LoginButton` to render a ready-made sign-in button. Use the `useAuth()` hook to check auth state and sign users out.
 
    ```tsx title="components/Header.tsx"
-   import { PrivyLoginButton, usePrivy } from '@varity-labs/ui-kit';
+   import { LoginButton, useAuth } from '@varity-labs/ui-kit';
 
    export function Header() {
-     const { authenticated, logout } = usePrivy();
+     const { authenticated, logout } = useAuth();
 
      return (
        <header>
          {authenticated ? (
            <button onClick={logout}>Sign Out</button>
          ) : (
-           <PrivyLoginButton />
+           <LoginButton />
          )}
        </header>
      );
@@ -95,16 +95,16 @@ Add authentication to your app in under 5 minutes. No configuration required for
 
 3. **Protect routes**
 
-   Wrap any page with `PrivyProtectedRoute`. Unauthenticated users are automatically redirected to sign in.
+   Wrap any page with `ProtectedRoute`. Unauthenticated users are automatically redirected to sign in.
 
    ```tsx title="app/dashboard/page.tsx"
-   import { PrivyProtectedRoute } from '@varity-labs/ui-kit';
+   import { ProtectedRoute } from '@varity-labs/ui-kit';
 
    export default function DashboardPage() {
      return (
-       <PrivyProtectedRoute>
+       <ProtectedRoute>
          <Dashboard />
-       </PrivyProtectedRoute>
+       </ProtectedRoute>
      );
    }
    ```
@@ -115,13 +115,13 @@ That's it. Users can now sign in with email or social accounts.
 
 ## Access user data
 
-Use the `usePrivy()` hook anywhere in your app to read the current user.
+Use the `useAuth()` hook anywhere in your app to read the current user.
 
 ```tsx
-import { usePrivy } from '@varity-labs/ui-kit';
+import { useAuth } from '@varity-labs/ui-kit';
 
 function Profile() {
-  const { user, authenticated } = usePrivy();
+  const { user, authenticated } = useAuth();
 
   if (!authenticated) {
     return <p>Please sign in</p>;
@@ -149,5 +149,5 @@ function Profile() {
 
 - [Email Login](/build/auth/email-login): configure magic link options
 - [Social Login](/build/auth/social-login): Google, Twitter, Discord setup
-- [Protected Routes](/packages/ui-kit/components#privyprotectedroute): route protection API
+- [Protected Routes](/packages/ui-kit/components#protectedroute): route protection API
 - [Storage Guide](/build/storage/quickstart): upload and retrieve files

--- a/src/content/docs/build/auth/social-login.mdx
+++ b/src/content/docs/build/auth/social-login.mdx
@@ -32,17 +32,17 @@ Let users sign in with accounts they already have. No new passwords, no email ve
 1. **Configure login methods**
 
    ```tsx title="app/layout.tsx"
-   import { PrivyStack } from '@varity-labs/ui-kit';
+   import { AuthProvider } from '@varity-labs/ui-kit';
 
    export default function RootLayout({ children }) {
      return (
        <html>
          <body>
-           <PrivyStack
+           <AuthProvider
              loginMethods={['email', 'google', 'twitter', 'discord']}
            >
              {children}
-           </PrivyStack>
+           </AuthProvider>
          </body>
        </html>
      );
@@ -51,13 +51,13 @@ Let users sign in with accounts they already have. No new passwords, no email ve
 
 2. **Add the login button**
 
-   The `PrivyLoginButton` automatically shows all configured providers:
+   The `LoginButton` automatically shows all configured providers:
 
    ```tsx title="components/LoginButton.tsx"
-   import { PrivyLoginButton } from '@varity-labs/ui-kit';
+   import { LoginButton } from '@varity-labs/ui-kit';
 
    export function LoginButton() {
-     return <PrivyLoginButton />;
+     return <LoginButton />;
    }
    ```
 
@@ -71,13 +71,13 @@ Users will see a modal with options for email and all configured social provider
 
 ## Accessing User Data
 
-After social login, user data is available through `usePrivy`:
+After social login, user data is available through `useAuth`:
 
 ```tsx title="components/UserInfo.tsx"
-import { usePrivy } from '@varity-labs/ui-kit';
+import { useAuth } from '@varity-labs/ui-kit';
 
 export function UserInfo() {
-  const { user } = usePrivy();
+  const { user } = useAuth();
 
   if (!user) return null;
 
@@ -117,7 +117,7 @@ export function UserInfo() {
 Customize the appearance of the login modal:
 
 ```tsx title="app/layout.tsx"
-<PrivyStack
+<AuthProvider
   loginMethods={['email', 'google', 'twitter']}
   appearance={{
     theme: 'light',
@@ -126,7 +126,7 @@ Customize the appearance of the login modal:
   }}
 >
   {children}
-</PrivyStack>
+</AuthProvider>
 ```
 
 ### Theme Options
@@ -142,11 +142,11 @@ Customize the appearance of the login modal:
 To disable email login and only allow social providers:
 
 ```tsx title="app/layout.tsx"
-<PrivyStack
+<AuthProvider
   loginMethods={['google', 'twitter', 'discord']}
 >
   {children}
-</PrivyStack>
+</AuthProvider>
 ```
 
 ## Best Practices
@@ -164,12 +164,12 @@ Pick providers your users actually use:
 ### Handle Login Errors
 
 ```tsx title="components/LoginWithErrorHandling.tsx"
-import { PrivyLoginButton } from '@varity-labs/ui-kit';
+import { LoginButton } from '@varity-labs/ui-kit';
 import { toast } from 'react-hot-toast';
 
 export function LoginWithErrorHandling() {
   return (
-    <PrivyLoginButton
+    <LoginButton
       onSuccess={(user) => {
         toast.success(`Welcome, ${user.email?.address || 'User'}!`);
       }}

--- a/src/content/docs/build/payments/credit-card.mdx
+++ b/src/content/docs/build/payments/credit-card.mdx
@@ -47,10 +47,10 @@ Add payment components directly in your app:
 
 ```tsx title="components/UpgradeButton.tsx"
 import { PaymentWidget } from '@varity-labs/ui-kit';
-import { usePrivy } from '@varity-labs/ui-kit';
+import { useAuth } from '@varity-labs/ui-kit';
 
 export function UpgradeButton() {
-  const { user } = usePrivy();
+  const { user } = useAuth();
 
   if (!user) {
     return <p>Please log in to upgrade</p>;
@@ -77,11 +77,11 @@ For a complete payment experience:
 
 ```tsx title="pages/checkout.tsx"
 import { PaymentGate } from '@varity-labs/ui-kit';
-import { usePrivy } from '@varity-labs/ui-kit';
+import { useAuth } from '@varity-labs/ui-kit';
 import { useRouter } from 'next/navigation';
 
 export default function CheckoutPage() {
-  const { user, authenticated } = usePrivy();
+  const { user, authenticated } = useAuth();
   const router = useRouter();
 
   if (!authenticated) {

--- a/src/content/docs/component-showcase.mdx
+++ b/src/content/docs/component-showcase.mdx
@@ -282,25 +282,25 @@ Collapsible content for advanced/optional sections.
   Here's a complete example showing login, user state, and logout:
 
   ```tsx
-  import { PrivyStack, PrivyLoginButton, usePrivy } from '@varity-labs/ui-kit'
+  import { AuthProvider, LoginButton, useAuth } from '@varity-labs/ui-kit'
 
   // Set up auth provider
   function App() {
     return (
-      <PrivyStack appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID}>
+      <AuthProvider appId={process.env.NEXT_PUBLIC_VARITY_AUTH_APP_ID}>
         <AuthExample />
-      </PrivyStack>
+      </AuthProvider>
     )
   }
 
   // Use the auth hook for state
   function AuthExample() {
-    const { ready, authenticated, user, logout } = usePrivy()
+    const { ready, authenticated, user, logout } = useAuth()
 
     if (!ready) return <p>Loading...</p>
 
     if (!authenticated) {
-      return <PrivyLoginButton />
+      return <LoginButton />
     }
 
     return (

--- a/src/content/docs/deploy/managed-credentials.mdx
+++ b/src/content/docs/deploy/managed-credentials.mdx
@@ -121,10 +121,10 @@ You can override the managed authentication credential with your own provider co
 2. Add to your `.env.local`:
 
 ```bash title=".env.local"
-NEXT_PUBLIC_PRIVY_APP_ID=your_privy_app_id
+NEXT_PUBLIC_VARITY_AUTH_APP_ID=your_varity_auth_app_id
 ```
 
-Storage is handled automatically by Varity. When `NEXT_PUBLIC_PRIVY_APP_ID` is set, the SDK uses your own authentication app instead of the managed one.
+Storage is handled automatically by Varity. When `NEXT_PUBLIC_VARITY_AUTH_APP_ID` is set, the SDK uses your own authentication app instead of the managed one.
 
 </Accordion>
 

--- a/src/content/docs/getting-started/quickstart-react.mdx
+++ b/src/content/docs/getting-started/quickstart-react.mdx
@@ -69,15 +69,15 @@ Set up a React app with Vite and add Varity authentication and database.
    ```tsx title="src/main.tsx"
    import React from 'react';
    import ReactDOM from 'react-dom/client';
-   import { PrivyStack } from '@varity-labs/ui-kit';
+   import { AuthProvider } from '@varity-labs/ui-kit';
    import App from './App';
    import './index.css';
 
    ReactDOM.createRoot(document.getElementById('root')!).render(
      <React.StrictMode>
-       <PrivyStack appId={import.meta.env.VITE_PRIVY_APP_ID}>
+       <AuthProvider appId={import.meta.env.VITE_VARITY_AUTH_APP_ID}>
          <App />
-       </PrivyStack>
+       </AuthProvider>
      </React.StrictMode>
    );
    ```
@@ -89,10 +89,10 @@ Set up a React app with Vite and add Varity authentication and database.
 2. **Add a login button**
 
    ```tsx title="src/App.tsx"
-   import { PrivyLoginButton, PrivyProtectedRoute, usePrivy } from '@varity-labs/ui-kit';
+   import { LoginButton, ProtectedRoute, useAuth } from '@varity-labs/ui-kit';
 
    function Dashboard() {
-     const { user, logout } = usePrivy();
+     const { user, logout } = useAuth();
 
      return (
        <div>
@@ -106,11 +106,11 @@ Set up a React app with Vite and add Varity authentication and database.
      return (
        <div>
          <h1>My App</h1>
-         <PrivyLoginButton />
+         <LoginButton />
 
-         <PrivyProtectedRoute>
+         <ProtectedRoute>
            <Dashboard />
-         </PrivyProtectedRoute>
+         </ProtectedRoute>
        </div>
      );
    }
@@ -255,7 +255,7 @@ For Vite projects, use the `VITE_` prefix:
 
 ```bash title=".env"
 VITE_VARITY_APP_ID=your-app-id
-VITE_PRIVY_APP_ID=your-privy-id
+VITE_VARITY_AUTH_APP_ID=your-varity-auth-app-id
 ```
 
 <Aside type="tip">

--- a/src/content/docs/packages/sdk/api-reference.mdx
+++ b/src/content/docs/packages/sdk/api-reference.mdx
@@ -338,9 +338,7 @@ Automatically resolves credentials from environment variables with fallback to d
 
 ```typescript
 interface CredentialConfig {
-  privy: {
-    appId: string;
-  };
+  authAppId: string;
 
 **Returns:** `boolean` - `true` if using dev credentials
 
@@ -368,7 +366,7 @@ Checks if credentials are production-ready (opposite of `isUsingDevCredentials`)
 ```typescript
 import { isProductionCredentials } from '@varity-labs/sdk';
 
-const appId = process.env.NEXT_PUBLIC_PRIVY_APP_ID;
+const appId = process.env.NEXT_PUBLIC_VARITY_AUTH_APP_ID;
 
 **Example:**
 

--- a/src/content/docs/packages/sdk/overview.mdx
+++ b/src/content/docs/packages/sdk/overview.mdx
@@ -86,7 +86,7 @@ const items = customDb.collection('items');
 
 | Export | Type | Description |
 |--------|------|-------------|
-| `VARITY_DEV_CREDENTIALS` | const (object) | Shared dev credentials containing `privy.appId` and `rateLimits` |
+| `VARITY_DEV_CREDENTIALS` | const (object) | Shared dev credentials containing `authAppId` and `rateLimits` |
 | `resolveCredentials` | function | `(appId?) => CredentialConfig` -- resolves with fallback to dev credentials |
 | `validateCredentials` | function | `(appId) => void` -- throws if credentials are invalid |
 | `isUsingDevCredentials` | function | `(appId?) => boolean` -- check if using shared dev credentials |
@@ -105,9 +105,9 @@ import {
 
 // Resolve credentials with automatic fallback to dev credentials
 const creds = resolveCredentials(
-  process.env.NEXT_PUBLIC_PRIVY_APP_ID,
+  process.env.NEXT_PUBLIC_VARITY_AUTH_APP_ID,
 );
-console.log(creds.privy.appId);
+console.log(creds.authAppId);
 
 // Check if using dev credentials (useful for showing warnings)
 if (isUsingDevCredentials()) {
@@ -140,7 +140,7 @@ The SDK exports these TypeScript types from the main entry point:
 
 ```typescript
 import type {
-  CredentialConfig,   // { privy: { appId } }
+  CredentialConfig,   // { authAppId: string }
   DatabaseConfig,     // { proxyUrl?: string, appToken?: string }
   QueryOptions,       // { limit?, offset?, orderBy? }
   Document,           // { id: string, created_at?, updated_at?, [key]: any }

--- a/src/content/docs/packages/ui-kit/components.mdx
+++ b/src/content/docs/packages/ui-kit/components.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Components Reference"
-description: "Full API reference for @varity-labs/ui-kit React components: Button, Card, DataTable, Modal, Toast, PrivyStack, and 20+ more."
+description: "Full API reference for @varity-labs/ui-kit React components: Button, Card, DataTable, Modal, Toast, AuthProvider, and 20+ more."
 ---
 
 import { Aside } from '@astrojs/starlight/components';
@@ -23,15 +23,15 @@ import { ComponentName } from '@varity-labs/ui-kit';
 
 ## Providers
 
-### PrivyStack
+### AuthProvider
 
 All-in-one provider that sets up authentication and account management. Wrap your app with this once.
 
 ```tsx
-import { PrivyStack } from '@varity-labs/ui-kit';
+import { AuthProvider } from '@varity-labs/ui-kit';
 
-<PrivyStack
-  appId="your-privy-app-id"
+<AuthProvider
+  appId="your-varity-auth-app-id"
   loginMethods={['email', 'google']}
   appearance={{
     theme: 'light',
@@ -40,7 +40,7 @@ import { PrivyStack } from '@varity-labs/ui-kit';
   }}
 >
   {children}
-</PrivyStack>
+</AuthProvider>
 ```
 
 | Prop | Type | Default | Description |
@@ -58,7 +58,7 @@ Full-featured provider for dashboards. Includes authentication, React Query, and
 import { VarityDashboardProvider } from '@varity-labs/ui-kit';
 
 <VarityDashboardProvider
-  privyAppId={process.env.NEXT_PUBLIC_PRIVY_APP_ID}
+  appId={process.env.NEXT_PUBLIC_VARITY_AUTH_APP_ID}
   appearance={{ theme: 'light', logo: '/logo.png' }}
 >
   <Dashboard />
@@ -67,21 +67,21 @@ import { VarityDashboardProvider } from '@varity-labs/ui-kit';
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `privyAppId` | `string` | env var | Auth App ID |
+| `appId` | `string` | env var | Auth App ID |
 | `appearance` | `{ theme, accentColor, logo }` | - | UI customization |
 | `loginMethods` | `string[]` | `['email', 'google']` | Login options |
 | `children` | `ReactNode` | Required | App content |
 
-### VarityPrivyProvider
+### AuthBaseProvider
 
-Lower-level auth wrapper. Most apps should use `PrivyStack` instead.
+Lower-level auth wrapper. Most apps should use `AuthProvider` instead.
 
 ```tsx
-import { VarityPrivyProvider } from '@varity-labs/ui-kit';
+import { AuthBaseProvider } from '@varity-labs/ui-kit';
 
-<VarityPrivyProvider appId="your-privy-app-id">
+<AuthBaseProvider appId="your-varity-auth-app-id">
   {children}
-</VarityPrivyProvider>
+</AuthBaseProvider>
 ```
 
 ### ThemeProvider
@@ -137,22 +137,22 @@ function SaveButton() {
 
 ## Authentication Components
 
-### PrivyLoginButton
+### LoginButton
 
 Pre-built login button that opens the authentication modal.
 
 ```tsx
-import { PrivyLoginButton } from '@varity-labs/ui-kit';
+import { LoginButton } from '@varity-labs/ui-kit';
 
-<PrivyLoginButton />
+<LoginButton />
 
-<PrivyLoginButton
+<LoginButton
   onSuccess={() => router.push('/dashboard')}
   onError={(error) => console.error(error)}
   className="btn-primary"
 >
   Sign In to Continue
-</PrivyLoginButton>
+</LoginButton>
 ```
 
 | Prop | Type | Default | Description |
@@ -162,16 +162,16 @@ import { PrivyLoginButton } from '@varity-labs/ui-kit';
 | `onError` | `function` | - | Called on login error |
 | `className` | `string` | - | CSS class name |
 
-### PrivyUserProfile
+### UserProfile
 
 Displays user information with optional logout button.
 
 ```tsx
-import { PrivyUserProfile } from '@varity-labs/ui-kit';
+import { UserProfile } from '@varity-labs/ui-kit';
 
-<PrivyUserProfile showLogoutButton />
+<UserProfile showLogoutButton />
 
-<PrivyUserProfile
+<UserProfile
   showLogoutButton
   onLogout={() => router.push('/')}
 />
@@ -183,23 +183,23 @@ import { PrivyUserProfile } from '@varity-labs/ui-kit';
 | `onLogout` | `function` | - | Custom logout handler |
 | `className` | `string` | - | CSS class name |
 
-### PrivyProtectedRoute
+### ProtectedRoute
 
 Shows content only to authenticated users.
 
 ```tsx
-import { PrivyProtectedRoute } from '@varity-labs/ui-kit';
+import { ProtectedRoute } from '@varity-labs/ui-kit';
 
-<PrivyProtectedRoute>
+<ProtectedRoute>
   <Dashboard />
-</PrivyProtectedRoute>
+</ProtectedRoute>
 
-<PrivyProtectedRoute
+<ProtectedRoute
   fallback={<CustomLoginPage />}
   loadingComponent={<CustomSpinner />}
 >
   <Dashboard />
-</PrivyProtectedRoute>
+</ProtectedRoute>
 ```
 
 | Prop | Type | Default | Description |
@@ -208,20 +208,20 @@ import { PrivyProtectedRoute } from '@varity-labs/ui-kit';
 | `fallback` | `ReactNode` | Login prompt | Shown when not authenticated |
 | `loadingComponent` | `ReactNode` | Spinner | Shown while loading |
 
-### PrivyReadyGate
+### ReadyGate
 
 Prevents a blank screen during auth initialization (5-15 seconds).
 
 ```tsx
-import { PrivyReadyGate } from '@varity-labs/ui-kit';
+import { ReadyGate } from '@varity-labs/ui-kit';
 
-<PrivyReadyGate
+<ReadyGate
   timeout={10000}
   initializingScreen={<SplashScreen />}
   timeoutScreen={<ConnectionError />}
 >
   {children}
-</PrivyReadyGate>
+</ReadyGate>
 ```
 
 | Prop | Type | Default | Description |
@@ -235,9 +235,9 @@ import { PrivyReadyGate } from '@varity-labs/ui-kit';
 For convenience, these authentication hooks are re-exported from `@varity-labs/ui-kit`:
 
 ```tsx
-import { usePrivy, useLogin, useLogout } from '@varity-labs/ui-kit';
+import { useAuth, useLogin, useLogout } from '@varity-labs/ui-kit';
 
-const { authenticated, user, ready } = usePrivy();
+const { authenticated, user, ready } = useAuth();
 ```
 
 ---
@@ -1350,7 +1350,7 @@ The `Attribution` component is required per the Varity licensing agreement and m
 |------|--------|-------------|
 | `useToast` | `@varity-labs/ui-kit` | Access toast notifications (`success`, `error`, `info`) |
 | `useTheme` | `@varity-labs/ui-kit` | Access current `VarityTheme` from `ThemeProvider` |
-| `usePrivy` | `@varity-labs/ui-kit` | Auth state (`authenticated`, `user`, `ready`) |
+| `useAuth` | `@varity-labs/ui-kit` | Auth state (`authenticated`, `user`, `ready`) |
 | `useLogin` | `@varity-labs/ui-kit` | Programmatic login trigger |
 | `useLogout` | `@varity-labs/ui-kit` | Programmatic logout trigger |
 | `useVarityPayment` | `@varity-labs/ui-kit` | Programmatic payment control |
@@ -1361,40 +1361,40 @@ The `Attribution` component is required per the Varity licensing agreement and m
 
 ```tsx
 import {
-  PrivyStack,
-  PrivyLoginButton,
-  PrivyUserProfile,
-  PrivyProtectedRoute,
+  AuthProvider,
+  LoginButton,
+  UserProfile,
+  ProtectedRoute,
   DashboardLayout,
   KPICard,
   DataTable,
   Button,
   ToastProvider,
   useToast,
-  usePrivy,
+  useAuth,
 } from '@varity-labs/ui-kit';
 
 function App() {
   return (
-    <PrivyStack appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID}>
+    <AuthProvider appId={process.env.NEXT_PUBLIC_VARITY_AUTH_APP_ID}>
       <ToastProvider>
         <Header />
         <main>
-          <PrivyProtectedRoute>
+          <ProtectedRoute>
             <DashboardPage />
-          </PrivyProtectedRoute>
+          </ProtectedRoute>
         </main>
       </ToastProvider>
-    </PrivyStack>
+    </AuthProvider>
   );
 }
 
 function Header() {
-  const { authenticated } = usePrivy();
+  const { authenticated } = useAuth();
   return (
     <header className="flex justify-between p-4">
       <h1>My App</h1>
-      {authenticated ? <PrivyUserProfile showLogoutButton /> : <PrivyLoginButton />}
+      {authenticated ? <UserProfile showLogoutButton /> : <LoginButton />}
     </header>
   );
 }

--- a/src/content/docs/packages/ui-kit/hooks.mdx
+++ b/src/content/docs/packages/ui-kit/hooks.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Hooks Reference"
-description: "API reference for all @varity-labs/ui-kit React hooks including usePrivy, useTheme, useToast, and authentication state management."
+description: "API reference for all @varity-labs/ui-kit React hooks including useAuth, useTheme, useToast, and authentication state management."
 ---
 
 import Accordion from '../../../../components/Accordion.astro';
@@ -22,9 +22,9 @@ All React hooks exported by `@varity-labs/ui-kit`. Every hook listed here is ver
 | `useToast` | Feedback | `<ToastProvider>` |
 | `useTheme` | Branding | `<ThemeProvider>` |
 | `useVarityPayment` | Payments | None |
-| `usePrivy` | Authentication | `<VarityPrivyProvider>` |
-| `useLogin` | Authentication | `<VarityPrivyProvider>` |
-| `useLogout` | Authentication | `<VarityPrivyProvider>` |
+| `useAuth` | Authentication | `<AuthBaseProvider>` |
+| `useLogin` | Authentication | `<AuthBaseProvider>` |
+| `useLogout` | Authentication | `<AuthBaseProvider>` |
 
 ---
 
@@ -218,14 +218,14 @@ function PremiumFeature({ appId }: { appId: number }) {
 
 ## Authentication Hooks
 
-These hooks are re-exported from the auth library. They require `<VarityPrivyProvider>` in your component tree.
+These hooks are re-exported from the auth library. They require `<AuthBaseProvider>` in your component tree.
 
-### usePrivy
+### useAuth
 
 Core authentication hook. Provides login state, user profile, and auth actions.
 
 ```tsx
-import { usePrivy } from '@varity-labs/ui-kit';
+import { useAuth } from '@varity-labs/ui-kit';
 
 function MyComponent() {
   const {
@@ -234,7 +234,7 @@ function MyComponent() {
     user,           // User object or null
     login,          // () => void - Open login modal
     logout,         // () => Promise<void> - Log out
-  } = usePrivy();
+  } = useAuth();
 
   if (!ready) return <div>Loading...</div>;
 
@@ -293,30 +293,30 @@ function AuthControls() {
 
 ```tsx
 import {
-  usePrivy,
+  useAuth,
   useToast,
   useTheme,
   ToastProvider,
   ThemeProvider,
-  VarityPrivyProvider,
+  AuthBaseProvider,
 } from '@varity-labs/ui-kit';
 
 // App setup with all required providers
 function App() {
   return (
-    <VarityPrivyProvider appId="your-privy-app-id">
+    <AuthBaseProvider appId="your-varity-auth-app-id">
       <ThemeProvider theme={{ primaryColor: '#1976d2' }}>
         <ToastProvider>
           <Dashboard />
         </ToastProvider>
       </ThemeProvider>
-    </VarityPrivyProvider>
+    </AuthBaseProvider>
   );
 }
 
 // Dashboard using all hooks
 function Dashboard() {
-  const { user, authenticated, logout } = usePrivy();
+  const { user, authenticated, logout } = useAuth();
   const toast = useToast();
   const theme = useTheme();
 

--- a/src/content/docs/packages/ui-kit/installation.mdx
+++ b/src/content/docs/packages/ui-kit/installation.mdx
@@ -71,15 +71,15 @@ Just install the packages and start building. The UI Kit uses managed credential
 1. **Set up your auth provider**
 
    ```tsx title="app/layout.tsx"
-   import { PrivyStack } from '@varity-labs/ui-kit';
+   import { AuthProvider } from '@varity-labs/ui-kit';
 
    export default function RootLayout({ children }) {
      return (
        <html>
          <body>
-           <PrivyStack appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID}>
+           <AuthProvider appId={process.env.NEXT_PUBLIC_VARITY_AUTH_APP_ID}>
              {children}
-           </PrivyStack>
+           </AuthProvider>
          </body>
        </html>
      );
@@ -89,17 +89,17 @@ Just install the packages and start building. The UI Kit uses managed credential
 2. **Add a login button**
 
    ```tsx title="components/Header.tsx"
-   import { PrivyLoginButton, usePrivy } from '@varity-labs/ui-kit';
+   import { LoginButton, useAuth } from '@varity-labs/ui-kit';
 
    export function Header() {
-     const { authenticated, logout } = usePrivy();
+     const { authenticated, logout } = useAuth();
 
      return (
        <header>
          {authenticated ? (
            <button onClick={logout}>Sign Out</button>
          ) : (
-           <PrivyLoginButton />
+           <LoginButton />
          )}
        </header>
      );
@@ -109,13 +109,13 @@ Just install the packages and start building. The UI Kit uses managed credential
 3. **Protect routes**
 
    ```tsx title="app/dashboard/page.tsx"
-   import { PrivyProtectedRoute } from '@varity-labs/ui-kit';
+   import { ProtectedRoute } from '@varity-labs/ui-kit';
 
    export default function DashboardPage() {
      return (
-       <PrivyProtectedRoute>
+       <ProtectedRoute>
          <Dashboard />
-       </PrivyProtectedRoute>
+       </ProtectedRoute>
      );
    }
    ```
@@ -127,7 +127,7 @@ Just install the packages and start building. The UI Kit uses managed credential
 ### Next.js (App Router)
 
 ```tsx title="app/layout.tsx"
-import { PrivyStack } from '@varity-labs/ui-kit';
+import { AuthProvider } from '@varity-labs/ui-kit';
 
 export default function RootLayout({
   children,
@@ -137,9 +137,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <PrivyStack appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID}>
+        <AuthProvider appId={process.env.NEXT_PUBLIC_VARITY_AUTH_APP_ID}>
           {children}
-        </PrivyStack>
+        </AuthProvider>
       </body>
     </html>
   );
@@ -151,14 +151,14 @@ export default function RootLayout({
 ```tsx title="src/main.tsx"
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { PrivyStack } from '@varity-labs/ui-kit';
+import { AuthProvider } from '@varity-labs/ui-kit';
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <PrivyStack appId={import.meta.env.VITE_PRIVY_APP_ID}>
+    <AuthProvider appId={import.meta.env.VITE_VARITY_AUTH_APP_ID}>
       <App />
-    </PrivyStack>
+    </AuthProvider>
   </React.StrictMode>
 );
 ```
@@ -168,7 +168,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
 ```tsx title="src/index.tsx"
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { PrivyStack } from '@varity-labs/ui-kit';
+import { AuthProvider } from '@varity-labs/ui-kit';
 import App from './App';
 
 const root = ReactDOM.createRoot(
@@ -177,21 +177,21 @@ const root = ReactDOM.createRoot(
 
 root.render(
   <React.StrictMode>
-    <PrivyStack appId={process.env.REACT_APP_PRIVY_APP_ID}>
+    <AuthProvider appId={process.env.REACT_APP_VARITY_AUTH_APP_ID}>
       <App />
-    </PrivyStack>
+    </AuthProvider>
   </React.StrictMode>
 );
 ```
 
 ## Configuration Options
 
-`PrivyStack` accepts these configuration options:
+`AuthProvider` accepts these configuration options:
 
 ```tsx
-<PrivyStack
+<AuthProvider
   // Optional (uses dev defaults if not set)
-  appId="your-privy-app-id"
+  appId="your-varity-auth-app-id"
 
   // Login methods to show
   loginMethods={['email', 'google', 'twitter', 'discord']}
@@ -207,7 +207,7 @@ root.render(
   onAddressChange={(address) => console.log('Address:', address)}
 >
   {children}
-</PrivyStack>
+</AuthProvider>
 ```
 
 ## TypeScript Support
@@ -216,8 +216,8 @@ The UI Kit is fully typed. Import types as needed:
 
 ```typescript
 import type {
-  PrivyStackProps,
-  PrivyLoginButtonProps,
+  AuthProviderProps,
+  LoginButtonProps,
   PaymentWidgetProps,
 } from '@varity-labs/ui-kit';
 ```

--- a/src/content/docs/packages/ui-kit/overview.mdx
+++ b/src/content/docs/packages/ui-kit/overview.mdx
@@ -34,14 +34,14 @@ npm install @varity-labs/ui-kit @varity-labs/sdk
 ```
 
 ```tsx
-import { PrivyStack, PrivyLoginButton } from '@varity-labs/ui-kit';
+import { AuthProvider, LoginButton } from '@varity-labs/ui-kit';
 
 function App() {
   return (
-    <PrivyStack>
-      <PrivyLoginButton />
+    <AuthProvider>
+      <LoginButton />
       <YourApp />
-    </PrivyStack>
+    </AuthProvider>
   );
 }
 ```
@@ -51,16 +51,16 @@ That's it. Users can now sign in with email or social accounts.
 ## Key Components
 
 <CardGrid>
-  <Card title="PrivyStack" icon="rocket">
+  <Card title="AuthProvider" icon="rocket">
     All-in-one provider that sets up authentication and account management. Wrap your app with this once.
   </Card>
-  <Card title="PrivyLoginButton" icon="user">
+  <Card title="LoginButton" icon="user">
     Pre-built login button that opens the authentication modal. Supports email, Google, Twitter, Discord, and more.
   </Card>
   <Card title="PaymentWidget" icon="document">
     Payment widget for in-app purchases and upgrades (post-beta).
   </Card>
-  <Card title="PrivyProtectedRoute" icon="approve-check">
+  <Card title="ProtectedRoute" icon="approve-check">
     Wrapper that shows content only to authenticated users. Shows login prompt otherwise.
   </Card>
 </CardGrid>
@@ -74,13 +74,13 @@ That's it. Users can now sign in with email or social accounts.
 5. User is authenticated and ready to use your app
 
 ```tsx
-import { usePrivy } from '@varity-labs/ui-kit';
+import { useAuth, LoginButton } from '@varity-labs/ui-kit';
 
 function Dashboard() {
-  const { authenticated, user, logout } = usePrivy();
+  const { authenticated, user, logout } = useAuth();
 
   if (!authenticated) {
-    return <PrivyLoginButton />;
+    return <LoginButton />;
   }
 
   return (
@@ -110,18 +110,18 @@ Users never see technical details or extra prompts unless you choose to show the
 
 | Export | Description |
 |--------|-------------|
-| `PrivyStack` | All-in-one provider (recommended) |
-| `VarityPrivyProvider` | Authentication provider with Wagmi |
+| `AuthProvider` | All-in-one provider (recommended) |
+| `AuthBaseProvider` | Lower-level authentication provider |
 | `VarityDashboardProvider` | Dashboard-specific provider setup |
 
 ### Components
 
 | Export | Description |
 |--------|-------------|
-| `PrivyLoginButton` | Login button with modal |
-| `PrivyUserProfile` | Display user info with logout |
-| `PrivyProtectedRoute` | Auth-gated content wrapper |
-| `PrivyReadyGate` | Loading state during initialization |
+| `LoginButton` | Login button with modal |
+| `UserProfile` | Display user info with logout |
+| `ProtectedRoute` | Auth-gated content wrapper |
+| `ReadyGate` | Loading state during initialization |
 | `PaymentWidget` | In-app payment widget (post-beta) |
 | `PaymentGate` | Subscription/tier gate (post-beta) |
 
@@ -129,7 +129,7 @@ Users never see technical details or extra prompts unless you choose to show the
 
 | Export | Description |
 |--------|-------------|
-| `usePrivy` | Core authentication hook (re-exported) |
+| `useAuth` | Core authentication hook |
 | `useLogin` | Trigger login programmatically |
 | `useLogout` | Trigger logout programmatically |
 
@@ -182,17 +182,17 @@ These exports provide lower-level access for advanced use cases. All are current
 
 ```tsx
 import {
-  PrivyStack,
-  PrivyLoginButton,
-  PrivyUserProfile,
-  PrivyProtectedRoute,
-  usePrivy,
+  AuthProvider,
+  LoginButton,
+  UserProfile,
+  ProtectedRoute,
+  useAuth,
 } from '@varity-labs/ui-kit';
 
 function App() {
   return (
-    <PrivyStack
-      appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID}
+    <AuthProvider
+      appId={process.env.NEXT_PUBLIC_VARITY_AUTH_APP_ID}
       loginMethods={['email', 'google']}
       appearance={{
         theme: 'light',
@@ -202,23 +202,23 @@ function App() {
     >
       <Layout>
         <Header />
-        <PrivyProtectedRoute>
+        <ProtectedRoute>
           <Dashboard />
-        </PrivyProtectedRoute>
+        </ProtectedRoute>
       </Layout>
-    </PrivyStack>
+    </AuthProvider>
   );
 }
 
 function Header() {
-  const { authenticated } = usePrivy();
+  const { authenticated } = useAuth();
 
   return (
     <header>
       {authenticated ? (
-        <PrivyUserProfile showLogoutButton />
+        <UserProfile showLogoutButton />
       ) : (
-        <PrivyLoginButton>Sign In</PrivyLoginButton>
+        <LoginButton>Sign In</LoginButton>
       )}
     </header>
   );

--- a/src/content/docs/resources/troubleshooting.mdx
+++ b/src/content/docs/resources/troubleshooting.mdx
@@ -101,12 +101,12 @@ Possible causes and solutions:
 
 ## Authentication Issues
 
-### "PrivyStack: appId is required"
+### "AuthProvider: appId is required"
 
 Set your Auth App ID in environment variables:
 
 ```bash title=".env.local"
-NEXT_PUBLIC_PRIVY_APP_ID=your_app_id
+NEXT_PUBLIC_VARITY_AUTH_APP_ID=your_app_id
 ```
 
 Or use Varity development credentials (the SDK will use defaults if none provided).
@@ -115,11 +115,11 @@ Or use Varity development credentials (the SDK will use defaults if none provide
 
 <Steps>
 
-1. Verify `PrivyStack` wraps your application:
+1. Verify `AuthProvider` wraps your application:
    ```tsx
-   <PrivyStack appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID}>
+   <AuthProvider appId={process.env.NEXT_PUBLIC_VARITY_AUTH_APP_ID}>
      <App />
-   </PrivyStack>
+   </AuthProvider>
    ```
 
 2. Check browser console for errors
@@ -139,7 +139,7 @@ Sessions are stored in localStorage. Private browsing or clearing storage will l
 </Aside>
 
 Check that:
-- `PrivyStack` is at the root of your app
+- `AuthProvider` is at the root of your app
 - You're not accidentally clearing localStorage
 - Cookies are enabled in the browser
 
@@ -228,7 +228,7 @@ Common causes:
 3. Verify you're using tree-shaking:
    ```typescript
    // Good - tree-shakeable
-   import { PrivyStack } from '@varity-labs/ui-kit';
+   import { AuthProvider } from '@varity-labs/ui-kit';
 
    // Avoid - imports entire package
    import * as VarityUI from '@varity-labs/ui-kit';

--- a/src/content/docs/templates/overview.mdx
+++ b/src/content/docs/templates/overview.mdx
@@ -47,7 +47,7 @@ This creates a new project directory with:
 
 | Feature | Template | Manual Setup |
 |---------|----------|-------------|
-| Auth | Pre-configured | Add `PrivyStack` yourself |
+| Auth | Pre-configured | Add `AuthProvider` yourself |
 | Database | Collections + hooks ready | Set up `db.collection()` yourself |
 | Dashboard | 5 pages with CRUD | Build from scratch |
 | Mobile nav | Included | Build from scratch |

--- a/src/content/docs/templates/saas-starter.mdx
+++ b/src/content/docs/templates/saas-starter.mdx
@@ -142,15 +142,15 @@ interface UseCollectionReturn<T> {
 
 ```tsx
 // Root layout sets up auth provider
-<PrivyStack appId={process.env.NEXT_PUBLIC_PRIVY_APP_ID}>
+<AuthProvider appId={process.env.NEXT_PUBLIC_VARITY_AUTH_APP_ID}>
   {children}
-</PrivyStack>
+</AuthProvider>
 
 // Dashboard layout protects all dashboard routes
-<PrivyProtectedRoute>{children}</PrivyProtectedRoute>
+<ProtectedRoute>{children}</ProtectedRoute>
 
 // Access user info in any component
-const { user, authenticated, logout } = usePrivy();
+const { user, authenticated, logout } = useAuth();
 ```
 
 ## Customization Guide
@@ -258,7 +258,7 @@ export default function AboutPage() {
 
 ```bash title=".env.example"
 # Auth (optional for development — shared creds used automatically)
-NEXT_PUBLIC_PRIVY_APP_ID=
+NEXT_PUBLIC_VARITY_AUTH_APP_ID=
 
 # Your app ID (assigned after first deploy)
 NEXT_PUBLIC_VARITY_APP_ID=


### PR DESCRIPTION
## Summary
- Replace `PrivyStack` → `AuthProvider`, `PrivyLoginButton` → `LoginButton`, `PrivyProtectedRoute` → `ProtectedRoute`, `PrivyUserProfile` → `UserProfile`, `usePrivy` → `useAuth` across 17 docs files
- Replace `NEXT_PUBLIC_PRIVY_APP_ID` → `NEXT_PUBLIC_VARITY_AUTH_APP_ID`, `VITE_PRIVY_APP_ID` → `VITE_VARITY_AUTH_APP_ID`
- Fixes RULE 4 violation: Privy vendor jargon was visible in public-facing developer documentation

## Files Changed
17 docs files including: ui-kit components/hooks/installation/overview, build/auth/*, getting-started/quickstart-react, templates, ai-tools/prompts, sdk/overview, sdk/api-reference, deploy/managed-credentials, resources/troubleshooting, component-showcase

## Test Plan
- [ ] Verify all code examples in docs use correct API names (`AuthProvider`, `LoginButton`, `useAuth`)
- [ ] Verify no `PrivyStack`, `usePrivy`, `NEXT_PUBLIC_PRIVY_APP_ID` references remain
- [ ] CDN rebuild will publish updated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code) — dogfood(regression): VAR-621