### PR TITLE
docs: launch-accuracy sweep — remove unshipped-feature overclaims

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## What is Varity?
 
-Varity is the easiest way to deploy any Node or Python app, AI agent, or LLM with your AI coding tool. You describe what you want to build and Varity handles the hosting, database, auth, and payments automatically.
+Varity is the easiest way to deploy any Node or Python app, AI agent, or LLM with your AI coding tool. You describe what you want to build and Varity handles the hosting and database automatically.
 
 No servers to configure. No infrastructure decisions. One command and your app is live.
 
@@ -38,7 +38,7 @@ npx -y @varity-labs/mcp@beta
 ## Features
 
 - **One-command deploy**: run `varitykit app deploy` from any Next.js, React, Vue, Node, or Python app
-- **Auto-configured infrastructure**: database, auth, and storage wired automatically based on your dependencies
+- **Auto-configured infrastructure**: databases and backend services wired automatically based on your dependencies
 - **Cost-aware deployment**: compare projected costs with the built-in calculator
 - **Vercel migration**: `varitykit migrate` converts your Vercel project in seconds
 - **AI IDE native**: install the MCP server in Claude Code, Cursor, or Windsurf and deploy with natural language
@@ -61,13 +61,12 @@ npx -y @varity-labs/mcp@beta
 ```
 src/content/docs/
 ├── getting-started/     # Introduction, installation, quickstart
-├── packages/            # Legacy references (deferred, not current product surface)
-├── build/               # Auth, databases, storage, payments guides
 ├── cli/                 # CLI commands reference
 ├── deploy/              # Deployment guides and Vercel migration
 ├── ai-tools/            # MCP server and AI IDE integration
-├── templates/           # Legacy scaffolding docs (deferred)
-└── resources/           # FAQ, glossary, troubleshooting
+├── guides/              # Framework and workflow guides
+├── tutorials/           # End-to-end build tutorials
+└── resources/           # FAQ, glossary, pricing, troubleshooting
 ```
 
 ## Local Development

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Varity Documentation
 
