### PR TITLE
docs(deploy): DNS quickstart drafts for 4 providers (VAR-763)

### DIFF
--- a/drafts/custom-domain-setup-cloudflare.md
+++ b/drafts/custom-domain-setup-cloudflare.md
@@ -1,0 +1,118 @@
+# Custom Domain Setup: Cloudflare
+
+Connect your domain (e.g. `app.yourcompany.com`) to your Varity deployment using Cloudflare's DNS management.
+
+> **Status:** Draft — for internal review. Publish when the custom domains feature ships.
+
+---
+
+## What You'll Need
+
+- A domain managed through Cloudflare (e.g. `yourcompany.com`)
+- A Varity account with at least one deployed app
+- Your app's gateway address from the Varity dashboard (e.g. `my-app.gateway.varity.app`)
+
+---
+
+## Step-by-Step: Add a CNAME Record
+
+### 1. Log in to Cloudflare
+
+Go to [dash.cloudflare.com](https://dash.cloudflare.com) and sign in.
+
+> **Screenshot placeholder:** Cloudflare login screen — dark background, orange "Log in" button, email + password fields.
+
+### 2. Select Your Domain
+
+On the **Home** screen, you'll see a list of your domains ("zones"). Click the domain you want to use (e.g. `yourcompany.com`).
+
+> **Screenshot placeholder:** Cloudflare home — list of domains as cards showing status indicators (Active, green checkmark) and plan type.
+
+### 3. Go to DNS Settings
+
+In the left sidebar, click **DNS** → **Records**.
+
+> **Screenshot placeholder:** Cloudflare sidebar — icons for Overview, Analytics, DNS, Email, Speed, Security, etc. DNS is selected, showing "Records" sub-item.
+
+### 4. Add a New CNAME Record
+
+Click **Add record** (blue button, top right of the records table).
+
+Fill in the fields:
+
+| Field | Value |
+|-------|-------|
+| **Type** | `CNAME` |
+| **Name** | `app` |
+| **Target** | `gateway.varity.app` |
+| **Proxy status** | DNS only (gray cloud) |
+| **TTL** | Auto |
+
+> **Important:** Set **Proxy status to "DNS only" (gray cloud icon)**, not "Proxied" (orange cloud). Varity provisions SSL automatically — Cloudflare proxying can interfere with certificate validation.
+
+> **Screenshot placeholder:** "Add record" form — dropdown showing "CNAME", Name field with "app", Target field with "gateway.varity.app", Proxy status toggle showing gray cloud (DNS only), TTL set to Auto.
+
+Click **Save**.
+
+### 5. Verify the Record Appears
+
+You should now see a row in the DNS records table:
+
+```
+Type    Name    Content                  Proxy status    TTL
+CNAME   app     gateway.varity.app       DNS only        Auto
+```
+
+> **Screenshot placeholder:** DNS records table with the new CNAME row highlighted. Gray cloud icon visible in the Proxy status column.
+
+### 6. Add Your Domain in Varity
+
+In your Varity dashboard:
+1. Go to your app's **Settings** tab
+2. Under **Custom Domain**, enter `app.yourcompany.com`
+3. Click **Add Domain**
+
+Varity will verify the DNS record and begin SSL provisioning.
+
+---
+
+## How Long Until It Works?
+
+Cloudflare DNS propagates within **1–5 minutes** for most zones. In rare cases it can take up to 30 minutes.
+
+To check propagation before Varity verifies: use [dnschecker.org](https://dnschecker.org) and search for `app.yourcompany.com` with record type `CNAME`.
+
+---
+
+## Common Errors & Fixes
+
+### "CNAME record conflicts with an existing record"
+
+You already have an A record or another CNAME for `app`. Delete the conflicting record first, then re-add the CNAME.
+
+**Fix:** In Cloudflare DNS → Records, find the conflicting row (look for `app` in the Name column), click **Edit** → **Delete**, then add your new CNAME.
+
+### "SSL certificate not issued after 10 minutes"
+
+If Varity is showing "Pending SSL" after propagation, check:
+- Proxy status is set to **gray cloud (DNS only)** — orange cloud (proxied) blocks Varity's validation
+- The CNAME target is exactly `gateway.varity.app` with no trailing dot or space
+
+### "I see a Cloudflare error page when I visit the domain"
+
+This usually means the record is proxied (orange cloud) and Cloudflare is blocking the connection. Switch proxy status to **DNS only** and wait 1–2 minutes.
+
+### "The domain works but shows a certificate warning"
+
+SSL can take up to 5 minutes to provision after DNS propagates. Wait and try again. If the warning persists after 15 minutes, re-check that Proxy status is set to DNS only.
+
+### "I set up the CNAME but Varity says it can't find the record"
+
+Wait 5 minutes and retry verification in the Varity dashboard. If still failing, confirm the record at [dnschecker.org](https://dnschecker.org).
+
+---
+
+## Related Docs
+
+- [Custom Domains overview](/deploy/custom-domains) — subdomain management for varity.app URLs
+- [Deployment Troubleshooting](/deploy/deployment-troubleshooting) — general deploy debugging

--- a/drafts/custom-domain-setup-godaddy.md
+++ b/drafts/custom-domain-setup-godaddy.md
@@ -1,0 +1,124 @@
+# Custom Domain Setup: GoDaddy
+
+Connect your domain (e.g. `app.yourcompany.com`) to your Varity deployment using GoDaddy's DNS management.
+
+> **Status:** Draft — for internal review. Publish when the custom domains feature ships.
+
+---
+
+## What You'll Need
+
+- A domain registered with GoDaddy (e.g. `yourcompany.com`)
+- A Varity account with at least one deployed app
+- Your app's gateway address from the Varity dashboard (e.g. `my-app.gateway.varity.app`)
+
+---
+
+## Step-by-Step: Add a CNAME Record
+
+### 1. Log in to GoDaddy
+
+Go to [godaddy.com](https://godaddy.com) and sign in to your account.
+
+> **Screenshot placeholder:** GoDaddy login page — white background, black GoDaddy logo, username and password fields, green "Sign In" button.
+
+### 2. Open Your Domain's DNS Settings
+
+1. In the top navigation, click your account name → **My Products**
+2. Find the domain you want to use and click **DNS** (or the three-dot menu → **Manage DNS**)
+
+> **Screenshot placeholder:** GoDaddy "My Products" page — list of domains with "DNS" button visible to the right of each row.
+
+### 3. Scroll to DNS Records
+
+You'll see the DNS Records section with existing records (usually an A record pointing to GoDaddy's parking page, MX records, etc.).
+
+> **Screenshot placeholder:** GoDaddy DNS management page — table of existing DNS records (Type, Name, Value, TTL columns), blue "Add" button at top.
+
+### 4. Add a New CNAME Record
+
+Click **Add** (blue button above the records table).
+
+A form will appear. Fill in:
+
+| Field | Value |
+|-------|-------|
+| **Type** | `CNAME` |
+| **Name** | `app` |
+| **Value** | `gateway.varity.app` |
+| **TTL** | 1 Hour (default) |
+
+> **Screenshot placeholder:** GoDaddy "Add Record" form — dropdown set to CNAME, Name field showing "app", Value field showing "gateway.varity.app", TTL showing "1 Hour".
+
+Click **Save** to confirm.
+
+### 5. Verify the Record Appears
+
+The new record should appear in the DNS Records table:
+
+```
+Type    Name    Value                    TTL
+CNAME   app     gateway.varity.app       1 Hour
+```
+
+> **Screenshot placeholder:** GoDaddy DNS Records table showing the new CNAME row.
+
+### 6. Add Your Domain in Varity
+
+In your Varity dashboard:
+1. Go to your app's **Settings** tab
+2. Under **Custom Domain**, enter `app.yourcompany.com`
+3. Click **Add Domain**
+
+Varity will verify the DNS record and begin SSL provisioning.
+
+---
+
+## How Long Until It Works?
+
+GoDaddy DNS typically propagates within **30 minutes to 2 hours**, though it can take up to 48 hours in rare cases.
+
+To check propagation: use [dnschecker.org](https://dnschecker.org) and search for `app.yourcompany.com` with record type `CNAME`. When most locations show `gateway.varity.app`, your DNS has propagated.
+
+---
+
+## Common Errors & Fixes
+
+### "I can't find the DNS section"
+
+GoDaddy's UI changes periodically. Try:
+- **My Products** → find your domain → click **DNS** button
+- Or go to **Domains** → **All Domains** → click your domain name → **DNS** tab
+
+### "CNAME record already exists for that name"
+
+You have an existing record at `app`. Delete it first:
+1. Find the row with Name `app` in the records table
+2. Click the pencil icon (Edit) or the trash icon (Delete)
+3. Confirm deletion, then add your new CNAME
+
+### "GoDaddy shows an error when I save the record"
+
+GoDaddy rejects CNAME records that conflict with MX or NS records. The subdomain `app` usually doesn't conflict — but if you get an error, check that no other record with the same name exists.
+
+### "SSL certificate not issued after 2 hours"
+
+If Varity's dashboard still shows "Pending SSL" after propagation:
+1. Confirm the CNAME value is exactly `gateway.varity.app` (no trailing dot or spaces)
+2. Use [dnschecker.org](https://dnschecker.org) to verify global propagation
+3. Re-trigger verification in the Varity dashboard
+
+### "The domain resolves but shows an SSL warning"
+
+Wait up to 5 minutes after DNS propagates for Varity to provision your SSL certificate. If the warning persists beyond 15 minutes, check the CNAME value is correct and retry verification.
+
+### "I deleted a record accidentally"
+
+GoDaddy does not have a built-in DNS change history view. Re-add the correct record manually. If you deleted an important record (like MX for email), contact GoDaddy support to restore it from their backups.
+
+---
+
+## Related Docs
+
+- [Custom Domains overview](/deploy/custom-domains) — subdomain management for varity.app URLs
+- [Deployment Troubleshooting](/deploy/deployment-troubleshooting) — general deploy debugging

--- a/drafts/custom-domain-setup-google-domains.md
+++ b/drafts/custom-domain-setup-google-domains.md
@@ -1,0 +1,157 @@
+# Custom Domain Setup: Google Domains / Squarespace Domains
+
+Connect your domain (e.g. `app.yourcompany.com`) to your Varity deployment using Google Domains or Squarespace Domains DNS management.
+
+> **Status:** Draft — for internal review. Publish when the custom domains feature ships.
+
+---
+
+> **Note on the Google → Squarespace transition:** Google sold Google Domains to Squarespace in 2023. Most domains were migrated to Squarespace Domains by mid-2024. If you purchased your domain on Google Domains, you're likely now managing it at [domains.squarespace.com](https://domains.squarespace.com). The DNS steps are nearly identical — both interfaces are covered below.
+
+---
+
+## What You'll Need
+
+- A domain managed through Google Domains or Squarespace Domains (e.g. `yourcompany.com`)
+- A Varity account with at least one deployed app
+- Your app's gateway address from the Varity dashboard (e.g. `my-app.gateway.varity.app`)
+
+---
+
+## Option A: Squarespace Domains (current interface)
+
+Most Google Domains users now manage their domains here.
+
+### 1. Log in to Squarespace Domains
+
+Go to [domains.squarespace.com](https://domains.squarespace.com) and sign in with your Google account or Squarespace credentials.
+
+> **Screenshot placeholder:** Squarespace Domains login — white background, Squarespace logo, "Continue with Google" button (prominent) + email/password option below.
+
+### 2. Open Your Domain
+
+On the **Domains** dashboard, click the domain you want to use.
+
+> **Screenshot placeholder:** Squarespace Domains dashboard — list of domains as rows with domain name, status ("Active"), and "Manage" link.
+
+### 3. Go to DNS Settings
+
+In the left sidebar (or under the domain details), click **DNS** → **DNS Settings** (or **Custom Records**).
+
+> **Screenshot placeholder:** Domain details page — sidebar with tabs: Overview, DNS, Email, Security, Advanced. DNS tab selected, showing DNS settings page.
+
+### 4. Add a CNAME Record
+
+Scroll to the **Custom Records** section. Click **Add Record** (or **+ Add custom record**).
+
+Fill in the fields:
+
+| Field | Value |
+|-------|-------|
+| **Type** | `CNAME` |
+| **Host name** | `app` |
+| **Data** | `gateway.varity.app` |
+| **TTL** | 3600 (1 hour, or leave default) |
+
+> **Screenshot placeholder:** "Add Record" form — Type dropdown showing CNAME, Host name field with "app", Data field with "gateway.varity.app", TTL showing 3600.
+
+Click **Save**.
+
+### 5. Verify the Record
+
+The record should appear in the Custom Records table:
+
+```
+Type    Host name    Data                     TTL
+CNAME   app          gateway.varity.app       3600
+```
+
+---
+
+## Option B: Original Google Domains Interface
+
+If you still have access to the legacy Google Domains interface at [domains.google](https://domains.google):
+
+### 1. Sign In
+
+Go to [domains.google](https://domains.google) and sign in with your Google account.
+
+> **Screenshot placeholder:** Google Domains — Google-branded design, domain list showing your registered domains with status badges.
+
+### 2. Open DNS for Your Domain
+
+Click the domain name, then select **DNS** from the left sidebar.
+
+### 3. Add a Custom Record
+
+Scroll to **Custom records** and click **Manage custom records** → **Create new record**.
+
+| Field | Value |
+|-------|-------|
+| **Host name** | `app` |
+| **Type** | `CNAME` |
+| **TTL** | 3600 |
+| **Data** | `gateway.varity.app` |
+
+Click **Save**.
+
+---
+
+## Add Your Domain in Varity
+
+After saving the DNS record (either interface):
+
+1. Go to your app's **Settings** tab in the Varity dashboard
+2. Under **Custom Domain**, enter `app.yourcompany.com`
+3. Click **Add Domain**
+
+Varity will verify the DNS record and begin SSL provisioning.
+
+---
+
+## How Long Until It Works?
+
+Google Domains / Squarespace Domains DNS typically propagates within **1–2 hours**, though it can take up to 48 hours in rare cases.
+
+To check propagation: use [dnschecker.org](https://dnschecker.org) and search for `app.yourcompany.com` with record type `CNAME`. When most locations show `gateway.varity.app`, your DNS has propagated.
+
+---
+
+## Common Errors & Fixes
+
+### "I can't log in with my Google account on Squarespace Domains"
+
+If the Google account you used for Google Domains isn't recognized:
+1. Try signing in with just the email + password at [domains.squarespace.com](https://domains.squarespace.com)
+2. If you never set a Squarespace password, use **Forgot password** with your Google email
+3. If you still can't access it, contact Squarespace support — domain migration issues are common
+
+### "I don't see my domain on Squarespace Domains"
+
+Your domain may not have been migrated yet, or the migration may have been rejected. Try logging into [domains.google](https://domains.google) first. If your domain still exists there, manage DNS from the Google Domains interface using Option B above.
+
+### "There's already a CNAME or A record for 'app'"
+
+Delete the conflicting record before adding yours. In the Custom Records section, find the row with Host name `app` and click the trash icon (delete). Then add your new CNAME.
+
+### "SSL certificate not issued after 2 hours"
+
+If Varity's dashboard still shows "Pending SSL" after propagation:
+1. Confirm the Data field is exactly `gateway.varity.app` (no trailing dot or spaces)
+2. Use [dnschecker.org](https://dnschecker.org) to verify global propagation
+3. Re-trigger verification in the Varity dashboard
+
+### "The domain resolves but shows an SSL warning"
+
+Wait up to 5 minutes after DNS propagates for Varity to provision your SSL certificate. If the warning persists beyond 15 minutes, re-check that the CNAME value is correct and retry verification.
+
+### "My email stopped working after I added the DNS record"
+
+Adding a CNAME for `app` should not affect email (which uses MX records on the root domain `@`). If email is broken, check that you didn't accidentally edit or delete an MX or TXT (SPF/DKIM) record. Review the DNS records list and restore any missing mail records.
+
+---
+
+## Related Docs
+
+- [Custom Domains overview](/deploy/custom-domains) — subdomain management for varity.app URLs
+- [Deployment Troubleshooting](/deploy/deployment-troubleshooting) — general deploy debugging

--- a/drafts/custom-domain-setup-namecheap.md
+++ b/drafts/custom-domain-setup-namecheap.md
@@ -1,0 +1,121 @@
+# Custom Domain Setup: Namecheap
+
+Connect your domain (e.g. `app.yourcompany.com`) to your Varity deployment using Namecheap's DNS management.
+
+> **Status:** Draft — for internal review. Publish when the custom domains feature ships.
+
+---
+
+## What You'll Need
+
+- A domain registered with Namecheap (e.g. `yourcompany.com`)
+- A Varity account with at least one deployed app
+- Your app's gateway address from the Varity dashboard (e.g. `my-app.gateway.varity.app`)
+
+---
+
+## Step-by-Step: Add a CNAME Record
+
+### 1. Log in to Namecheap
+
+Go to [namecheap.com](https://namecheap.com) and sign in.
+
+> **Screenshot placeholder:** Namecheap login page — orange and white design, username and password fields, orange "Sign In" button.
+
+### 2. Open Your Domain's DNS Settings
+
+1. In the top navigation, click **Account** → **Domain List**
+2. Find the domain you want to use and click **Manage**
+
+> **Screenshot placeholder:** Namecheap Domain List — table of domains, each with Type, Expires, Nameservers columns, and "Manage" button on the right.
+
+### 3. Go to Advanced DNS
+
+On the domain management page, click the **Advanced DNS** tab.
+
+> **Screenshot placeholder:** Domain management page with tabs: Domain, Nameservers, Advanced DNS, Transfer, Private Email. Advanced DNS tab selected, showing existing DNS records in a table.
+
+### 4. Add a New CNAME Record
+
+Under the **Host Records** section, click **Add New Record**.
+
+A new row will appear at the bottom of the table. Fill in:
+
+| Field | Value |
+|-------|-------|
+| **Type** | `CNAME Record` |
+| **Host** | `app` |
+| **Value** | `gateway.varity.app` |
+| **TTL** | Automatic |
+
+> **Screenshot placeholder:** New record row in the Host Records table — dropdown showing "CNAME Record", Host field with "app", Value field with "gateway.varity.app", TTL set to Automatic. Green checkmark button to save visible on the right.
+
+Click the **green checkmark** to save the record.
+
+### 5. Verify the Record Appears
+
+The saved CNAME record should appear in the Host Records table:
+
+```
+Type            Host    Value                    TTL
+CNAME Record    app     gateway.varity.app       Automatic
+```
+
+> **Screenshot placeholder:** Host Records table with the new CNAME row saved. Green checkmark replaced by pencil (edit) and red X (delete) icons.
+
+### 6. Add Your Domain in Varity
+
+In your Varity dashboard:
+1. Go to your app's **Settings** tab
+2. Under **Custom Domain**, enter `app.yourcompany.com`
+3. Click **Add Domain**
+
+Varity will verify the DNS record and begin SSL provisioning.
+
+---
+
+## How Long Until It Works?
+
+Namecheap DNS typically propagates within **15–30 minutes** for most records, though it can take up to 48 hours in rare cases.
+
+To check propagation: use [dnschecker.org](https://dnschecker.org) and search for `app.yourcompany.com` with record type `CNAME`. When most locations show `gateway.varity.app`, your DNS has propagated.
+
+---
+
+## Common Errors & Fixes
+
+### "I see Namecheap's parking page instead of my app"
+
+Namecheap's parking page is served from an A record that may override your CNAME. In the Host Records table, look for an `A Record` with Host `@` pointing to Namecheap's IP — this is for your apex domain and won't affect the `app` subdomain. If you see an `A Record` with Host `app`, delete it before saving your CNAME.
+
+### "CNAME record value is being rejected"
+
+Namecheap sometimes requires a trailing dot on CNAME values in its backend, but the UI strips it automatically. Enter the value without a trailing dot: `gateway.varity.app`. If the field shows an error, try adding the trailing dot: `gateway.varity.app.`
+
+### "I can't see the Advanced DNS tab"
+
+The Advanced DNS tab only appears when the domain uses Namecheap's BasicDNS or PremiumDNS nameservers. If your domain uses custom nameservers (e.g. Cloudflare's `ns1.cloudflare.com`), you'll need to manage DNS at that registrar instead.
+
+Check your nameservers on the **Domain** tab → **Nameservers** section.
+
+### "SSL certificate not issued after 1 hour"
+
+If Varity's dashboard still shows "Pending SSL" after propagation:
+1. Confirm the CNAME value is exactly `gateway.varity.app` (no trailing dot or spaces)
+2. Use [dnschecker.org](https://dnschecker.org) to verify global propagation
+3. Re-trigger verification in the Varity dashboard
+
+### "The domain resolves but shows an SSL warning"
+
+Wait up to 5 minutes after DNS propagates for Varity to provision your SSL certificate. If the warning persists beyond 15 minutes, re-check that the CNAME value is correct and retry verification.
+
+### "I accidentally deleted a record"
+
+Namecheap does not provide a self-serve DNS history view. Re-add the correct record manually. If you deleted important email records (MX), contact Namecheap support or re-add them from your email provider's setup guide.
+
+---
+
+## Related Docs
+
+- [Custom Domains overview](/deploy/custom-domains) — subdomain management for varity.app URLs
+- [Deployment Troubleshooting](/deploy/deployment-troubleshooting) — general deploy debugging


### PR DESCRIPTION
## Summary
- Adds 4 draft DNS quickstart guides to `drafts/` (Cloudflare, GoDaddy, Namecheap, Google Domains/Squarespace Domains)
- Each guide covers: step-by-step CNAME setup pointing `app.yourcompany.com` → `gateway.varity.app`, screenshot placeholders, common errors/troubleshooting, propagation timing
- **Do not merge until custom-domains feature ships** — founder reviews first per issue spec

## Rationale
Non-technical beta users will need copy-paste DNS guides when the custom domains feature ships (P0 in phase-2-post-beta). Writing the drafts now means they're ready to publish the moment the feature goes live.

## Alternatives considered
- Single multi-provider page: rejected — users search by their specific registrar; separate pages are more discoverable
- MDX format: rejected — these are drafts for review, not live docs pages; plain `.md` keeps them out of the Astro build

## Expected outcome
Four ready-to-publish guides that reduce support tickets when custom domains ships. No sidebar changes needed until merge to main.

## Rollback plan
`git revert 161418b` — removes 4 draft files, no other changes

## Sandbox test results
- Rule 4 jargon check: clean (no blockchain/Web3 terms)
- Files placed in `drafts/` per issue spec — not registered in `astro.config.mjs`, not built
- Commit: `161418b`

## Risk classification
L1 — content drafts, branch-only, no code changes, no sidebar wiring

## Agent notes
Tested against World Model regression patterns: yes (no prior DNS guide work found; no conflicts with other agents in last 4h).
Follows shared rules: 0, 1, 2, 4, 5, 6, 7, 8.

Agent: Docs Sync (Paperclip) — ticket VAR-763