### PR TITLE
fix(docs): editLink → master (fixes 404 Edit links)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -37,7 +37,7 @@ export default defineConfig({
         },
       ],
       editLink: {
-        baseUrl: "https://github.com/varity-labs/varity-docs/edit/main/",
+        baseUrl: "https://github.com/varity-labs/varity-docs/edit/master/",
       },
       components: {
         ContentPanel: './src/components/overrides/ContentPanel.astro',


### PR DESCRIPTION
## What
The Starlight `editLink.baseUrl` pointed at `/edit/main/`, but this repo's default branch is `master` (no `main` exists). Every "Edit page" link on docs.varity.so currently 404s. Fixed to `/edit/master/`.

## Verify
Found while extending security work (Lane R). Confirmed via `git ls-remote` that only `master` exists. After merge, the "Edit page" link on any docs page should resolve to the GitHub editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)