### PR TITLE
docs(security): add SECURITY.md (Lane R, security Wave 1)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+We take the security of Varity and our users seriously.
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+- **Email:** security@varity.so
+- **Do not** open a public issue for security vulnerabilities.
+
+Please include enough detail to reproduce the issue. We aim to acknowledge your
+report within 48 hours and will keep you informed as we work on a fix. We target
+a fix within 7 days for critical vulnerabilities.
+
+We appreciate the security community's help in keeping Varity and our users safe.
+Please act in good faith, avoid privacy violations and service disruption, and
+give us reasonable time to remediate before any public disclosure.
+
+## More information
+
+For how we protect data, the shared-responsibility model, and our machine-readable
+contact, see <https://www.varity.so/security> and
+<https://www.varity.so/.well-known/security.txt>.


### PR DESCRIPTION
## What
Adds a `SECURITY.md` disclosure policy to the public docs repo (GitHub Security tab + issue auto-link). Points to security@varity.so, mirrors the disclosure terms (48h ack, 7d critical), links to `/security` + `security.txt`. IP-safe.

Part of security Wave 1 (Lane R). Source: `DATA-SECURITY-AND-PRIVACY.md` §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)