### PR TITLE
docs(deploy): correct custom-domains URL claim (static subpath vs dynamic subdomain)

### DIFF
--- a/src/content/docs/deploy/custom-domains.mdx
+++ b/src/content/docs/deploy/custom-domains.mdx
@@ -13,7 +13,7 @@ import PageMeta from '../../../components/PageMeta.astro';
   stability="stable"
 />
 
-Every Varity deployment gets a public URL at `https://varity.app/{name}/`. This guide covers how to set a custom name for that URL and manage your registered domains.
+Every Varity deployment gets a public URL based on its hosting type: **static apps** (IPFS) are served at `https://varity.app/{name}/`, and **dynamic apps** (Node/Python servers) get their own subdomain at `https://{name}.varity.app/`. This guide covers how to set a custom name and manage your registered domains.
 
 <Aside type="note">
 **External custom domain support** (pointing `myapp.com` via DNS to your Varity deployment) is under development. This guide covers `varity.app` subdomain management, which is available now.
@@ -21,10 +21,14 @@ Every Varity deployment gets a public URL at `https://varity.app/{name}/`. This 
 
 ## How Your Domain Is Assigned
 
-When you run `varitykit app deploy`, Varity registers a subdomain at `varity.app` using your project's name:
+When you run `varitykit app deploy`, Varity registers a name for your app from your project's name. The resulting URL depends on hosting type:
 
 ```
+# Static (IPFS) apps — served on a sub-path
 https://varity.app/{your-app-name}/
+
+# Dynamic (Node/Python) apps — served on their own subdomain
+https://{your-app-name}.varity.app/
 ```
 
 Your app name is derived from the `name` field in your `package.json` by default. You can override it with the `--name` flag.


### PR DESCRIPTION
## Summary
`custom-domains.mdx` claimed *every* deployment is served at `varity.app/{name}/`. That is false for **dynamic** (Node/Python) apps, which get their own subdomain `{name}.varity.app/`. This corrects the URL claim to distinguish static (IPFS sub-path) vs dynamic (subdomain) hosting.

## Verification
Checked against the deploy-URL ground truth: `varity-sdk-private/cli/varitykit/core/deployment_orchestrator.py` (static → `varity.app/<name>/`, dynamic → `<name>.varity.app` via `register_akash_domain`/`sanitize_subdomain`). Matches the pinned ground truth in the docs-sync agent spec.

## Test plan
- [ ] `pnpm dev` (Astro/Starlight :4321) renders the page without errors