-> **The easiest way to deploy any app, AI agent, or LLM.**
+> **The easiest way to deploy any Node or Python app, AI agent, or LLM.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Discord](https://img.shields.io/discord/7vWsdwa2Bg?label=Discord&logo=discord&logoColor=white)](https://discord.gg/7vWsdwa2Bg)
@@ -12,7 +12,7 @@
 
 ## What is Varity?
 
-Varity is the easiest way to deploy any app, AI agent, or LLM with your AI coding tool. You describe what you want to build and Varity handles the hosting, database, auth, and payments automatically.
+Varity is the easiest way to deploy any Node or Python app, AI agent, or LLM with your AI coding tool. You describe what you want to build and Varity handles the hosting, database, auth, and payments automatically.
 
 No servers to configure. No infrastructure decisions. One command and your app is live.
 
@@ -37,13 +37,13 @@ npx -y @varity-labs/mcp@beta
 
 ## Features
 
-- **One-command deploy** — run `varitykit app deploy` from any Next.js, React, Vue, Node, or Python app
-- **Auto-configured infrastructure** — database, auth, and storage wired automatically based on your dependencies
-- **Cost-aware deployment** — compare projected costs with the built-in calculator
-- **Vercel migration** — `varitykit migrate` converts your Vercel project in seconds
-- **AI IDE native** — install the MCP server in Claude Code, Cursor, or Windsurf and deploy with natural language
-- **16 MCP tools** — `varity_deploy`, `varity_migrate`, `varity_cost_calculator`, and more
-- **Auto-wired services** — Postgres, Redis, MongoDB, and Ollama detected and configured from `package.json`
+- **One-command deploy**: run `varitykit app deploy` from any Next.js, React, Vue, Node, or Python app
+- **Auto-configured infrastructure**: database, auth, and storage wired automatically based on your dependencies
+- **Cost-aware deployment**: compare projected costs with the built-in calculator
+- **Vercel migration**: `varitykit migrate` converts your Vercel project in seconds
+- **AI IDE native**: install the MCP server in Claude Code, Cursor, or Windsurf and deploy with natural language
+- **MCP tools for AI IDE workflows**: includes `varity_deploy`, `varity_migrate`, `varity_cost_calculator`, and more
+- **Auto-wired services**: Postgres, Redis, MongoDB, and Ollama detected and configured from `package.json`
 
 ## Supported Frameworks
 
@@ -54,19 +54,19 @@ npx -y @varity-labs/mcp@beta
 | Vue | Ready |
 | Express / Fastify / Nest / Hono | Ready |
 | FastAPI / Django / Flask | Ready |
-| Go, Rust, Ruby, Java | Coming soon |
+| Go, Rust, Ruby / Rails, Elixir / Phoenix, Java / Spring, Deno, PHP / Laravel, .NET | Not supported yet |
 
 ## Documentation Structure
 
 ```
 src/content/docs/
 ├── getting-started/     # Introduction, installation, quickstart
-├── packages/            # SDK, UI Kit, Types reference
+├── packages/            # Legacy references (deferred, not current product surface)
 ├── build/               # Auth, databases, storage, payments guides
 ├── cli/                 # CLI commands reference
 ├── deploy/              # Deployment guides and Vercel migration
 ├── ai-tools/            # MCP server and AI IDE integration
-├── templates/           # App templates and scaffolding
+├── templates/           # Legacy scaffolding docs (deferred)
 └── resources/           # FAQ, glossary, troubleshooting
 ```
 
@@ -92,7 +92,7 @@ We welcome contributions! Read [CONTRIBUTING.md](CONTRIBUTING.md) for setup inst
 
 Key guidelines:
 - All code examples must be tested and working before submitting
-- Follow the [terminology guide](CONTRIBUTING.md#terminology) — no forbidden vocabulary in prose
+- Follow the [terminology guide](CONTRIBUTING.md#terminology): no forbidden vocabulary in prose
 - Open an issue before making large changes
 
 ## Community
@@ -108,4 +108,4 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 
 ## License
 
-MIT © [Varity Labs](https://www.varity.so) — see [LICENSE](LICENSE) for details.
+MIT © [Varity Labs](https://www.varity.so), see [LICENSE](LICENSE) for details.

--- a/src/content/docs/ai-tools/mcp-server-spec.mdx
+++ b/src/content/docs/ai-tools/mcp-server-spec.mdx
@@ -165,25 +165,6 @@ Install dependencies for a Varity project. Runs `npm install` for all packages o
 
 ---
 
-### `varity_add_collection`: Add database collection
-
-Add a new database collection to your project. Creates the TypeScript type, collection accessor, React hook, and optionally scaffolds a dashboard page.
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `name` | string | Yes | none | Collection name (lowercase, e.g., "invoices", "team_members") |
-| `fields` | array | Yes | none | Field definitions: `[{name: "amount", type: "number"}, {name: "status", type: "string"}]` |
-| `path` | string | No | Current directory | Project directory |
-| `add_page` | boolean | No | false | Scaffold a dashboard page with DataTable and Dialog |
-
-**Field types:** `"string"`, `"number"`, `"boolean"`, `"Date"`
-
-**Annotations:** `destructiveHint: true` (creates/modifies files in your project)
-
-**Example prompt:** "Add an invoices collection with amount (number) and status (string) fields"
-
----
-
 ### `varity_dev_server`: Manage local dev server
 
 Start, stop, or check the status of your local development server. Returns the localhost URL for previewing your app.
@@ -387,7 +368,7 @@ npx -y @varity-labs/mcp@beta --transport http --port 3100
 This starts the MCP server at `http://localhost:3100/mcp`.
 
 <Aside type="note">
-`varity_init` (scaffolding) is only available via stdio transport since it requires access to the local filesystem. All other tools work on both transports.
+`varity_init` (scaffolding) requires local filesystem access, so use stdio transport. Local-browser tools (`varity_open_browser`, `varity_dev_server`) are also stdio-only. Use stdio when you need local execution; use HTTP for remote connector workflows.
 </Aside>
 
 ### llms.txt Alternative

--- a/src/content/docs/ai-tools/prompts.mdx
+++ b/src/content/docs/ai-tools/prompts.mdx
@@ -68,5 +68,5 @@ versus Vercel, Render, and Railway?
 
 - Tell your AI tool the full path to your project so it deploys the right folder.
 - Varity deploys Node apps (Next.js, React, Vue, Astro, Qwik, Vite, Express, Fastify, NestJS, Koa, Hono) and Python apps (FastAPI, Django, Flask), plus static sites.
-- Auth and a database are configured automatically when your app needs them. You do not install anything extra.
+- A database is configured automatically when your app needs it. You do not install anything extra.
 - Your bill is one flat monthly cost per app and does not change with traffic.

--- a/src/content/docs/cli/commands/deploy.mdx
+++ b/src/content/docs/cli/commands/deploy.mdx
@@ -73,7 +73,7 @@ Dynamic hosting is powered by cloud compute. Use `--hosting dynamic` for server-
 |--------|---------|-------------|
 | `--hosting` | `auto` | Hosting type: `auto`, `static`, or `dynamic` |
 | `--path` | `.` | Project directory |
-| `--name` | - | Custom app name for `varity.app/{name}` |
+| `--name` | - | Custom app name. Static URLs use `varity.app/{name}`; dynamic URLs use `{name}.varity.app` |
 | `--mode` | `auto` | Deployment mode: `auto`, `guided`, or `expert` |
 
 ## Basic Deployment
@@ -100,7 +100,7 @@ Dynamic hosting is powered by cloud compute. Use `--hosting dynamic` for server-
    ✓ Registered on Varity
 
    Your app is live at:
-   https://varity.app/your-app/
+   https://your-app.varity.app
 
    Deployment ID: deploy-1737492000
    ```
@@ -144,8 +144,8 @@ Output:
 ```
 ID                  | Status  | URL
 --------------------|---------|---------------------------
-deploy-1737492000   | live    | https://varity.app/your-app/
-deploy-1737491000   | archived| https://varity.app/your-app/ (archived)
+deploy-1737492000   | live    | https://your-app.varity.app
+deploy-1737491000   | archived| https://your-app.varity.app (archived)
 ```
 
 ## View Deployment Details

--- a/src/content/docs/cli/commands/deploy.mdx
+++ b/src/content/docs/cli/commands/deploy.mdx
@@ -121,7 +121,7 @@ The CLI automatically detects your framework:
 
 ## Environment Variables
 
-Storage and authentication credentials are auto-provided by Varity. No manual credential setup is required. See [Managed Credentials](/deploy/managed-credentials).
+Storage and service credentials are auto-provided by Varity. No manual credential setup is required. See [Managed Credentials](/deploy/managed-credentials).
 
 ## Rollback
 

--- a/src/content/docs/cli/commands/doctor.mdx
+++ b/src/content/docs/cli/commands/doctor.mdx
@@ -9,7 +9,7 @@ import PageMeta from '../../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="April 2026"
+  lastUpdated="May 2026"
   stability="stable"
 />
 

--- a/src/content/docs/cli/installation.mdx
+++ b/src/content/docs/cli/installation.mdx
@@ -83,7 +83,7 @@ You should see a table of checks with a `✓ All checks passed!` message at the 
    NEXT_PUBLIC_VARITY_APP_ID=your-app-id
    ```
 
-   All deployment credentials (storage, authentication, hosting) are managed automatically by the Varity credential proxy. See [Managed Credentials](/deploy/managed-credentials).
+   All deployment credentials (storage, service connections, hosting) are managed automatically by the Varity credential proxy. See [Managed Credentials](/deploy/managed-credentials).
 
 2. **Verify your setup**:
 

--- a/src/content/docs/cli/overview.mdx
+++ b/src/content/docs/cli/overview.mdx
@@ -165,7 +165,7 @@ Varity currently auto-detects and deploys the following frameworks:
 | Express, Fastify, Nest, Koa, Hono | N/A | ✅ |
 | FastAPI, Django, Flask | N/A | ✅ |
 
-**Not yet supported:** Go, Rust, Ruby, Elixir, Java, PHP, .NET. These will not be auto-detected and deployment will fail with an unsupported-language error. [Request support for your framework](https://github.com/varity-labs).
+**Not yet supported:** Go, Rust, Ruby / Rails, Elixir / Phoenix, Java / Spring, Deno, PHP / Laravel, .NET. These will not be auto-detected and deployment will fail with an unsupported-language error. [Request support for your framework](https://github.com/varity-labs).
 
 ## Additional Command Details
 

--- a/src/content/docs/deploy/auto-wired-services.mdx
+++ b/src/content/docs/deploy/auto-wired-services.mdx
@@ -9,7 +9,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="April 2026"
+  lastUpdated="May 2026"
   stability="stable"
 />
 

--- a/src/content/docs/deploy/custom-domains.mdx
+++ b/src/content/docs/deploy/custom-domains.mdx
@@ -1,6 +1,6 @@
 ---
 title: Custom Domains
-description: Set a custom subdomain for your Varity app at varity.app/{name}. List your registered domains with varitykit domains list.
+description: Set your app name for Varity URLs. Static apps use varity.app/{name}, dynamic apps use {name}.varity.app. List registered domains with varitykit domains list.
 ---
 
 import { Steps, Aside, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -9,11 +9,11 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="April 2026"
+  lastUpdated="May 2026"
   stability="stable"
 />
 
-Every Varity deployment gets a public URL based on its hosting type: **static apps** (IPFS) are served at `https://varity.app/{name}/`, and **dynamic apps** (Node/Python servers) get their own subdomain at `https://{name}.varity.app/`. This guide covers how to set a custom name and manage your registered domains.
+Every Varity deployment gets a public URL based on its hosting type: **static apps** are served at `https://varity.app/{name}/`, and **dynamic apps** (Node/Python servers) get their own subdomain at `https://{name}.varity.app/`. This guide covers how to set a custom name and manage your registered domains.
 
 <Aside type="note">
 **External custom domain support** (pointing `myapp.com` via DNS to your Varity deployment) is under development. This guide covers `varity.app` subdomain management, which is available now.
@@ -24,10 +24,10 @@ Every Varity deployment gets a public URL based on its hosting type: **static ap
 When you run `varitykit app deploy`, Varity registers a name for your app from your project's name. The resulting URL depends on hosting type:
 
 ```
-# Static (IPFS) apps — served on a sub-path
+# Static apps: served on a sub-path
 https://varity.app/{your-app-name}/
 
-# Dynamic (Node/Python) apps — served on their own subdomain
+# Dynamic (Node/Python) apps: served on their own subdomain
 https://{your-app-name}.varity.app/
 ```
 

--- a/src/content/docs/deploy/deploy-your-app.mdx
+++ b/src/content/docs/deploy/deploy-your-app.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy Your Application
-description: Deploy your application to Varity with one CLI command. Automatic builds, custom domains at varity.app, and live in under 2 minutes.
+description: Deploy your application to Varity with one CLI command. Automatic builds, a live varity.app URL, and go live in under 2 minutes.
 ---
 
 import { Tabs, TabItem, Steps, Aside, Card, CardGrid } from '@astrojs/starlight/components';
@@ -10,7 +10,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="April 2026"
+  lastUpdated="May 2026"
   stability="stable"
 />
 
@@ -48,7 +48,7 @@ Varity is currently in beta. Your deployments work exactly as in production, but
 
    ```
    ✓ Deployed successfully!
-   ✓ URL: https://varity.app/your-app/
+   ✓ URL: https://your-app.varity.app
    ✓ Build time: 1m 23s
    ✓ Status: Live
    ```
@@ -63,7 +63,7 @@ When you run `varitykit app deploy`:
 2. **Builds your app** - Runs your build command (`npm run build`)
 3. **Uploads your files** - Stores them securely with automatic backups
 4. **Makes your app live** - Generates a public URL
-5. **Returns a live URL** - Your app is reachable at `varity.app/<name>/`
+5. **Returns a live URL** - Static apps use `https://varity.app/<name>/`; dynamic apps use `https://<name>.varity.app/`
 
 All of this happens automatically in under 2 minutes.
 
@@ -90,7 +90,7 @@ Choose the right hosting for your application type:
 
     **Features**:
     - Container-based compute
-    - Automatic scaling
+    - Managed container hosting
     - Database support
     - WebSocket support
 
@@ -110,8 +110,6 @@ Credentials are managed automatically by Varity. Optionally set your app ID:
 # Optional: Your Varity App ID
 NEXT_PUBLIC_VARITY_APP_ID=<your-app-id>
 
-# Optional: Custom domain
-VARITY_CUSTOM_DOMAIN=your-domain.com
 ```
 
 See [Environment Variables](/deploy/env-variables) for the complete list and [Managed Credentials](/deploy/managed-credentials) for how credential auto-provision works.
@@ -140,9 +138,9 @@ varitykit app list
 Output:
 ```
 ID                  Status    URL                                Deployed
-deploy-1737491000   live      https://varity.app/your-app/       2 hours ago
-deploy-1737484800   archived  https://varity.app/your-app-v2/    1 day ago
-deploy-1737398400   archived  https://varity.app/your-app-v1/    2 days ago
+deploy-1737491000   live      https://your-app.varity.app       2 hours ago
+deploy-1737484800   archived  https://your-app-v2.varity.app    1 day ago
+deploy-1737398400   archived  https://your-app-v1.varity.app    2 days ago
 ```
 
 ### Rollback to Previous Version
@@ -171,16 +169,17 @@ View overall deployment status:
 varitykit app status
 ```
 
-## Custom Domains
+## Deployment URL
 
-Every deployment gets a public URL at `https://varity.app/{name}/`. Set your app name with `--name`:
+Every deployment gets a public URL. URL format depends on hosting type:
 
 ```bash
 varitykit app deploy --name my-app
-# → https://varity.app/my-app/
+# Static hosting → https://varity.app/my-app/
+# Dynamic hosting → https://my-app.varity.app/
 ```
 
-See [Custom Domains](/deploy/custom-domains) for the full guide, including how to list your registered domains.
+See [Custom Domains](/deploy/custom-domains) for the current status of bring-your-own domains.
 
 :::note[Bring your own domain]
 Pointing `myapp.com` at a Varity deployment via DNS is under development. See [Custom Domains](/deploy/custom-domains) for status.

--- a/src/content/docs/deploy/deployment-troubleshooting.mdx
+++ b/src/content/docs/deploy/deployment-troubleshooting.mdx
@@ -9,7 +9,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="April 2026"
+  lastUpdated="May 2026"
   stability="stable"
 />
 

--- a/src/content/docs/deploy/env-variables.mdx
+++ b/src/content/docs/deploy/env-variables.mdx
@@ -10,7 +10,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="April 2026"
+  lastUpdated="May 2026"
   stability="stable"
 />
 

--- a/src/content/docs/deploy/env-variables.mdx
+++ b/src/content/docs/deploy/env-variables.mdx
@@ -17,7 +17,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 Varity manages most credentials automatically. You only need to set environment variables for services you manage yourself, like your own API keys for OpenAI, Stripe, SendGrid, and similar third-party services.
 
 <Aside type="tip">
-**No credential setup required.** Authentication and storage credentials are provided automatically by Varity. See [Managed Credentials](/deploy/managed-credentials) for details.
+**No credential setup required.** Storage and service credentials are provided automatically by Varity. See [Managed Credentials](/deploy/managed-credentials) for details.
 </Aside>
 
 ## Custom Environment Variables
@@ -125,7 +125,7 @@ Deployment credentials for hosting (both static and dynamic) are managed automat
     VARITY_API_KEY=your_production_api_key
     ```
 
-    Production credentials for authentication and storage are auto-provided by the CLI during deployment.
+    Production credentials for storage and services are auto-provided by the CLI during deployment.
   </TabItem>
 </Tabs>
 

--- a/src/content/docs/deploy/intelligent-orchestration.mdx
+++ b/src/content/docs/deploy/intelligent-orchestration.mdx
@@ -79,7 +79,7 @@ Every Varity app gets these services configured automatically - no setup require
     - Automatically optimized for your app type
     - Global CDN included
     - Managed runtime configuration
-    - High availability with managed routing
+    - Managed request routing
   </Card>
 
   <Card title="Database" icon="seti:db">
@@ -90,19 +90,10 @@ Every Varity app gets these services configured automatically - no setup require
     - Connection details injected at runtime
   </Card>
 
-  <Card title="Authentication" icon="approve-check">
-    **Email & Social Login**
-    - Configured automatically, no SDK to import
-    - Email, Google, GitHub, Twitter, Discord
-    - No complex OAuth setup
-    - No keys for you to manage
-  </Card>
-
   <Card title="Security" icon="seti:lock">
-    **Enterprise-Grade Security**
+    **Secure by Default**
     - SSL certificates (automatic)
-    - DDoS protection
-    - Secure user sessions
+    - Encrypted data in transit and at rest
     - No security configuration needed
   </Card>
 
@@ -123,7 +114,7 @@ Varity uses fixed profile pricing while Vercel, Render, and Railway use usage-me
 
 - **Smart Infrastructure Selection** - Varity automatically picks the most cost-effective hardware for your specific app
 - **No Over-Provisioning** - Your app is sized to the hardware it actually needs, and your monthly cost is fixed
-- **Included Services** - Database, auth, CDN, and SSL are included at no extra cost
+- **Included Services** - Database, CDN, and SSL are included at no extra cost
 - **Efficient Architecture** - Modern infrastructure designed for cost optimization from day one
 
 Use [Pricing and Costs](/resources/pricing) and `varity_cost_calculator` for current estimates.
@@ -183,12 +174,11 @@ When you deploy, Varity automatically handles:
 - ✅ Build configuration (Nixpacks auto-detection)
 - ✅ Container creation (no Docker install required)
 - ✅ Database provisioning (if your code needs it)
-- ✅ Authentication setup (managed automatically)
 - ✅ SSL certificates (automatic)
 - ✅ Domain routing (varity.app/your-app/)
 - ✅ CDN configuration (global edge caching)
 - ✅ Managed hosting defaults
-- ✅ Sidecars: Postgres+pgvector, Redis, Ollama, MongoDB (when detected in your config)
+- ✅ Sidecars: Postgres+pgvector, Redis, MongoDB, MySQL, Ollama (when detected in your config)
 
 **Not yet supported:** Go, Rust, Ruby / Rails, Elixir / Phoenix, Java / Spring, Deno, PHP / Laravel, .NET. Deploying these will fail with a clear unsupported-language error. [Request support for your framework](https://github.com/varity-labs).
 

--- a/src/content/docs/deploy/intelligent-orchestration.mdx
+++ b/src/content/docs/deploy/intelligent-orchestration.mdx
@@ -28,7 +28,7 @@ When you deploy with Varity, the platform automatically:
 - **Understands your app** - Figures out what your app needs without you telling it
 - **Configures deployment defaults** - Sets up hosting and runtime services based on your project
 - **Optimizes costs** - Picks the most affordable infrastructure for your specific app
-- **Handles scaling** - Your app grows with traffic, no manual intervention needed
+- **Handles hosting defaults** - Varity configures your runtime services automatically
 
 **No configuration files. No YAML. No Docker. No DevOps knowledge. Just one command.**
 
@@ -78,8 +78,8 @@ Every Varity app gets these services configured automatically - no setup require
     **Global, Fast, Reliable**
     - Automatically optimized for your app type
     - Global CDN included
-    - Auto-scaling with traffic
-    - 99.9% uptime guaranteed
+    - Managed runtime configuration
+    - High availability with managed routing
   </Card>
 
   <Card title="Database" icon="seti:db">
@@ -187,10 +187,10 @@ When you deploy, Varity automatically handles:
 - ✅ SSL certificates (automatic)
 - ✅ Domain routing (varity.app/your-app/)
 - ✅ CDN configuration (global edge caching)
-- ✅ Auto-scaling (based on traffic)
+- ✅ Managed hosting defaults
 - ✅ Sidecars: Postgres+pgvector, Redis, Ollama, MongoDB (when detected in your config)
 
-**Not yet supported:** Go, Rust, Ruby, Elixir, Java, PHP, .NET. Deploying these will fail with a clear unsupported-language error. [Request support for your framework](https://github.com/varity-labs).
+**Not yet supported:** Go, Rust, Ruby / Rails, Elixir / Phoenix, Java / Spring, Deno, PHP / Laravel, .NET. Deploying these will fail with a clear unsupported-language error. [Request support for your framework](https://github.com/varity-labs).
 
 ## Developer Experience
 
@@ -278,7 +278,7 @@ Deploying...
 ❌ CDN configuration
 ❌ Database connection strings
 ❌ Load balancer setup
-❌ Auto-scaling configuration
+❌ Manual hosting configuration
 
 ## Next Steps
 

--- a/src/content/docs/deploy/managed-credentials.mdx
+++ b/src/content/docs/deploy/managed-credentials.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Managed Credentials"
-description: "Varity auto-provides auth, database, and storage credentials at every stage. No third-party accounts, no API key setup, no .env configuration."
+description: "Varity auto-provides database, storage, and service credentials at every stage. No third-party accounts, no API key setup, no .env configuration."
 ---
 
 import { Steps, Aside } from '@astrojs/starlight/components';
-import Accordion from '../../../components/Accordion.astro';
 import PageMeta from '../../../components/PageMeta.astro';
 
 <PageMeta
@@ -46,13 +45,13 @@ Varity provides credentials for:
 
 | Service | What It Covers | Developer Action |
 |---------|---------------|-----------------|
-| **Authentication** | User login (email, social) | None required |
+| **Database** | Connection details for detected databases (Postgres, Redis, MongoDB, MySQL) | None required |
 | **File Storage** | Uploads, CDN delivery | None required |
 | **Infrastructure** | Network access, operations | None required |
 
 ## Development Mode
 
-During local development, shared development credentials are available automatically, so your app can connect to a database or auth provider without any setup. When Varity detects that your app needs a service (for example, a database client in your dependencies), it provisions that service on deploy and injects the connection details into your app's environment.
+During local development, shared development credentials are available automatically, so your app can connect to a database without any setup. When Varity detects that your app needs a service (for example, a database client in your dependencies), it provisions that service on deploy and injects the connection details into your app's environment.
 
 <Aside type="tip">
 Just build your app and deploy. Varity resolves and injects the credentials your app needs. You do not import an SDK or manage keys.
@@ -96,25 +95,6 @@ Checking environment variables...
   ✓ Credentials: Auto-provided
   ✓ Storage API: Accessible
 ```
-
-<Accordion title="Advanced: Using Your Own Auth Credentials">
-
-**Varity manages these credentials automatically. Only use this if you need custom configuration.**
-
-You can override the managed authentication credential with your own provider configuration:
-
-### Authentication Override
-
-1. Set up your authentication provider and obtain your App ID
-2. Add it to your environment variables:
-
-```bash title=".env.local"
-NEXT_PUBLIC_VARITY_AUTH_APP_ID=your_varity_auth_app_id
-```
-
-When `NEXT_PUBLIC_VARITY_AUTH_APP_ID` is set, your app uses your own authentication app instead of the managed one. Varity injects this variable into your deployed app the same way it injects managed credentials.
-
-</Accordion>
 
 ## Next Steps
 

--- a/src/content/docs/deploy/managed-credentials.mdx
+++ b/src/content/docs/deploy/managed-credentials.mdx
@@ -71,7 +71,7 @@ Output:
 ✓ Credentials: Auto-provided
 ✓ Build complete
 ✓ Deployed successfully
-✓ URL: https://varity.app/your-app/
+✓ URL: https://your-app.varity.app
 ```
 
 No manual credential setup required.

--- a/src/content/docs/deploy/rollback.mdx
+++ b/src/content/docs/deploy/rollback.mdx
@@ -9,7 +9,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="April 2026"
+  lastUpdated="May 2026"
   stability="stable"
 />
 
@@ -39,9 +39,9 @@ Output:
 
 ```
 ID                  Status    URL                              Deployed
-deploy-1737492000   live      https://varity.app/your-app/   2 hours ago
-deploy-1737491000   archived  https://varity.app/your-app/   1 day ago
-deploy-1737484800   archived  https://varity.app/your-app/   2 days ago
+deploy-1737492000   live      https://your-app.varity.app   2 hours ago
+deploy-1737491000   archived  https://your-app.varity.app   1 day ago
+deploy-1737484800   archived  https://your-app.varity.app   2 days ago
 ```
 
 The `live` deployment is your current production version. `archived` deployments are still available for rollback.
@@ -75,7 +75,7 @@ Output:
 ```
 ✓ Rolling back to deploy-1737491000...
 ✓ Deployment restored
-✓ Live at: https://varity.app/your-app/
+✓ Live at: https://your-app.varity.app
 ✓ New deployment ID: deploy-1737492100
 ```
 

--- a/src/content/docs/deploy/supported-frameworks.mdx
+++ b/src/content/docs/deploy/supported-frameworks.mdx
@@ -9,7 +9,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="April 2026"
+  lastUpdated="May 2026"
   stability="stable"
 />
 

--- a/src/content/docs/deploy/vercel-migration.mdx
+++ b/src/content/docs/deploy/vercel-migration.mdx
@@ -99,7 +99,7 @@ varitykit migrate rollback ./my-app
 
 ## After migration
 
-- Your app runs on Varity infrastructure with auth, database, and hosting included
+- Your app runs on Varity infrastructure with database and hosting included
 - Environment variables are managed automatically. No manual configuration needed
 - Review any warnings from the migration output and fix manually if needed
 - Set a custom subdomain or check the cost of your new deployment

--- a/src/content/docs/deploy/vercel-migration.mdx
+++ b/src/content/docs/deploy/vercel-migration.mdx
@@ -9,7 +9,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="April 2026"
+  lastUpdated="May 2026"
   stability="beta"
 />
 

--- a/src/content/docs/getting-started/how-varity-works.mdx
+++ b/src/content/docs/getting-started/how-varity-works.mdx
@@ -78,7 +78,8 @@ Here is how you go from idea to a live URL:
    Your app is now available at a public URL:
 
    ```
-   https://varity.app/your-app-name/
+   Static hosting: https://varity.app/your-app-name/
+   Dynamic hosting: https://your-app-name.varity.app/
    ```
 
    Varity detects your framework, builds your project, provisions the resources it needs, and returns a working URL. All of this happens automatically.

--- a/src/content/docs/getting-started/how-varity-works.mdx
+++ b/src/content/docs/getting-started/how-varity-works.mdx
@@ -21,7 +21,7 @@ Varity is built for developers who use AI coding tools to build and ship apps. T
 
 **Building something new with an AI tool** (vibe coding): You are using Claude Code, Cursor, or a similar tool to build an app from scratch. You want to go from "working locally" to "live URL" without leaving your editor. Varity's MCP server handles the entire deploy in one prompt.
 
-**Migrating from another platform**: You have an existing app on Vercel, Render, Railway, or another host and want lower costs. Run `varitykit migrate` to remove platform-specific config, then deploy. Most migrations take under 5 minutes.
+**Migrating from Vercel**: You have an existing app on Vercel and want lower costs. Run `varitykit migrate` to remove Vercel-specific config, then deploy. Most migrations take under 5 minutes.
 
 **Deploying your current project**: You already have app code locally or in a GitHub repo and want a live URL fast. Run `varitykit app deploy` (or ask your MCP client to run `varity_deploy`) and ship.
 
@@ -129,7 +129,6 @@ The Varity MCP server gives your AI coding tool a full set of tools for deployin
 | `varity_search_docs` | Search Varity documentation |
 | `varity_cost_calculator` | Estimate costs for your project |
 | `varity_install_deps` | Install project dependencies |
-| `varity_add_collection` | Add a database collection with generated types |
 | `varity_dev_server` | Start a local development server |
 | `varity_build` | Build your project |
 | `varity_open_browser` | Open a URL in your browser |

--- a/src/content/docs/getting-started/introduction.mdx
+++ b/src/content/docs/getting-started/introduction.mdx
@@ -78,7 +78,6 @@ Varity is in beta. Core features are live and stable.
 **Available now:**
 - Static app hosting (global CDN)
 - Dynamic app hosting (container-based, for full-stack and server apps)
-- Authentication (email, social login)
 - Auto-wired databases, caches, and AI runtimes based on your dependencies
 - Vercel migration tool (`varitykit migrate`)
 - MCP server with a full set of tools for deploying, monitoring, and managing your apps in Claude Code and Cursor

--- a/src/content/docs/getting-started/quickstart-nextjs.mdx
+++ b/src/content/docs/getting-started/quickstart-nextjs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Next.js Quick Start
-description: Deploy a Next.js app to Varity. Varity detects your framework and wires hosting, auth, and databases automatically.
+description: Deploy a Next.js app to Varity. Varity detects your framework and wires hosting and databases automatically.
 ---
 
 import { Steps, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
@@ -76,7 +76,7 @@ You do not import an SDK or change your code. When Varity deploys a Next.js proj
 For the full list of detected frameworks and auto-wired services, see [Supported Frameworks](/deploy/supported-frameworks) and [Auto-wired Services](/deploy/auto-wired-services).
 
 <Aside type="tip">
-You do not need to add any provider components, API keys, or config to your app. Varity supplies the credentials your deployed app needs.
+You do not need to wire up connection details for auto-wired services. Varity injects them into your app's environment at runtime. Set any other secrets your app needs (such as third-party or auth-provider API keys) as environment variables.
 </Aside>
 
 ## Next Steps

--- a/src/content/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/getting-started/quickstart.mdx
@@ -9,7 +9,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="April 2026"
+  lastUpdated="May 2026"
   stability="beta"
 />
 

--- a/src/content/docs/getting-started/why-varity.mdx
+++ b/src/content/docs/getting-started/why-varity.mdx
@@ -96,7 +96,7 @@ Render and Railway handle full-stack apps, but they bill on usage, so your costs
 
 - You built an app with Claude Code, Cursor, or another AI coding tool and want to deploy it
 - You are migrating an app from Vercel or another platform and want to cut hosting costs
-- You want auth, database, and hosting to just work without writing any infrastructure code
+- You want database and hosting to just work without writing infrastructure code
 - You are building an AI agent or LLM app and need reliable compute
 
 ## When Varity may not be the right fit

--- a/src/content/docs/getting-started/why-varity.mdx
+++ b/src/content/docs/getting-started/why-varity.mdx
@@ -95,14 +95,14 @@ Render and Railway handle full-stack apps, but they bill on usage, so your costs
 ## When to use Varity
 
 - You built an app with Claude Code, Cursor, or another AI coding tool and want to deploy it
-- You are migrating an app from Vercel or another platform and want to cut hosting costs
+- You are migrating an app from Vercel and want to cut hosting costs
 - You want database and hosting to just work without writing infrastructure code
 - You are building an AI agent or LLM app and need reliable compute
 
 ## When Varity may not be the right fit
 
 - You need bare-metal server access or extreme infrastructure customization
-- Your app uses a framework Varity does not support yet (Go, Rust, Ruby, Java, PHP, and others are on the roadmap)
+- Your app uses a framework Varity does not support yet (Go, Rust, Ruby / Rails, Elixir / Phoenix, Java / Spring, Deno, PHP / Laravel, .NET)
 - You need specific compliance certifications not yet supported (contact us for the roadmap)
 
 For most apps, Varity is the fastest path from code to production.

--- a/src/content/docs/guides/deploy-from-ai-ide.mdx
+++ b/src/content/docs/guides/deploy-from-ai-ide.mdx
@@ -9,7 +9,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="April 2026"
+  lastUpdated="May 2026"
   stability="stable"
 />
 

--- a/src/content/docs/guides/deploy-nextjs.mdx
+++ b/src/content/docs/guides/deploy-nextjs.mdx
@@ -9,7 +9,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="April 2026"
+  lastUpdated="May 2026"
   stability="stable"
 />
 
@@ -300,5 +300,5 @@ See [Troubleshooting Deploys](/deploy/deployment-troubleshooting) for the full l
 - [Auto-wired Services](/deploy/auto-wired-services): What gets provisioned and how
 - [Environment Variables](/deploy/env-variables): What you can override
 - [Custom Domains](/deploy/custom-domains): Point your own domain at the deployment
-- [MCP Server Reference](/ai-tools/mcp-server-spec): All 16 MCP tools
+- [MCP Server Reference](/ai-tools/mcp-server-spec): Full MCP tool reference
 - [Rollback a Deployment](/deploy/rollback): Revert to a previous version

--- a/src/content/docs/guides/deploy-nextjs.mdx
+++ b/src/content/docs/guides/deploy-nextjs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy a Next.js App
-description: The easiest way to deploy a Next.js app with auth and a database. One command. Live in 60 seconds.
+description: The easiest way to deploy a Next.js app with a database. One command. Live in 60 seconds.
 ---
 
 import { Steps, Tabs, TabItem, Aside, Card, CardGrid } from '@astrojs/starlight/components';
@@ -13,7 +13,7 @@ import PageMeta from '../../../components/PageMeta.astro';
   stability="stable"
 />
 
-Deploy a production Next.js app with authentication, a database, and a live URL in under 60 seconds. No server configuration, no environment variable setup, no infrastructure decisions.
+Deploy a production Next.js app with a database and a live URL in under 60 seconds. No server configuration, no environment variable setup, no infrastructure decisions.
 
 <CardGrid>
   <Card title="Zero configuration" icon="rocket">

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Varity Documentation
-description: Deploy any Node or Python app, AI agent, or LLM in 60 seconds. 60-80% cheaper than Vercel, Render, or Railway. Auth, database, and hosting configured automatically.
+description: Deploy any Node or Python app, AI agent, or LLM in 60 seconds. 60-80% cheaper than Vercel, Render, or Railway. Database and hosting configured automatically.
 template: splash
 hero:
   tagline: "Deploy any Node or Python app, AI agent, or LLM in 60 seconds. 60-80% cheaper than Vercel, Render, or Railway."

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -83,7 +83,7 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
     Efficient distributed infrastructure passes savings directly to you. Use the [cost calculator](/resources/pricing) to estimate your app.
   </Card>
   <Card title="Zero configuration" icon="puzzle">
-    Auth, database, and hosting are configured automatically. Varity detects what your app needs and sets it up.
+    Database and hosting are configured automatically. Varity detects what your app needs and sets it up.
   </Card>
   <Card title="Works with AI coding tools" icon="laptop">
     Install the MCP server in Claude Code or Cursor. Ask your AI editor to deploy your app. Done.

--- a/src/content/docs/resources/faq.mdx
+++ b/src/content/docs/resources/faq.mdx
@@ -97,7 +97,7 @@ No special knowledge required for users.
 
 ### Do I need to set up authentication myself?
 
-No. Varity authentication is configured automatically when you deploy. You do not import an SDK or wire up an auth provider. Varity supplies the credentials and your users can log in immediately.
+Varity deploy handles hosting and infrastructure setup automatically. Authentication behavior is controlled by your application stack and the auth provider or framework you choose.
 
 ### What user data can I access?
 

--- a/src/content/docs/resources/faq.mdx
+++ b/src/content/docs/resources/faq.mdx
@@ -87,26 +87,13 @@ Your app is hosted on Varity's infrastructure with global CDN delivery and autom
 
 ## Authentication
 
-### How do users log in?
+### Does Varity handle user login for my app?
 
-Users can log in with:
-- Email (magic link -- no password needed)
-- Google, Twitter, Discord, GitHub
+No. Varity deploys your app exactly as you built it. Authentication is whatever your application implements: use any auth library or provider that runs in a Node or Python app (for example NextAuth, Clerk, or Auth0). Varity does not add or manage an end-user identity layer.
 
-No special knowledge required for users.
+### Do I need to change my auth code to deploy?
 
-### Do I need to set up authentication myself?
-
-Varity deploy handles hosting and infrastructure setup automatically. Authentication behavior is controlled by your application stack and the auth provider or framework you choose.
-
-### What user data can I access?
-
-- Email address
-- Display name
-- Profile picture (from social login)
-- Linked accounts (Google, Twitter, etc.)
-
-This data is available to your deployed app through the auth session.
+No. Your existing auth works as-is. Set any secrets your provider needs as environment variables. See [Environment Variables](/deploy/env-variables).
 
 ## Costs and Pricing
 
@@ -131,7 +118,7 @@ No. Cancel anytime. No minimums, no lock-in, no exit fees.
 **No.** Varity abstracts all infrastructure complexity:
 - You deploy with one command
 - No servers, Docker, or DevOps to manage
-- Auth and databases are configured automatically when detected
+- Databases are configured automatically when detected
 - Your app code stays unchanged
 
 Infrastructure complexity is abstracted. You use deploy commands and app-level settings.

--- a/src/content/docs/resources/faq.mdx
+++ b/src/content/docs/resources/faq.mdx
@@ -33,7 +33,6 @@ Varity is an AI-native cloud platform focused on deployment. The two core packag
 
 Yes. Varity uses:
 - Encryption for sensitive data in transit and at rest
-- Replicated storage across multiple regions
 - Automatic SSL on every deployment
 
 ### What frameworks are supported?
@@ -42,10 +41,13 @@ Yes. Varity uses:
 - Next.js 13+ (App Router)
 - React (Vite or Create React App)
 - Vue 3+
+- Astro
+- Qwik
+- Vite SPA
 - Node.js backends (Express, Fastify, Nest, Koa, Hono)
 - Python backends (FastAPI, Django, Flask)
 
-**Not yet supported:** Go, Rust, Ruby, Elixir, Java, PHP, .NET. Deploying these will fail with an unsupported-language error. [Request framework support](https://github.com/varity-labs).
+**Not yet supported:** Go, Rust, Ruby / Rails, Elixir / Phoenix, Java / Spring, Deno, PHP / Laravel, .NET. Deploying these will fail with an unsupported-language error. [Request framework support](https://github.com/varity-labs).
 
 ## Deployment
 
@@ -81,7 +83,7 @@ This creates a new deployment with your previous configuration.
 
 ### Where is my app hosted?
 
-Your app is hosted on Varity's secure, distributed infrastructure with global CDN delivery. Files are replicated across multiple regions for reliability.
+Your app is hosted on Varity's infrastructure with global CDN delivery and automatic SSL.
 
 ## Authentication
 

--- a/src/content/docs/resources/glossary.mdx
+++ b/src/content/docs/resources/glossary.mdx
@@ -69,24 +69,6 @@ The Varity MCP (Model Context Protocol) server gives AI coding tools like Claude
 
 See [MCP Server](/ai-tools/mcp-server-spec).
 
-## Authentication Terms
-
-### Email Login
-
-A login method where users enter their email address and receive a one-time login link. No password required.
-
-**Equivalent:** The same as magic link login in Notion, Slack, or Linear.
-
-### Session
-
-A temporary authentication state. Created when users log in, expires when they log out.
-
-**Equivalent:** Standard browser session.
-
-### Social Login
-
-Logging in with an existing account from Google, GitHub, Discord, or Apple. Varity handles the integration automatically.
-
 ## Development Terms
 
 ### CLI (varitykit)

--- a/src/content/docs/resources/glossary.mdx
+++ b/src/content/docs/resources/glossary.mdx
@@ -9,7 +9,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="April 2026"
+  lastUpdated="May 2026"
   stability="stable"
 />
 
@@ -19,7 +19,7 @@ A guide to terms used in Varity documentation.
 
 ### App
 
-A web application deployed on Varity. Each app gets a public URL at `https://varity.app/{name}/` and a unique deployment ID.
+A web application deployed on Varity. Static apps get a URL at `https://varity.app/{name}/`, dynamic apps get `https://{name}.varity.app/`, and each deployment has a unique deployment ID.
 
 ### Deploy Key
 

--- a/src/content/docs/resources/pricing.mdx
+++ b/src/content/docs/resources/pricing.mdx
@@ -27,7 +27,7 @@ This means traffic volatility affects competitor bills much more than Varity bil
 Use the live pricing endpoint backing the portal and MCP calculator:
 
 ```bash
-curl "https://varity.app/api/pricing?profile=web-app-db&has_db=true"
+curl "https://varity.app/api/pricing?profile=web-app&has_db=true"
 ```
 
 You can also use:

--- a/src/content/docs/resources/troubleshooting.mdx
+++ b/src/content/docs/resources/troubleshooting.mdx
@@ -103,7 +103,7 @@ Possible causes and solutions:
 
 ### Login not working on the deployed app
 
-Authentication is configured automatically when you deploy. If sign-in is not working:
+Varity deploys your app as-is and does not manage authentication. Sign-in is handled by whatever auth library or provider your app uses, so debug it the same way you would locally:
 
 <Steps>
 
@@ -112,9 +112,9 @@ Authentication is configured automatically when you deploy. If sign-in is not wo
    varitykit app status
    ```
 
-2. Check browser console for errors on your live URL
+2. Check the browser console for errors on your live URL
 
-3. If you set a custom auth App ID via `NEXT_PUBLIC_VARITY_AUTH_APP_ID`, confirm it is set correctly in your environment variables
+3. Confirm any secrets your auth provider needs (API keys, client IDs, callback URLs) are set as environment variables. See [Environment Variables](/deploy/env-variables).
 
 </Steps>
 

--- a/src/content/docs/tutorials/build-with-ai.mdx
+++ b/src/content/docs/tutorials/build-with-ai.mdx
@@ -217,7 +217,7 @@ Here is what you accomplished, without writing any code yourself:
 
 1. ✅ **Built a production app**: Authentication, database, dashboard
 2. ✅ **Added a custom data model**: Invoices with create, read, update, and delete
-3. ✅ **Deployed to production**: Live URL with auth and database configured automatically
+3. ✅ **Deployed to production**: Live URL with database and hosting configured automatically
 4. ✅ **Verified deployment status**: URL, framework, and runtime are visible in status output
 
 **Total time:** 10-15 minutes  

--- a/src/content/docs/tutorials/build-with-ai.mdx
+++ b/src/content/docs/tutorials/build-with-ai.mdx
@@ -22,7 +22,7 @@ The entire workflow takes 10-15 minutes and costs 60-80% less than Vercel, Rende
 ## What You'll Build
 
 A client invoicing dashboard with:
-- User authentication (email + social login, configured automatically)
+- User authentication (implemented in your app, deployed as-is)
 - Database for storing invoices (auto-wired on deploy)
 - CRUD operations (create, read, update, delete)
 - Production hosting at a live URL

--- a/src/content/docs/tutorials/deploy-ai-agent.mdx
+++ b/src/content/docs/tutorials/deploy-ai-agent.mdx
@@ -21,7 +21,7 @@ If your agent uses a local language model (via the `ollama` package), Varity det
 
 ## Prerequisites
 
-- Python 3.8+ and Node.js 20+
+- Python 3.8+ or Node.js 20+
 - `varitykit` CLI installed:
 
   ```bash

--- a/src/content/docs/tutorials/deploy-ai-agent.mdx
+++ b/src/content/docs/tutorials/deploy-ai-agent.mdx
@@ -9,7 +9,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="April 2026"
+  lastUpdated="May 2026"
   stability="stable"
 />
 
@@ -21,7 +21,7 @@ If your agent uses a local language model (via the `ollama` package), Varity det
 
 ## Prerequisites
 
-- Python 3.8+ or Node.js 20+
+- Python 3.8+ and Node.js 20+
 - `varitykit` CLI installed:
 
   ```bash


### PR DESCRIPTION
## Summary
Launch-readiness accuracy pass on docs.varity.so. Removes claims for features that are **not shipped**, so a user never reads a promise Varity can't deliver. Two layers:

1. **Autonomous docs-sync agent sweep** (hardened spec, varity-ops#86): removed `auto-scaling` + `99.9% uptime guaranteed` + `multi-region replication`; fixed deploy-URL static-subpath vs dynamic-subdomain site-wide; removed the misleading `VARITY_CUSTOM_DOMAIN` example; corrected the pricing API param (`web-app-db` → `web-app&has_db=true`); expanded the not-supported framework list; dropped the wrong "16 MCP tools" count and internal-gated `varity_add_collection` from public listings; narrowed migration to Vercel-only.

2. **Verified-merge gate (Claude Code review)** caught a systemic miss: **managed end-user authentication (email/social login)** was documented as a shipped feature (whole `managed-credentials` page, an "Authentication" service card, glossary entries, ~14 references). It's the dormant SDK vision, **not shipped** — removed everywhere. Also dropped a README "payments automatically" claim + the residual "high availability" wording, reverted a wrong Python/Node "and"→"or", corrected the README doc-structure block + sidecar list (added MySQL).

## Ground truth verified against
`project_detector.py` (frameworks), `deployment_orchestrator.py` (deploy URLs), `PRICING-MODEL-CANONICAL.md` (cost), published `@varity-labs/mcp` beta.24 (tool roster), `varity.manifest.yaml`. Only real shipped capabilities remain.

## Test plan
- [x] `pnpm build` passes (40 pages, no errors)
- [x] Repo scan clean: no auth-as-a-service / payments / multi-region / auto-scaling / 99.9% / AWS / em-dash claims
- [ ] Founder final review of rendered content