### PR TITLE
fix(docs): D1 cost claim sweep — drop vs-AWS, compare vs Vercel/Render/Railway

### DIFF
--- a/src/content/docs/cli/commands/deploy.mdx
+++ b/src/content/docs/cli/commands/deploy.mdx
@@ -61,7 +61,7 @@ varitykit app deploy --hosting dynamic
 **Features:**
 - Container hosting
 - Persistent storage
-- 60-80% cheaper than AWS
+- 60-80% cheaper than Vercel/Render/Railway
 
 <Aside type="tip">
 Dynamic hosting is powered by cloud compute. Use `--hosting dynamic` for server-side frameworks (Next.js API routes, Express, etc.). Static hosting remains the default.

--- a/src/content/docs/deploy/intelligent-orchestration.mdx
+++ b/src/content/docs/deploy/intelligent-orchestration.mdx
@@ -125,7 +125,7 @@ Every Varity app gets these services configured automatically - no setup require
 
 ## Why Varity Is 60-80% Cheaper
 
-Varity makes the same apps cost **60-80% less** than AWS, Vercel, or Heroku.
+Varity makes the same apps cost **60-80% less** than Vercel, Render, or Railway.
 
 ### The Varity Advantage
 
@@ -137,7 +137,7 @@ Varity makes the same apps cost **60-80% less** than AWS, Vercel, or Heroku.
 ### Real-World Cost Comparison
 
 <Aside type="tip" title="Typical SaaS App (5,000 users)">
-**Traditional Platforms (AWS/Vercel):** $2,800/month
+**Traditional Platforms (Vercel/Render/Railway):** $2,800/month
 - Compute: $500/mo
 - Database: $800/mo
 - CDN/Storage: $300/mo

--- a/src/content/docs/getting-started/how-varity-works.mdx
+++ b/src/content/docs/getting-started/how-varity-works.mdx
@@ -13,7 +13,7 @@ import PageMeta from '../../../components/PageMeta.astro';
   stability="beta"
 />
 
-Varity deploys any app, AI agent, or LLM in under 60 seconds, 60-80% cheaper than AWS. You do not need Docker, infrastructure knowledge, or DevOps experience.
+Varity deploys any app, AI agent, or LLM in under 60 seconds, 60-80% cheaper than Vercel/Render/Railway. You do not need Docker, infrastructure knowledge, or DevOps experience.
 
 ## Who Varity is for
 

--- a/src/content/docs/getting-started/introduction.mdx
+++ b/src/content/docs/getting-started/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: Varity is the easiest way to deploy any app, AI agent, or LLM. 60-80% cheaper than AWS, with zero infrastructure to manage.
+description: Varity is the easiest way to deploy any app, AI agent, or LLM. 60-80% cheaper than Vercel/Render/Railway, with zero infrastructure to manage.
 ---
 
 import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
@@ -14,7 +14,7 @@ import PageMeta from '../../../components/PageMeta.astro';
   stability="beta"
 />
 
-Varity is the easiest way to deploy any app, AI agent, or LLM. Point it at your project, and your app is live in under 60 seconds, 60-80% cheaper than AWS.
+Varity is the easiest way to deploy any app, AI agent, or LLM. Point it at your project, and your app is live in under 60 seconds, 60-80% cheaper than Vercel/Render/Railway.
 
 No Docker. No infrastructure setup. No DevOps.
 

--- a/src/content/docs/getting-started/why-varity.mdx
+++ b/src/content/docs/getting-started/why-varity.mdx
@@ -13,7 +13,7 @@ import PageMeta from '../../../components/PageMeta.astro';
   stability="stable"
 />
 
-Deploy any app in 60 seconds. 60-80% cheaper than AWS. No DevOps required.
+Deploy any app in 60 seconds. 60-80% cheaper than Vercel/Render/Railway. No DevOps required.
 
 ## The problem with traditional hosting
 
@@ -40,7 +40,7 @@ varitykit app deploy
 
 Your app is live in under 2 minutes, with auth, database, and hosting already configured.
 
-### 60-80% cheaper than AWS
+### 60-80% cheaper than Vercel/Render/Railway
 
 Varity uses efficient distributed infrastructure that passes savings directly to developers. The same app that costs thousands per month on AWS costs a fraction on Varity.
 
