### PR TITLE
fix(docs): remove blockchain jargon from SDK overview, bump to beta.12 (VAR-689)

### DIFF
--- a/src/content/docs/packages/sdk/overview.mdx
+++ b/src/content/docs/packages/sdk/overview.mdx
@@ -10,13 +10,13 @@ import PageMeta from '../../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="March 2026"
+  lastUpdated="April 2026"
   stability="beta"
 />
 
 The Varity SDK provides the core building blocks for your application: a zero-config database, credential management, and infrastructure utilities. Install it once and start building immediately.
 
-<Badge text="v2.0.0-beta.11" variant="note" />
+<Badge text="v2.0.0-beta.12" variant="note" />
 
 ## What's Included
 
@@ -125,7 +125,7 @@ if (warning) {
 
 | Export | Type | Description |
 |--------|------|-------------|
-| `VERSION` | const (string) | SDK version (`'2.0.0-beta.11'`) |
+| `VERSION` | const (string) | SDK version (`'2.0.0-beta.12'`) |
 | `SDK_VERSION` | const (string) | Same as `VERSION` |
 
 ```typescript
@@ -183,18 +183,6 @@ const raw = parseUSDC('25.00'); // BigInt(25000000)
 const url = getVarityExplorerUrl('0xabc...');
 ```
 
-### Revenue & Licensing Services (`@varity-labs/sdk/blockchain`)
-
-Low-level services for app licensing and revenue splits.
-
-```typescript
-import {
-  BlockchainService,
-  NFTLicensingService,
-  RevenueSplitService,
-} from '@varity-labs/sdk/blockchain';
-```
-
 ### Gas Tracking (`@varity-labs/sdk/tracking`)
 
 Track gas usage, calculate costs in USDC, and manage billing cycles.
@@ -215,10 +203,10 @@ import {
 
 You may see references to a class-based SDK pattern (`createVaritySDK`, `sdk.connect()`, `sdk.storage`, `sdk.analytics`, etc.) in older code or documentation. This v1 API exists in the SDK source code but is **currently commented out** and not exported from the package.
 
-The current SDK (v2.0.0-beta.11) uses a modular approach:
+The current SDK (v2.0.0-beta.12) uses a modular approach:
 - **Database**: Use the `db` singleton or create a `Database` instance directly
 - **Credentials**: Use the standalone credential functions
-- **Infrastructure**: Use subpath imports (`/chains`, `/blockchain`, `/tracking`)
+- **Infrastructure**: Use subpath imports (`/chains`, `/tracking`)
 
 The class-based API may be re-enabled in a future release once the underlying infrastructure is fully set up.
 


### PR DESCRIPTION
## Summary

- Removes the `Blockchain Services` section (`BlockchainService`, `NFTLicensingService`, `RevenueSplitService`) from the SDK overview page — violates POSITIONING.md §5 (no blockchain/Web3 jargon in user-facing content)
- Updates version badge and Version table: `v2.0.0-beta.11` → `v2.0.0-beta.12`
- Updates `lastUpdated` metadata: March 2026 → April 2026
- Removes `/blockchain` from subpath imports list in the class-based API accordion (keeps it consistent after section removal)

## Source

Found during nightly drift scan [VAR-678]. Fixed via [VAR-689].

## Test plan

- [ ] Confirm `Blockchain Services` section no longer appears on docs.varity.so SDK overview page
- [ ] Confirm version badge shows `v2.0.0-beta.12`
- [ ] Confirm `lastUpdated` shows April 2026
- [ ] Confirm `Gas Tracking` and `Chains` sections still render correctly in the Advanced accordion
- [ ] No broken links or render errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)