### PR TITLE
docs(getting-started): align pricing + capability wording with canonical truth (VAR-1832)

### DIFF
--- a/src/content/docs/getting-started/how-varity-works.mdx
+++ b/src/content/docs/getting-started/how-varity-works.mdx
@@ -91,7 +91,7 @@ Here is how you go from idea to a live URL:
 
 When you deploy, Varity inspects your project and makes all infrastructure decisions:
 
-**Framework detection:** Varity reads your `package.json` or `requirements.txt` to identify your framework (Next.js, React, Vue, FastAPI, Django, etc.) and selects the right build process.
+**Framework detection:** Varity reads your `package.json`, `requirements.txt`, or `pyproject.toml` to identify your framework (Next.js, React, Vue, FastAPI, Django, etc.) and selects the right build process.
 
 **Static vs. dynamic hosting:** Projects with a server or backend run in containers. Static sites (React, Vue, Next.js with export mode) go to a global CDN. You can override this with `--hosting dynamic` or `--hosting static` if needed.
 
@@ -112,7 +112,7 @@ You do not write connection strings or provision databases. Varity handles it.
 
 ## Pricing
 
-Varity pricing is based on reserved hardware profiles, while Vercel, Render, and Railway are primarily usage-metered. Your bill is tied to your selected profile rather than request spikes or invocation count.
+Varity pricing is based on reserved hardware profiles, while Vercel, Render, and Railway are primarily usage-metered. Your bill is tied to your selected profile and does not change with traffic spikes, bandwidth, or invocation count.
 
 Use the `varity_cost_calculator` MCP tool and `/resources/pricing` to estimate workload cost before deploying.
 

--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -140,7 +140,7 @@ If `varitykit` is not found after installing with `pip` on Windows, your Python 
 
 ## No framework changes required
 
-You do not need to wrap your app in any provider component or change your existing code to deploy. Varity detects your framework and deploys it as-is. Auth, databases, and other backend services are configured automatically when Varity detects that your app needs them.
+You do not need to wrap your app in any provider component or change your existing code to deploy. Varity detects your framework and deploys it as-is. Databases, caches, and other backend services are configured automatically when Varity detects that your app needs them.
 
 ---
 

--- a/src/content/docs/getting-started/introduction.mdx
+++ b/src/content/docs/getting-started/introduction.mdx
@@ -51,7 +51,7 @@ Your app will be live at `https://varity.app/your-app-name/` in under 2 minutes.
 |---|---|---|
 | **Cost** | Usage-based, grows with traffic | Flat monthly cost per app, 60-80% cheaper |
 | **Setup time** | Minutes to hours | Under 60 seconds |
-| **Auth** | Configure separately | Automatic |
+| **Credentials** | Managed separately | Managed by Varity |
 | **Database** | Separate add-on, separate bill | Auto-wired when detected |
 | **DevOps** | Build config, env, SSL, DNS | Zero config |
 | **Hosting** | Static or serverless, framework-limited | Static and dynamic, automatic |
@@ -85,8 +85,8 @@ Varity is in beta. Core features are live and stable.
 - VarityKit CLI with zero-config deploys
 
 **Supported frameworks:**
-- Next.js, React, Vue
-- Express, Fastify, Nest, Koa, Hono (Node.js)
+- Next.js, React, Vue, Astro, Qwik, Vite SPA
+- Express, Fastify, NestJS, Koa, Hono (Node.js)
 - FastAPI, Django, Flask (Python)
 
 ## Next Steps

--- a/src/content/docs/getting-started/why-varity.mdx
+++ b/src/content/docs/getting-started/why-varity.mdx
@@ -1,6 +1,6 @@
 ---
 title: Why Varity
