### PR TITLE
docs(deploy): align supported-frameworks page to project_detector.py (VAR-1831)

### DIFF
--- a/src/content/docs/deploy/supported-frameworks.mdx
+++ b/src/content/docs/deploy/supported-frameworks.mdx
@@ -168,16 +168,17 @@ The following languages and frameworks are not supported in the current beta. De
 | Ruby / Rails | Not supported |
 | Elixir / Phoenix | Not supported |
 | Java / Spring | Not supported |
+| Kotlin | Not supported |
 | Deno | Not supported |
 | PHP / Laravel | Not supported |
-| .NET | Not supported |
+| C# / .NET | Not supported |
 
 If your framework is in this list, `varitykit app deploy` will return an error like:
 
 ```
-ProjectDetectionError: Framework not supported.
-Supported: Next.js, Astro, React, Vue, Qwik/QwikCity, Express, Fastify, Nest.js, Koa, Hono, plain Node.js, FastAPI, Django, Flask.
-To request support: https://github.com/varity-labs
+ProjectDetectionError: Found go.mod - Go deployments are not yet supported.
+Varity currently supports: Next.js, Astro, React, Vue, Node.js (Express/Fastify/NestJS/Koa/Hono), Python (FastAPI/Django/Flask).
+Request Go support at https://github.com/varity-labs/varity/issues/new?title=Support+Go
 ```
 
 No deployment is started and no charges are incurred.
@@ -203,9 +204,7 @@ When you run `varitykit app deploy`, Varity scans your project directory for the
 | `package.json` with `@nestjs/core` | Nest.js |
 | `package.json` with `koa` | Koa |
 | `package.json` with `hono` | Hono |
-| `requirements.txt` with `fastapi` | FastAPI |
-| `requirements.txt` with `django` | Django |
-| `requirements.txt` with `flask` | Flask |
+| `requirements.txt` or `pyproject.toml` | Python project |
 | `package.json` with `scripts.start` and no known framework | Node.js |
 
 Detection happens in under a second and requires no configuration from you.


### PR DESCRIPTION
## Summary
- Audit `/deploy/supported-frameworks` against `varitykit/core/project_detector.py` and `varity.manifest.yaml`.
- Correct Python detection row to match actual detector behavior (`requirements.txt` or `pyproject.toml` => Python project).
- Add missing unsupported marker coverage (`Kotlin`, `C# / .NET`) and replace generic unsupported error example with the real marker-specific style and support-request URL pattern.

## Rationale
The docs claimed framework-specific Python parsing from `requirements.txt` values and used a generic unsupported error/link that did not match runtime behavior. This drift creates false expectations in launch-critical docs.

## Alternatives considered
- Leave existing framework-specific Python rows and add a caveat. Rejected because detector does not parse FastAPI/Django/Flask packages at detection time.

## Expected outcome
- `/deploy/supported-frameworks` makes only claims that match current runtime detection behavior.

## Rollback plan
- `git revert 07e62b0`
- Impact: restores prior copy (including inaccurate detection details).

## Sandbox test results
- [x] `pnpm approve-builds --all && pnpm build` passes locally in `varity-docs`.
- Key evidence: Astro build completed; `/deploy/supported-frameworks/index.html` generated successfully.

## Risk classification
- `{\"layer\":\"L2\",\"rationale\":[\"no glob or content pattern matched → DEFAULT\"],\"confidence\":0.5,\"escalation_recommended\":false}`

## Hypothesis
- metric: wm-fresh:DocAccuracyAudit:7
- baseline: prior audit for this area had none in this run context
- expected: a fresh, source-cited DocAccuracyAudit exists; supported-framework discrepancies are fixed via this PR
- measure_after: 24h

## Agent notes
- World Model queries run first per RULE 6 (`find_failure_patterns`, `recent_activity`, `find_related_work`, `my_budget`, LaunchFreeze/PositioningPolicy checks).
- Wrote `DocAccuracyAudit` entity: `doc-audit-supported-frameworks-2026-05-21` (latest WM version id: 106047).

Agent: docs-sync (Paperclip) — ticket VAR-1831