@@ -75,7 +75,7 @@ That is it. The MCP handles installation, building, and deploying. See [MCP Serv
 
 | | AWS | Vercel | Varity |
 |---|---|---|---|
-| **Cost** | High (add up services yourself) | Mid (front-end focused) | 60-80% less than AWS |
+| **Cost** | High (add up services yourself) | Mid (front-end focused) | 60-80% less than Vercel/Render/Railway |
 | **Full-stack apps** | Yes (complex setup) | Limited (front-end focus) | Yes (auto-configured) |
 | **Auth included** | No | No | Yes |
 | **Database included** | No | No | Auto-provisioned |

--- a/src/content/docs/guides/deploy-nextjs.mdx
+++ b/src/content/docs/guides/deploy-nextjs.mdx
@@ -19,7 +19,7 @@ Deploy a production Next.js app with authentication, a database, and a live URL 
   <Card title="Zero configuration" icon="rocket">
     Varity detects your framework, wires your database, and deploys. You run one command.
   </Card>
-  <Card title="60-80% cheaper than AWS" icon="seti:money">
+  <Card title="60-80% cheaper than Vercel/Render/Railway" icon="seti:money">
     Pay only for what you use. No idle server costs. No DevOps overhead.
   </Card>
 </CardGrid>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Varity Documentation
-description: Deploy any app, AI agent, or LLM in 60 seconds. 60-80% cheaper than AWS. Auth, database, and hosting included automatically.
+description: Deploy any app, AI agent, or LLM in 60 seconds. 60-80% cheaper than Vercel/Render/Railway. Auth, database, and hosting included automatically.
 template: splash
 hero:
-  tagline: "Deploy any app, AI agent, or LLM in 60 seconds. 60-80% cheaper than AWS."
+  tagline: "Deploy any app, AI agent, or LLM in 60 seconds. 60-80% cheaper than Vercel/Render/Railway."
   image:
     file: ../../assets/varity-logo.svg
   actions:
@@ -79,7 +79,7 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
   <Card title="One-command deploy" icon="rocket">
     Run `varitykit app deploy` and your app is live. No servers to configure. No Docker. No CI/CD pipelines.
   </Card>
-  <Card title="60-80% cheaper than AWS" icon="seti:dollar">
+  <Card title="60-80% cheaper than Vercel/Render/Railway" icon="seti:dollar">
     Efficient distributed infrastructure passes savings directly to you. Use the [cost calculator](/resources/pricing) to estimate your app.
   </Card>
   <Card title="Zero configuration" icon="puzzle">

--- a/src/content/docs/resources/faq.mdx
+++ b/src/content/docs/resources/faq.mdx
@@ -22,9 +22,9 @@ Varity is an application deployment platform that provides:
 - **Secure hosting** - Your app runs on distributed infrastructure
 - **Built-in authentication** - Email, Google, Twitter login out of the box
 - **Zero usage fees** - Users never pay operational fees
-- **60-80% cost savings** compared to AWS and traditional cloud
+- **60-80% cost savings** compared to Vercel, Render, and Railway
 
-### How is Varity different from AWS/Vercel/Netlify?
+### How is Varity different from Vercel/Render/Railway?
 
 | Feature | Traditional Cloud | Varity |
 |---------|------------------|--------|
@@ -125,7 +125,7 @@ For specific numbers based on your app, use the [cost calculator](https://www.va
 
 Vercel charges $20/seat/month plus overage fees for bandwidth, function invocations, and build minutes. Varity uses a different infrastructure model that passes lower compute costs to you directly. No seat fees, no per-function charges, bandwidth included up to a generous default.
 
-For most apps, Varity is **60-80% cheaper than AWS** and **70-80% cheaper than Vercel**.
+For most apps, Varity is **60-80% cheaper than Vercel/Render/Railway** and **70-80% cheaper than Vercel/Render/Railway**.
 
 ### Is there a contract or commitment?
 

--- a/src/content/docs/resources/pricing.mdx
+++ b/src/content/docs/resources/pricing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pricing and Costs
-description: Varity is usage-based with no monthly fees or tiers. Pay only for what you use. 60-80% cheaper than AWS.
+description: Varity is usage-based with no monthly fees or tiers. Pay only for what you use. 60-80% cheaper than Vercel/Render/Railway.
 ---
 
 import { Aside, Card, CardGrid } from '@astrojs/starlight/components';

--- a/src/content/docs/tutorials/build-with-ai.mdx
+++ b/src/content/docs/tutorials/build-with-ai.mdx
@@ -16,7 +16,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 This tutorial shows you how to build and deploy a production-ready SaaS app using only natural language prompts. No coding knowledge required. You'll use Varity's MCP server in Cursor or Claude Code to handle everything from scaffolding to deployment to monetization.
 
 <Aside type="tip">
-The entire workflow takes 10-15 minutes and costs 60-80% less than AWS.
+The entire workflow takes 10-15 minutes and costs 60-80% less than Vercel/Render/Railway.
 </Aside>
 
 ## What You'll Build
@@ -236,7 +236,7 @@ That's it. No cloud provider accounts, no credit card, no complex setup.
 
     Prompt:
 
-    > "How much would this cost to host for 500 users on Varity vs AWS?"
+    > "How much would this cost to host for 500 users on Varity vs Vercel?"
 
     **What happens:** The AI runs `varity_cost_calculator` to show cost breakdown.
 
@@ -252,7 +252,7 @@ That's it. No cloud provider accounts, no credit card, no complex setup.
 
     Varity:
       - All-in-one: $75/month
-      - Savings: $175/month (70% cheaper)
+      - Savings: $175/month (~70% cheaper)
 
     Revenue (500 users × $29/mo):
       - Gross: $14,500/month
@@ -274,7 +274,7 @@ Here is what you accomplished, without writing any code:
 5. ✅ **Set up revenue stream**: 90% of subscription revenue goes to you
 
 **Total time:** 10-15 minutes  
-**Total cost:** 70% less than AWS/Vercel  
+**Total cost:** 70% less than Vercel/Render/Railway  
 **Code written:** 0 lines
 
 ## Next Steps
@@ -316,7 +316,7 @@ When you prompt the AI, here's what Varity does:
 | "Deploy" | `varity_deploy` | Uploads to CDN, injects prod credentials |
 | "Submit to store" | `varity_submit_to_store` | Lists app, sets up billing |
 | "Show status" | `varity_deploy_status` | Fetches deployment info |
-| "Compare costs" | `varity_cost_calculator` | Calculates Varity vs AWS/Vercel |
+| "Compare costs" | `varity_cost_calculator` | Calculates Varity vs Vercel/Render/Railway |
 
 Every tool runs locally or via Varity's infrastructure. No manual configuration needed.
 


### PR DESCRIPTION
## Summary

D1 cost claim sweep across the docs site. Drops "60-80% cheaper than AWS" (12 occurrences across 10 files) in favor of the canonical positioning: **"60-80% cheaper than Vercel/Render/Railway"**.

### Why

POSITIONING.md + the pricing calculator already compare vs Vercel/Render/Railway. The docs were anchored to AWS, creating a positioning contradiction. D1 decision 2026-05-20: drop AWS, align with calculator + manifest.

### Files changed (10)

- `index.mdx`, `cli/commands/deploy.mdx`, `getting-started/{introduction,why-varity,how-varity-works}.mdx`
- `guides/deploy-nextjs.mdx`, `deploy/intelligent-orchestration.mdx`
- `resources/{faq,pricing}.mdx`, `tutorials/build-with-ai.mdx`

### Verification

```bash
grep -rnE "cheaper than AWS|than AWS|vs AWS|AWS/Vercel" --include="*.mdx" src/content/docs/
# → 0 hits ✅
```

### Out-of-scope (post-launch follow-up)

- App Store references in quickstarts/templates/prompts — App Store is dormant (`sdk_pre_investment`); main `deploy/app-store.mdx` already has the "Not active for beta" banner.
- 4everland rebuild + redeploy of the live `docs.varity.so` site (founder action; 4everland is currently out of build credits per CLAUDE.md).

### Do NOT merge

Launch-day PR. Founder reviews locally before merge. Auto-merger is launch-frozen for this repo until 2026-05-21 06:00 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)