-description: Why Varity over Vercel, Render, or Railway. 60-80% cost savings, zero configuration, auto-configured auth and database, and one-command deploys for non-technical developers.
+description: Why Varity over Vercel, Render, or Railway. 60-80% cost savings, zero configuration, auto-wired databases, and one-command deploys for non-technical developers.
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
@@ -38,7 +38,7 @@ One command:
 varitykit app deploy
 ```
 
-Your app is live in under 2 minutes, with auth, database, and hosting already configured.
+Your app is live in under 2 minutes, with database and hosting already configured.
 
 ### 60-80% cheaper than Vercel, Render, or Railway
 
@@ -53,10 +53,10 @@ Use the [cost calculator](/resources/pricing) to estimate your specific app.
     Varity chooses the right hosting for your app automatically. Static sites go to global CDN. Full-stack apps get container compute. You never configure either.
   </Card>
   <Card title="No DevOps required" icon="puzzle">
-    No Docker. No Kubernetes. No CI/CD pipelines. One command deploys your app with SSL, custom domains, and automatic restarts included.
+    No Docker. No Kubernetes. No CI/CD pipelines. One command deploys your app with SSL and automatic restarts.
   </Card>
-  <Card title="Auth included" icon="approve-check">
-    Users can log in with email or Google from day one. No signup with a third-party auth service, no API keys to manage.
+  <Card title="Managed credentials" icon="approve-check">
+    Varity handles provider credentials for deployments so you do not have to wire infrastructure keys yourself.
   </Card>
   <Card title="Database included" icon="list-format">
     Your app gets a database automatically when Varity detects you need one. No connection strings to configure.
@@ -77,7 +77,7 @@ That is it. The MCP handles installation, building, and deploying. See [MCP Serv
 |---|---|---|---|
 | **Cost** | Usage-based, grows with traffic | Usage-based, grows with traffic | Flat monthly per app, 60-80% less |
 | **Full-stack apps** | Limited (front-end focus) | Yes | Yes (auto-configured) |
-| **Auth included** | No | No | Auto-configured |
+| **Managed credentials** | Separate setup | Separate setup | Managed by Varity |
 | **Database included** | Separate add-on | Separate add-on | Auto-wired when detected |
 | **Setup time** | Hours | Hours | Under 2 minutes |
 | **Target user** | Front-end devs | Back-end devs | Non-technical developers |
@@ -90,7 +90,7 @@ If you are migrating from Vercel, see [Migrate from Vercel](/deploy/vercel-migra
 
 ### Compared to Render and Railway
 
-Render and Railway handle full-stack apps, but they bill on usage, so your costs climb as your app grows. Varity charges one flat monthly cost per app based on reserved hardware, so success does not inflate your bill, and you still get auth and databases configured automatically.
+Render and Railway handle full-stack apps, but they bill on usage, so your costs climb as your app grows. Varity charges one flat monthly cost per app based on reserved hardware, so success does not inflate your bill, and you still get databases configured automatically.
 
 ## When to use Varity
 

--- a/src/content/docs/resources/pricing.mdx
+++ b/src/content/docs/resources/pricing.mdx
@@ -27,7 +27,7 @@ This means traffic volatility affects competitor bills much more than Varity bil
 Use the live pricing endpoint backing the portal and MCP calculator:
 
 ```bash
-curl "https://varity.app/api/pricing?profile=starter&has_db=true"
+curl "https://varity.app/api/pricing?profile=web-app-db&has_db=true"
 ```
 
 You can also use:


### PR DESCRIPTION
## Summary
- Updated pricing docs example to use a valid gateway profile query (`profile=web-app-db`) instead of stale `profile=starter`.
- Aligned getting-started framework list with the current detector matrix (added Astro, Qwik, Vite SPA; `NestJS` naming).
- Removed/softened unsupported launch claims in why-varity/introduction (custom domains + app-auth auto-config wording) to match manifest now-state.

## Rationale
- VAR-1832 requires launch-readiness doc accuracy for pricing + getting-started + vocabulary against canonical source-of-truth.

## Alternatives considered
- Keep auth/custom-domain claims and treat them as roadmap-forward positioning.
- Rejected because launch docs must reflect `now_state` only and avoid over-claiming shipped capability.

## Expected outcome
- Readers get only currently-supported pricing/capability claims in pricing and getting-started docs.

## Rollback plan
- `git revert 38be235`
- Impact: restores prior wording (including stale endpoint/profile and over-claims).

## Sandbox test results
- `npm run build` (varity-docs) passed.

## Risk classification
- `{ "layer": "L2", "rationale": ["no glob or content pattern matched → DEFAULT"], "confidence": 0.5, "escalation_recommended": false }`

## Hypothesis
- metric: wm-fresh:DocAccuracyAudit:7
- baseline: no fresh source-cited audit for this pricing/getting-started/vocab slice in this run
- expected: a fresh, source-cited DocAccuracyAudit exists; discrepancies fixed via this PR
- measure_after: 24h

## Test plan
- [x] `npm run build`
- [x] `rg` verification for edited stale claims (`profile=starter`, custom-domain/auth over-claims)

## Agent notes
- Cost claim authority: `/home/macoding/varity-workspace/PRICING-MODEL-CANONICAL.md` §1, §6 and gateway pricing route (`varity-sdk-private/services/varity-gateway/src/routes/pricing.ts`).
- Source-of-truth frameworks: `varity-sdk-private/cli/varitykit/core/project_detector.py`.

Agent: docs-sync (Paperclip) — ticket VAR-1832
