### PR TITLE
docs: pipx install + MCP @beta + ignore dev scratch (launch cleanup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,12 @@ coverage/
 
 # TypeScript
 *.tsbuildinfo
+
+# Local dev / agent scratch — not for the public docs repo
+.playwright-mcp/
+drafts/
+CLAUDE.md
+
+# npm is canonical (package-lock.json) — ignore stray pnpm artifacts
+pnpm-lock.yaml
+pnpm-workspace.yaml

--- a/src/content/docs/ai-tools/prompts.mdx
+++ b/src/content/docs/ai-tools/prompts.mdx
@@ -12,7 +12,7 @@ You only need to connect the Varity MCP once. After that, just ask.
 Claude Code:
 
 ```bash
-claude mcp add varity -- npx -y @varity-labs/mcp
+claude mcp add varity -- npx -y @varity-labs/mcp@beta
 ```
 
 Cursor (`.cursor/mcp.json`):
@@ -22,7 +22,7 @@ Cursor (`.cursor/mcp.json`):
   "mcpServers": {
     "varity": {
       "command": "npx",
-      "args": ["-y", "@varity-labs/mcp"]
+      "args": ["-y", "@varity-labs/mcp@beta"]
     }
   }
 }

--- a/src/content/docs/cli/installation.mdx
+++ b/src/content/docs/cli/installation.mdx
@@ -25,7 +25,7 @@ Get the VarityKit CLI installed on your system.
   </TabItem>
   <TabItem label="pip">
     ```bash
-    pip install varitykit
+    pipx install varitykit
     ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary
Launch-cleanup of uncommitted working-tree changes (deep-dived + founder-confirmed):
- `installation.mdx`: `pip install` → `pipx install varitykit` (canonical install).
- `prompts.mdx`: `@varity-labs/mcp` → `@varity-labs/mcp@beta` (MCP is beta-tagged on npm).
- `.gitignore`: stop committing dev/agent scratch to this public repo (`.playwright-mcp/`, `drafts/`, `CLAUDE.md`) + stray pnpm lockfiles (**npm is canonical** via `package-lock.json` + Dependabot).

## Risk
L1 — docs content + repo hygiene; no code.

## Rollback
`git revert` / `gh pr close`.