### PR TITLE
docs(api): agent-first API reference + machine-readable openapi.yaml & mcp-schema.json

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -236,6 +236,7 @@ export default defineConfig({
               label: "MCP Server (Claude Code / Cursor)",
               slug: "ai-tools/mcp-server-spec",
             },
+            { label: "API Reference", slug: "ai-tools/api-reference" },
             { label: "AI Prompts", slug: "ai-tools/prompts" },
             { label: "CLI (varitykit)", slug: "cli/overview" },
           ],

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -82,6 +82,7 @@ Full docs: https://docs.varity.so
 - Auto-wired Services: https://docs.varity.so/deploy/auto-wired-services/
 - Vercel Migration: https://docs.varity.so/deploy/vercel-migration/
 - MCP Server: https://docs.varity.so/ai-tools/mcp-server-spec/
+- API Reference: https://docs.varity.so/ai-tools/api-reference/
 - Pricing: https://docs.varity.so/resources/pricing/
 - FAQ: https://docs.varity.so/resources/faq/
 - Troubleshooting: https://docs.varity.so/resources/troubleshooting/
@@ -105,7 +106,21 @@ Install for Claude Code:
 claude mcp add varity -- npx -y @varity-labs/mcp
 ```
 
-Core tools: varity_doctor, varity_deploy, varity_deploy_status, varity_deploy_logs, varity_migrate, varity_cost_calculator, varity_search_docs, varity_create_repo, varity_login, varity_install_deps, varity_build, varity_dev_server, varity_open_browser
+Tools (17): varity_doctor, varity_login, varity_search_docs, varity_cost_calculator, varity_install_deps, varity_build, varity_dev_server, varity_open_browser, varity_create_repo, varity_deploy, varity_deploy_status, varity_deploy_logs, varity_delete_deployment, varity_migrate, varity_list_agents, varity_agent_info, varity_deploy_agent
+
+Machine-readable MCP tool schema (exact tools/list from the published package): https://docs.varity.so/mcp-schema.json
+
+## HTTP API
+
+Agents and integrations can deploy and operate apps directly over HTTP. Machine-readable spec: https://docs.varity.so/openapi.yaml — full reference: https://docs.varity.so/ai-tools/api-reference/
+
+- Base URL: https://varity.app
+- Auth: `Authorization: Bearer <deploy-key>` on /v1 endpoints (get a key with `varitykit login`). Pricing + health are public.
+- POST /v1/deploy — start a deploy (body: app_name, source, and one of repo_url or image). Returns { run_id }.
+- GET /v1/deploy/{run_id} — status + result (frontend_url on success; error_message + failure_stage on failure).
+- GET /v1/deploy/{run_id}/logs — SSE stream of deploy progress.
+- DELETE /v1/deployments/{app_name} — stop a deployment and its billing.
+- GET /api/pricing?profile=web — live flat pricing (public).
 
 ## Support
 

--- a/public/mcp-schema.json
+++ b/public/mcp-schema.json
@@ -1,0 +1,553 @@
+{
+  "$schema": "https://modelcontextprotocol.io/schema/2024-11-05/tools-list",
+  "description": "Varity MCP server tool catalog. The canonical machine-readable schema for AI agents and MCP clients. Generated from the published @varity-labs/mcp package (the exact tools an agent receives from tools/list).",
+  "server": {
+    "name": "varity",
+    "package": "@varity-labs/mcp",
+    "version": "2.1.1",
+    "docs": "https://docs.varity.so/ai-tools/mcp-server-spec/",
+    "install": {
+      "claudeCode": "claude mcp add varity -- npx -y @varity-labs/mcp",
+      "cursor": {
+        "mcpServers": {
+          "varity": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@varity-labs/mcp"
+            ]
+          }
+        }
+      },
+      "hostedHttp": "https://mcp.varity.so"
+    },
+    "transports": [
+      "stdio",
+      "http"
+    ]
+  },
+  "toolCount": 17,
+  "tools": [
+    {
+      "name": "varity_search_docs",
+      "title": "Search Varity Docs",
+      "description": "Search the live Varity documentation for how-to guides, getting-started tutorials, deployment, supported stacks, pricing, and troubleshooting. Always reflects the current docs.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search query (e.g., 'deploy a FastAPI app', 'custom domain', 'pricing')"
+          },
+          "maxResults": {
+            "type": "number",
+            "default": 3,
+            "description": "Maximum number of results to return (default: 3)"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_cost_calculator",
+      "title": "Cost Calculator",
+      "description": "Compare a deployment's flat monthly Varity cost against usage-metered hosting (bandwidth + invocations). Varity charges a FLAT hardware-only price that doesn't spike with traffic; usage-metered hosting bills grow as the app scales. Varity's price is fixed and doesn't move as the app grows. Use whenever a developer asks about pricing, cost, hosting bills, traffic costs, or platform comparison. Pass `subdomain` for a specific live deployment's REAL cost, or `app_profile` for a pre-deploy estimate.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "app_profile": {
+            "type": "string",
+            "enum": [
+              "static-site",
+              "web-app",
+              "web-app-db",
+              "ai-agent-cpu",
+              "ai-agent-gpu"
+            ],
+            "default": "web-app",
+            "description": "Pre-deploy estimate preset: static-site (flat $5/mo), web-app, web-app-db, ai-agent-cpu, ai-agent-gpu"
+          },
+          "subdomain": {
+            "type": "string",
+            "description": "A live deployment's subdomain → returns THIS deployment's real cost (overrides app_profile)"
+          },
+          "has_database": {
+            "type": "boolean",
+            "description": "Whether the app uses a database (affects competitor base cost)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_doctor",
+      "title": "Check Environment",
+      "description": "Check if the developer's environment is ready to build and deploy apps with Varity. Verifies Node.js, npm, varitykit CLI, and authentication are properly configured. Run this before varity_deploy to catch missing prerequisites early.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "annotations": {
+        "readOnlyHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_login",
+      "title": "Log in to Varity",
+      "description": "Log in to Varity to enable deployments. Opens the developer portal where you get your deploy key after adding a payment method. If deploy_key is provided, saves it immediately and you can run varity_deploy right away. If omitted, the browser opens to the settings page so you can copy your key.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "deploy_key": {
+            "type": "string",
+            "description": "Your deploy key from the Varity developer portal (developer.store.varity.so/dashboard/settings). If omitted, this tool opens the settings page in your browser, copy your key from there, then call varity_login again with the key."
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_install_deps",
+      "title": "Install Dependencies",
+      "description": "Install npm dependencies in a Varity project. Use after creating a project or when adding new packages.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Project directory to install dependencies in (default: current directory)"
+          },
+          "packages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Specific packages to install (e.g., ['axios', 'lodash']). If omitted, runs npm install for all dependencies."
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "destructiveHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_build",
+      "title": "Build Project",
+      "description": "Build the project for production. Auto-detects framework from package.json. Run before deploying or to verify the project compiles.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Path to the project directory (default: current directory)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "destructiveHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_open_browser",
+      "title": "Open in Browser",
+      "description": "Open a URL in the user's default browser. Use after deploying to show the live app or after starting the dev server.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to open in the default browser"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_dev_server",
+      "title": "Development Server",
+      "description": "Start, stop, or check the local development server. Returns the localhost URL for previewing the app.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "start",
+              "stop",
+              "status"
+            ],
+            "description": "Action to perform: start, stop, or check status of the dev server"
+          },
+          "path": {
+            "type": "string",
+            "description": "Project directory (default: current working directory)"
+          },
+          "port": {
+            "type": "number",
+            "default": 3000,
+            "description": "Port to run the dev server on (default: 3000). If this port is busy, the server auto-selects the next available port and persists it to varity.config.json so future starts use the same port automatically. You can also set this explicitly (e.g. port: 3031) to always start on a specific port."
+          }
+        },
+        "required": [
+          "action"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_create_repo",
+      "title": "Create GitHub Repository",
+      "description": "Create a new GitHub repository and push your local project to it. Pass the 'path' parameter with the local project directory — this creates an empty repo and pushes your actual code to GitHub. The GitHub URL is required for dynamic deployments, so call this before varity_deploy when you have code locally but no repo yet. Requires a GitHub personal access token (classic) with repo scope from https://github.com/settings/tokens.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "^[a-z0-9-]+$",
+            "description": "Repository name (lowercase, hyphens allowed, e.g. 'my-app')"
+          },
+          "description": {
+            "type": "string",
+            "description": "Short description of your app (optional)"
+          },
+          "path": {
+            "type": "string",
+            "description": "Absolute path to the local project directory to push to GitHub (e.g. '/home/user/my-app'). Pushes the actual project code. Required for apps that will use varity_deploy with dynamic hosting."
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "public",
+              "private"
+            ],
+            "default": "public",
+            "description": "Repository visibility"
+          },
+          "github_token": {
+            "type": "string",
+            "description": "GitHub personal access token (optional if GITHUB_TOKEN env var is set). Needs 'repo' scope."
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "destructiveHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_deploy",
+      "title": "Deploy to Production",
+      "description": "Deploy the current project to production on Varity. Detects the framework, selects the right hosting, and ships it live at https://varity.app/<name>/. Zero configuration required. Flat hardware-reserved pricing — your bill stays the same as your app grows. No usage-based billing, no surprise overages. Use this when a developer wants to deploy, publish, ship, or make their app live. If the developer wants to deploy a curated AI agent (Telegram bot, chat UI, etc.) rather than their own code, use varity_deploy_agent instead. To stop a deployment and its billing, use varity_delete_deployment.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Absolute path to the project directory (e.g. '/home/user/my-app'). IMPORTANT: always pass the full absolute path to the project root, the directory that contains package.json and varity.config.json. If omitted, the MCP server's working directory is used (which is rarely the correct project root). Pass the absolute path to the project root (the directory that contains package.json)."
+          },
+          "repo_url": {
+            "type": "string",
+            "description": "GitHub repository URL for the app (e.g. 'https://github.com/user/my-app'). Required for dynamic deployments. If omitted, auto-detected from .git/config. Use the repo_url returned by varity_create_repo as the value here."
+          },
+          "app_name": {
+            "type": "string",
+            "description": "Custom app name that controls the deployment URL: https://varity.app/{app_name}/. Must be URL-safe (lowercase letters, numbers, hyphens). If omitted, the project directory name is used. Use a different app_name than the directory to create named environments (staging, canary, etc.)."
+          },
+          "image": {
+            "type": "string",
+            "description": "Deploy a prebuilt Docker/OCI image directly (e.g. 'ghcr.io/you/app:latest') instead of building from source. Use when the developer has a container image rather than a repo/project. Mutually exclusive with repo_url."
+          },
+          "image_credentials": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string",
+                "description": "registry host, e.g. ghcr.io or docker.io"
+              },
+              "username": {
+                "type": "string"
+              },
+              "password": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "host",
+              "username",
+              "password"
+            ],
+            "additionalProperties": false,
+            "description": "Pull credentials for a PRIVATE image registry. Omit for public images."
+          },
+          "port": {
+            "type": "integer",
+            "description": "Container listen port for an --image deploy (default 80)."
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "destructiveHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_deploy_status",
+      "title": "Deployment Status",
+      "description": "List deployments or get status of a specific deployment. Shows URL, status, framework, size, and creation time. Use this when a developer asks about their deployments, wants to check status, or needs to find a deployment URL.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "deployment_id": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_-]+$",
+            "description": "Specific deployment ID to check (optional, omit to list recent)"
+          },
+          "path": {
+            "type": "string",
+            "description": "Project directory path, only show deployments for this project"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "default": 10,
+            "description": "Maximum number of deployments to return (default: 10, max: 50)"
+          }
+        },
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_deploy_logs",
+      "title": "Deployment Info & Logs",
+      "description": "Get build logs or deployment summary for a specific deployment. When full build logs exist (captured during varity_deploy or varity_build), returns the actual log lines. When only the deployment record exists, returns a structured summary receipt: URL, status, build size, build time, and a debug_tip pointing to varity_build for detailed output. Use this to get the live URL, check status, or confirm build metrics for a deployment. For detailed build error output (TypeScript errors, module-not-found, etc.), use varity_build, it captures the full compilation log with exact file/line numbers.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "deployment_id": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_-]+$",
+            "description": "The deployment ID to get logs for"
+          },
+          "limit": {
+            "type": "number",
+            "default": 100,
+            "description": "Maximum number of log lines to return (default: 100)"
+          }
+        },
+        "required": [
+          "deployment_id"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "readOnlyHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_delete_deployment",
+      "title": "Delete a Deployment and Stop Its Billing",
+      "description": "Delete an existing Varity deployment by name and stop its billing immediately. Use this when a developer says 'stop my <name>', 'shut down my deployment', 'I'm done with <name>', 'delete <name>', or when they no longer need a running app or agent. This shuts down the running app and releases its reserved hardware, so charges stop accruing right away. Static (CDN-hosted) deployments also stop being billed after delete. Use varity_deploy_status or list deployments at https://varity.app/dashboard to confirm the name first if the developer is unsure.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The subdomain / app name of the deployment to delete. This is the slug in https://varity.app/<name>/. Example: 'my-hermes-bot' or 'mvp-static-test'."
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_list_agents",
+      "title": "List Available AI Agent Templates",
+      "description": "List the curated AI agent templates Varity can deploy with one command. Available agents: hermes (Telegram bot, ~$16/mo), openclaw (Claude-compatible chat, ~$38/mo), agent-zero (general-purpose, zero config, ~$14/mo), autoresearch (GPU CUDA workstation, ~$280/mo), eliza-venice (Twitter automation, ~$168/mo). Use this when a developer asks 'what AI agents can I deploy?' or wants to compare options. Returns name, description, estimated monthly cost, required environment variables, exposed ports, and resource footprint. After picking one, deploy with varity_deploy_agent.",
+      "inputSchema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {}
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_agent_info",
+      "title": "Show AI Agent Template Details",
+      "description": "Show full details for a single AI agent template: image, ports, resources, required and optional environment variables, estimated monthly cost, access mode (web/SSH/Telegram), and operator notes. Use this when the developer has picked an agent (or is comparing 2-3) and wants to know exactly what they'll need to provide before deploying. Pass the agent slug from varity_list_agents (one of: hermes, openclaw, agent-zero, autoresearch, eliza-venice).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "hermes",
+              "openclaw",
+              "agent-zero",
+              "autoresearch",
+              "eliza-venice"
+            ],
+            "description": "The agent slug. One of: hermes, openclaw, agent-zero, autoresearch, eliza-venice."
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_deploy_agent",
+      "title": "Deploy an AI Agent Template",
+      "description": "Deploy a curated AI agent from one of the 5 templates (hermes, openclaw, agent-zero, autoresearch, eliza-venice), accessible at https://varity.app/<your-name>/. Use this when the developer says 'deploy hermes', 'I want a Telegram bot', 'spin up agent-zero', or similar. Required environment variables (which the developer provides via the `env` parameter) vary per agent, call varity_agent_info first to see what's needed. Pass `name` to give the deployment a memorable URL slug. Use varity_delete_deployment to stop the deployment and its billing later.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "agent": {
+            "type": "string",
+            "enum": [
+              "hermes",
+              "openclaw",
+              "agent-zero",
+              "autoresearch",
+              "eliza-venice"
+            ],
+            "description": "The agent slug. One of: hermes, openclaw, agent-zero, autoresearch, eliza-venice. Run varity_list_agents to see all options."
+          },
+          "name": {
+            "type": "string",
+            "description": "Memorable name for this deployment. Becomes the URL slug at varity.app/<name>/. Defaults to <agent>-<random> if omitted."
+          },
+          "env": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Environment variables to pass to the agent container, as a key-value object. Pass everything from the agent's required_env list (call varity_agent_info to see which). Example for hermes: { OPENAI_API_KEY: 'sk-...', TELEGRAM_BOT_TOKEN: '...', TELEGRAM_ALLOWED_USERS: '123,456' }"
+          }
+        },
+        "required": [
+          "agent"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_migrate",
+      "title": "Migrate from Vercel to Varity",
+      "description": "Migrate a Vercel project to Varity in one step: clones the GitHub repository, removes Vercel-specific artifacts (vercel.json, @vercel/* packages, image optimizer config, env var renames), and deploys the transformed app to Varity infrastructure. Returns a live deployment URL and a migration report. Works with Next.js projects. Use this when a developer wants to move their Vercel app to Varity.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "github_url": {
+            "type": "string",
+            "description": "GitHub repository URL to migrate (e.g. 'https://github.com/user/my-vercel-app'). The repository will be cloned to a temporary directory, transformed, and deployed."
+          },
+          "dry_run": {
+            "type": "boolean",
+            "default": false,
+            "description": "If true, show what would change without deploying. Useful for previewing migration impact."
+          }
+        },
+        "required": [
+          "github_url"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "annotations": {
+        "destructiveHint": true
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    }
+  ]
+}

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -1,0 +1,397 @@
+openapi: 3.0.3
+info:
+  title: Varity HTTP API
+  description: >
+    The public, agent-facing HTTP contract for Varity. AI agents, CLIs, and integrators
+    call these endpoints to deploy a project, poll its status, stream deploy logs, stop a
+    deployment, and read live pricing. This is the same stable `/v1` contract the
+    `varitykit` CLI and `@varity-labs/mcp` server use under the hood — point your agent at
+    it directly, or use the MCP server (see https://docs.varity.so/ai-tools/mcp-server-spec/).
+
+
+    Most agents should prefer the MCP tools (`varity_deploy`, `varity_deploy_status`,
+    `varity_deploy_logs`, `varity_delete_deployment`) — they wrap this API and handle
+    framework detection, auth, and result parsing. The raw HTTP API below is for direct
+    integrations.
+
+
+    Scope note: this spec documents only the endpoints intended for external/agent use.
+    Internal control-plane routes (identity callbacks, billing, the deployment registry,
+    telemetry ingest, and infrastructure plumbing) are intentionally not part of this
+    public contract and may change without notice.
+  version: 1.0.0
+servers:
+  - url: https://varity.app
+    description: Production API (the Varity gateway)
+tags:
+  - name: Deploy
+    description: Create, monitor, and stop deployments.
+  - name: Pricing
+    description: Read live, flat per-app pricing.
+  - name: Service
+    description: Service health.
+paths:
+  /v1/deploy:
+    post:
+      operationId: createDeploy
+      tags: [Deploy]
+      summary: Start a deploy
+      description: >
+        Deploy a project from a GitHub repo (`repo_url`) or a prebuilt Docker/OCI image
+        (`image`). The framework, hosting mode (static vs dynamic), and any backend
+        services your code needs (Postgres, Redis, MongoDB, MySQL, Ollama) are detected
+        and configured automatically. Returns immediately with a `run_id`; poll
+        `GET /v1/deploy/{run_id}` for status and stream `GET /v1/deploy/{run_id}/logs` for
+        progress. Exactly one of `repo_url` or `image` must be supplied.
+      security:
+        - deployKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeployRequest'
+      responses:
+        '202':
+          description: Deploy run accepted and queued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeployAccepted'
+        '400':
+          description: Invalid request (neither or both of repo_url/image supplied, or a bad manifest).
+        '401':
+          description: Missing or invalid deploy key.
+  /v1/deploy/{run_id}:
+    get:
+      operationId: getDeploy
+      tags: [Deploy]
+      summary: Get deploy status and result
+      description: >
+        Returns the current status of a deploy run and, once it reaches a terminal state,
+        the result (live URL, deployment id, selected hardware, and — on failure — a
+        redacted reason and failure stage).
+      security:
+        - deployKey: []
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          description: The `run_id` returned by POST /v1/deploy.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Current status and (when terminal) the result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeployStatus'
+        '401':
+          description: Missing or invalid deploy key.
+        '404':
+          description: Unknown run_id.
+  /v1/deploy/{run_id}/logs:
+    get:
+      operationId: getDeployLogs
+      tags: [Deploy]
+      summary: Stream deploy logs (Server-Sent Events)
+      description: >
+        Server-Sent Events stream of deploy progress (detect → build → bid → lease →
+        health → done) for the run. Each event is a `data:` line; the stream terminates
+        when the run reaches a terminal status. Note: this streams deploy-time progress,
+        not the running container's runtime stdout/stderr.
+      security:
+        - deployKey: []
+      parameters:
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: text/event-stream of log lines.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: "SSE-framed log lines, each as a data: event."
+        '401':
+          description: Missing or invalid deploy key.
+        '404':
+          description: Unknown run_id.
+  /v1/deployments/{subdomain}:
+    delete:
+      operationId: deleteDeployment
+      tags: [Deploy]
+      summary: Stop a deployment and its billing
+      description: >
+        Permanently stops the deployment identified by its app name (subdomain) and ends
+        its billing. This frees the reserved hardware; the app stops serving immediately.
+      security:
+        - deployKey: []
+      parameters:
+        - name: subdomain
+          in: path
+          required: true
+          description: The app name (the `{name}` in https://varity.app/{name}/).
+          schema:
+            type: string
+            pattern: '^[a-z0-9-]{1,63}$'
+      responses:
+        '200':
+          description: Deployment stopped.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean }
+                  deleted: { type: boolean }
+                  subdomain: { type: string }
+                  appName: { type: string }
+        '401':
+          description: Missing or invalid deploy key.
+        '403':
+          description: The deploy key does not own this deployment.
+        '404':
+          description: Unknown deployment.
+  /api/pricing:
+    get:
+      operationId: getPricing
+      tags: [Pricing]
+      summary: Get live flat per-app pricing
+      description: >
+        Returns Varity's flat monthly price for a workload profile (or an existing app)
+        plus a comparison against usage-metered hosts. Public — no authentication required.
+        Pricing is a flat hardware reservation; it does not change with traffic, bandwidth,
+        invocations, or build minutes.
+      parameters:
+        - name: profile
+          in: query
+          required: false
+          description: A workload profile to price (e.g. `static`, `web`, `agent`, `gpu`).
+          schema:
+            type: string
+        - name: subdomain
+          in: query
+          required: false
+          description: Price an existing deployed app by name instead of a profile.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Pricing for the requested profile or app.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pricing'
+        '404':
+          description: Unknown app/profile.
+  /health:
+    get:
+      operationId: getHealth
+      tags: [Service]
+      summary: Service health
+      description: Liveness check for the Varity API. Public — no authentication required.
+      responses:
+        '200':
+          description: Service is healthy.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string, example: healthy }
+                  service: { type: string, example: varity-gateway }
+                  version: { type: string }
+components:
+  securitySchemes:
+    deployKey:
+      type: http
+      scheme: bearer
+      description: >
+        Your Varity deploy key, sent as `Authorization: Bearer <key>`. Obtain it by running
+        `varitykit login` (the CLI stores it and sends it for you). Required on all `/v1`
+        deploy endpoints.
+  schemas:
+    DeployRequest:
+      type: object
+      description: >
+        The deploy manifest. Exactly one of `repo_url` or `image` is required. Resource
+        fields (`port`, `cpu_units`, `memory_mb`, `storage_mb`) apply to the Docker/OCI
+        image path; for repo builds, hosting and size are decided automatically.
+      properties:
+        app_name:
+          type: string
+          pattern: '^[a-z0-9-]{1,63}$'
+          description: Deployment / subdomain name. Controls the URL https://varity.app/{app_name}/.
+        source:
+          type: string
+          enum: [cli, portal, mcp, sandbox, staging]
+          description: Which client originated the deploy (used for telemetry).
+        repo_url:
+          type: string
+          description: GitHub https repo URL (alternative to a prebuilt `image`).
+        commit:
+          type: string
+          maxLength: 64
+          default: HEAD
+          description: Commit/ref to build. SHA or simple ref.
+        framework:
+          type: string
+          description: Optional framework override; auto-detected if omitted.
+        hosting:
+          type: string
+          enum: [static, dynamic]
+          description: Optional hosting-mode override; auto-decided if omitted.
+        services:
+          type: array
+          items:
+            type: string
+            enum: [postgres, redis, ollama, mongodb, mysql, minio]
+          description: >
+            Backend services to attach. Normally inferred from your dependencies
+            (e.g. `pg` → Postgres, `redis` → Redis); set explicitly to override.
+        env_vars:
+          type: object
+          additionalProperties:
+            type: string
+          description: >
+            Build/runtime environment variables. Values may reference auto-attached service
+            env as ${KEY} (e.g. MONGO_URI=${MONGODB_URI}).
+        package_manager:
+          type: string
+          enum: [npm, yarn, pnpm]
+          description: Optional package manager for Node projects; auto-detected if omitted.
+        python_start_command:
+          type: string
+          maxLength: 512
+          description: Optional start command for Python apps; derived from the framework if omitted.
+        image:
+          type: string
+          maxLength: 512
+          description: >
+            OCI image ref for a direct Docker-image deploy (alternative to `repo_url`).
+            Bare Docker Hub refs are normalized (e.g. "nginx:alpine" →
+            "docker.io/library/nginx:alpine").
+        image_credentials:
+          $ref: '#/components/schemas/ImageCredentials'
+        port:
+          type: integer
+          minimum: 1
+          maximum: 65535
+          description: Container listen port for an image deploy (default 80).
+        cpu_units:
+          type: number
+          minimum: 0.25
+          maximum: 4
+          description: Reserved CPU units — image/prebuilt paths only (default 0.5).
+        memory_mb:
+          type: integer
+          minimum: 256
+          maximum: 8192
+          description: Reserved memory in MiB — image/prebuilt paths only (default 512).
+        storage_mb:
+          type: integer
+          minimum: 512
+          maximum: 20480
+          description: Reserved storage in MiB — image/prebuilt paths only (default 1024).
+      required: [app_name, source]
+    ImageCredentials:
+      type: object
+      description: Pull credentials for a PRIVATE registry image. Omit for a public image.
+      properties:
+        host:
+          type: string
+          maxLength: 255
+          description: Bare registry host, e.g. ghcr.io / docker.io.
+        username:
+          type: string
+          maxLength: 255
+        password:
+          type: string
+          description: Write-only; never returned or logged.
+      required: [host, username, password]
+    DeployAccepted:
+      type: object
+      properties:
+        run_id:
+          type: string
+          description: Opaque id for polling status and streaming logs.
+      required: [run_id]
+    DeployStatus:
+      type: object
+      properties:
+        run_id:
+          type: string
+        status:
+          type: string
+          enum: [queued, running, succeeded, failed]
+        stage:
+          type: string
+          nullable: true
+          enum: [detect, build, bid, lease, health, done, failed]
+          description: Where the run is right now (progress). Null until the first stage-bearing log line.
+        deployment_id:
+          type: string
+          nullable: true
+          description: Stable deployment id once the app is live.
+        frontend_url:
+          type: string
+          nullable: true
+          description: Live URL of the deployed app.
+        memory_mb:
+          type: integer
+          nullable: true
+        error_message:
+          type: string
+          nullable: true
+          description: Redacted, bounded reason the run failed; null on success.
+        failure_stage:
+          type: string
+          nullable: true
+          enum:
+            - repo_access
+            - framework_detection
+            - build_execution
+            - ipfs_upload
+            - sdl_submission
+            - bid_collection
+            - lease_acceptance
+            - container_health
+            - gateway_registration
+            - orchestration
+      required: [run_id, status]
+    Pricing:
+      type: object
+      description: >
+        Live pricing for a profile or app. Field set is additive and may grow; the stable
+        fields are `varityMonthly` (flat USD/month) and `varityIsFlat` (always true).
+      properties:
+        profile:
+          type: string
+          nullable: true
+        subdomain:
+          type: string
+          nullable: true
+        varityMonthly:
+          type: number
+          description: Flat monthly price in USD.
+        varityIsFlat:
+          type: boolean
+          description: Always true — the bill does not change with usage.
+        mode:
+          type: string
+          enum: [static, dynamic]
+        competitors:
+          type: array
+          description: Usage-metered comparison points.
+          items:
+            type: object
+            properties:
+              id: { type: string }
+              label: { type: string }
+              atLaunch: { type: number }
+              atTraction: { type: number }

--- a/src/content/docs/ai-tools/api-reference.mdx
+++ b/src/content/docs/ai-tools/api-reference.mdx
@@ -1,0 +1,169 @@
+---
+title: API Reference
+description: The agent-facing Varity HTTP API and MCP tool schemas. Deploy, monitor, stream logs, and stop apps programmatically — with machine-readable openapi.yaml and mcp-schema.json.
+---
+
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import PageMeta from '../../../components/PageMeta.astro';
+
+<PageMeta
+  author="Varity Team"
+  authorRole="Core Contributors"
+  lastUpdated="June 2026"
+  stability="stable"
+/>
+
+Varity is built to be driven by AI agents. There are two equivalent ways to deploy and operate apps programmatically, and both are published as machine-readable schemas:
+
+| Surface | Best for | Schema |
+|---------|----------|--------|
+| **MCP tools** | Agents inside an AI editor (Claude Code, Cursor, Windsurf, VS Code) | [`/mcp-schema.json`](/mcp-schema.json) |
+| **HTTP API** | Direct integrations, custom agents, backend services | [`/openapi.yaml`](/openapi.yaml) |
+
+<Aside type="tip">
+If your agent runs inside an AI editor, prefer the [MCP server](/ai-tools/mcp-server-spec/) — `varity_deploy`, `varity_deploy_status`, `varity_deploy_logs`, and `varity_delete_deployment` wrap the HTTP API and handle auth, framework detection, and result parsing for you. The raw HTTP API below is for everything else.
+</Aside>
+
+## Machine-readable schemas
+
+Point your tooling directly at these URLs — they are generated from the shipped code, so they never drift from reality:
+
+- **`https://docs.varity.so/openapi.yaml`** — the public HTTP API (OpenAPI 3.0). Import into Postman, an OpenAPI client generator, or an agent's tool layer.
+- **`https://docs.varity.so/mcp-schema.json`** — the exact `tools/list` catalog the released `@varity-labs/mcp` package serves, including every tool's JSON Schema and annotations.
+
+## Base URL & authentication
+
+All HTTP API calls go to:
+
+```
+https://varity.app
+```
+
+The `/v1` deploy endpoints require your **deploy key**, sent as a bearer token:
+
+```
+Authorization: Bearer <your-deploy-key>
+```
+
+Get a deploy key by running `varitykit login` (the CLI stores and sends it for you) or from the developer portal at `developer.store.varity.so/dashboard/settings`. The pricing and health endpoints are public and need no auth.
+
+## The operate loop
+
+The full lifecycle is four calls: **deploy → poll status → stream logs → stop**.
+
+### 1. Deploy
+
+`POST /v1/deploy` — deploy from a GitHub repo or a prebuilt image. Returns a `run_id` immediately. Exactly one of `repo_url` or `image` is required.
+
+<Tabs>
+  <TabItem label="From a repo">
+    ```bash
+    curl -X POST https://varity.app/v1/deploy \
+      -H "Authorization: Bearer $VARITY_DEPLOY_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "app_name": "my-app",
+        "source": "cli",
+        "repo_url": "https://github.com/me/my-app"
+      }'
+    # → { "run_id": "..." }
+    ```
+  </TabItem>
+  <TabItem label="From an image">
+    ```bash
+    curl -X POST https://varity.app/v1/deploy \
+      -H "Authorization: Bearer $VARITY_DEPLOY_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "app_name": "my-api",
+        "source": "cli",
+        "image": "ghcr.io/me/my-api:latest",
+        "port": 8080
+      }'
+    ```
+  </TabItem>
+  <TabItem label="Private image">
+    ```bash
+    curl -X POST https://varity.app/v1/deploy \
+      -H "Authorization: Bearer $VARITY_DEPLOY_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "app_name": "my-api",
+        "source": "cli",
+        "image": "ghcr.io/me/private-api:latest",
+        "port": 8080,
+        "image_credentials": {
+          "host": "ghcr.io",
+          "username": "me",
+          "password": "<token>"
+        }
+      }'
+    ```
+  </TabItem>
+</Tabs>
+
+The framework, static-vs-dynamic hosting, and any backend services (Postgres, Redis, MongoDB, MySQL, Ollama) are detected and configured automatically — normally from your dependencies. See [Auto-wired Services](/deploy/auto-wired-services/).
+
+### 2. Poll status
+
+`GET /v1/deploy/{run_id}` — returns the run's `status` (`queued` → `running` → `succeeded` / `failed`), the current `stage`, and on success the live `frontend_url`. On failure it returns a redacted `error_message` and a `failure_stage`.
+
+```bash
+curl https://varity.app/v1/deploy/$RUN_ID \
+  -H "Authorization: Bearer $VARITY_DEPLOY_KEY"
+# → { "run_id": "...", "status": "succeeded", "frontend_url": "https://varity.app/my-app/", ... }
+```
+
+### 3. Stream logs
+
+`GET /v1/deploy/{run_id}/logs` — a Server-Sent Events stream of deploy progress (`detect → build → bid → lease → health → done`). The stream ends when the run reaches a terminal status.
+
+```bash
+curl -N https://varity.app/v1/deploy/$RUN_ID/logs \
+  -H "Authorization: Bearer $VARITY_DEPLOY_KEY"
+```
+
+<Aside type="note">
+This streams **deploy-time** progress, not the running container's runtime stdout/stderr.
+</Aside>
+
+### 4. Stop (and stop billing)
+
+`DELETE /v1/deployments/{app_name}` — permanently stops the app and ends its billing, freeing the reserved hardware.
+
+```bash
+curl -X DELETE https://varity.app/v1/deployments/my-app \
+  -H "Authorization: Bearer $VARITY_DEPLOY_KEY"
+```
+
+## Pricing (public)
+
+`GET /api/pricing?profile=<profile>` returns the flat monthly price for a workload profile plus a comparison against usage-metered hosts. No auth required.
+
+```bash
+curl "https://varity.app/api/pricing?profile=web"
+# → { "profile": "web", "varityMonthly": 6, "varityIsFlat": true, ... }
+```
+
+Pricing is a flat hardware reservation — it does not change with traffic, bandwidth, invocations, or build minutes.
+
+## Endpoint summary
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| `POST` | `/v1/deploy` | deploy key | Start a deploy |
+| `GET` | `/v1/deploy/{run_id}` | deploy key | Get status + result |
+| `GET` | `/v1/deploy/{run_id}/logs` | deploy key | Stream deploy logs (SSE) |
+| `DELETE` | `/v1/deployments/{app_name}` | deploy key | Stop a deployment + billing |
+| `GET` | `/api/pricing` | public | Live flat pricing |
+| `GET` | `/health` | public | Service health |
+
+<Aside type="caution">
+This is the complete public, agent-facing surface. Internal control-plane routes (identity, billing, the deployment registry, telemetry, and infrastructure plumbing) are intentionally not part of this contract and may change without notice.
+</Aside>
+
+## Next steps
+
+- **[MCP Server Spec](/ai-tools/mcp-server-spec/)** — the full tool reference for AI editors
+- **[Deploy a Docker Image](/deploy/deploy-docker-image/)** — image-deploy details
+- **[Auto-wired Services](/deploy/auto-wired-services/)** — how databases and caches get attached

--- a/src/content/docs/ai-tools/mcp-server-spec.mdx
+++ b/src/content/docs/ai-tools/mcp-server-spec.mdx
@@ -19,6 +19,10 @@ The Varity MCP server (`@varity-labs/mcp`) gives AI editors a full set of tools 
 The MCP server works with **any editor that supports MCP**: Cursor, Claude Code, VS Code (Copilot), Windsurf, and more. Setup takes under a minute.
 </Aside>
 
+<Aside type="note">
+**Machine-readable schema.** The exact tool catalog an agent receives from `tools/list` is published at [`/mcp-schema.json`](/mcp-schema.json) — generated directly from the released `@varity-labs/mcp` package, so it is always the source of truth. The HTTP API the tools wrap is published as [`/openapi.yaml`](/openapi.yaml). See the [API Reference](/ai-tools/api-reference/) for both.
+</Aside>
+
 ## Prerequisites
 
 - **Node.js 20+** (runs the MCP server)
@@ -101,14 +105,11 @@ Verify that your development environment is ready to build and deploy Varity app
 
 ### `varity_login`: Authenticate with Varity
 
-Authenticate with Varity using a deploy key or browser-based login. Required before deploying apps.
+Log in to Varity to enable deployments. If a `deploy_key` is provided, it is saved to local config; otherwise the tool opens the developer portal where you add a payment method and copy your deploy key. Required before deploying apps.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `method` | `"deploy-key"` \| `"browser"` | No | `"browser"` | Authentication method |
-| `deploy_key` | string | No | none | Deploy key (required when `method` is `"deploy-key"`) |
-
-**Annotations:** `destructiveHint: true` (writes credentials to local config)
+| `deploy_key` | string | No | none | Your deploy key from the developer portal (`developer.store.varity.so/dashboard/settings`). If omitted, opens the portal to get one. |
 
 **Example prompt:** "Log in to Varity" or "Authenticate with my deploy key"
 
@@ -205,8 +206,9 @@ Create a new GitHub repository and push your project to it. Useful for getting y
 |-----------|------|----------|---------|-------------|
 | `name` | string | Yes | none | Repository name (lowercase, hyphens allowed) |
 | `description` | string | No | none | Short description for the repo |
+| `path` | string | No | Current directory | Absolute path to the local project to push (e.g. `/home/user/my-app`) |
 | `visibility` | `"public"` \| `"private"` | No | `"public"` | Repository visibility |
-| `github_token` | string | No | none | GitHub personal access token with `repo` scope |
+| `github_token` | string | No | none | GitHub personal access token with `repo` scope (or set `GITHUB_TOKEN`) |
 
 **Annotations:** `destructiveHint: true` (creates an external GitHub repository)
 
@@ -216,25 +218,32 @@ Create a new GitHub repository and push your project to it. Useful for getting y
 
 ### `varity_deploy`: Deploy to production
 
-Build and deploy the current project. Auto-detects framework (Next.js, React, Vue), builds it, and returns a live URL.
+Deploy the current project to production. Detects the framework, selects static vs dynamic hosting, auto-configures any backend services your code needs, and returns a live URL at `https://varity.app/<name>/`. Deploy from source (a project path or a GitHub repo) or from a prebuilt Docker/OCI image.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `path` | string | No | Workspace root | Path to the project directory |
+| `path` | string | No | MCP working dir | Absolute path to the project root (the directory with `package.json`). |
+| `repo_url` | string | No | auto-detected | GitHub repo URL. Required for dynamic deployments; auto-detected from `.git/config` if omitted. |
+| `app_name` | string | No | directory name | URL-safe name controlling the URL `https://varity.app/{app_name}/`. |
+| `image` | string | No | none | Deploy a prebuilt Docker/OCI image (e.g. `ghcr.io/you/app:latest`) instead of building. Mutually exclusive with `repo_url`. |
+| `image_credentials` | object | No | none | `{ host, username, password }` pull credentials for a **private** registry image. Omit for public images. |
+| `port` | integer | No | `80` | Container listen port for an `image` deploy. |
 
 **Annotations:** `destructiveHint: true` (deploys real infrastructure)
 
-**Example prompt:** "Deploy this project to Varity"
+**Example prompt:** "Deploy this project to Varity" or "Deploy the image ghcr.io/me/api:latest on port 8080"
 
 ---
 
 ### `varity_deploy_status`: Check deployments
 
-List all deployments or get status of a specific one. Shows URL, status, framework, size, and creation time.
+List deployments or get the status of a specific one. Shows URL, status, framework, size, and creation time.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `deployment_id` | string | No | none | Specific deployment ID (omit to list all) |
+| `deployment_id` | string | No | none | Specific deployment ID (omit to list recent) |
+| `path` | string | No | none | Project directory — only show deployments for this project |
+| `limit` | integer | No | 10 | Maximum deployments to return (max 50) |
 
 **Annotations:** `readOnlyHint: true`
 
@@ -259,15 +268,15 @@ Get build and deployment logs for debugging failed or recent deployments.
 
 ### `varity_delete_deployment`: Tear down a deployment
 
-Permanently remove a deployment and free its resources. Use when you no longer need an app you deployed.
+Permanently remove a deployment by its app name and stop its billing immediately. Use when you no longer need an app you deployed.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `deployment_id` | string | Yes | none | The deployment ID to delete |
+| `name` | string | Yes | none | The app name / subdomain — the `<name>` in `https://varity.app/<name>/` |
 
 **Annotations:** `destructiveHint: true` (tears down live infrastructure)
 
-**Example prompt:** "Delete the deployment abc123"
+**Example prompt:** "Stop my hermes-bot deployment" or "Delete the app my-dashboard"
 
 ---
 
@@ -283,6 +292,46 @@ Migrate a Vercel project to Varity in one step: clone the GitHub repository, rem
 **Annotations:** `destructiveHint: true` (clones a repo and deploys infrastructure)
 
 **Example prompt:** "Migrate my Vercel app at https://github.com/user/my-app to Varity"
+
+---
+
+### `varity_list_agents`: List curated AI agent templates
+
+List the curated AI agent templates Varity can deploy with one command (for example: a Telegram bot, a Claude-compatible chat UI, an autonomous research agent). Each entry includes a slug and an estimated monthly cost.
+
+*No parameters required.*
+
+**Annotations:** `readOnlyHint` not set (no side effects)
+
+**Example prompt:** "What AI agents can I deploy on Varity?"
+
+---
+
+### `varity_agent_info`: Get details for one agent template
+
+Show full details for a single agent template: image, ports, resources, required and optional environment variables, estimated monthly cost, and access mode.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | string | Yes | none | The agent slug (run `varity_list_agents` to see valid values) |
+
+**Example prompt:** "What env vars does the hermes agent need?"
+
+---
+
+### `varity_deploy_agent`: Deploy a curated AI agent
+
+Deploy a curated AI agent template in one command, live at `https://varity.app/<name>/`. Use this when the developer wants a ready-made agent rather than deploying their own code.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `agent` | string | Yes | none | The agent slug to deploy (run `varity_list_agents` for options) |
+| `name` | string | No | `<agent>-<random>` | Memorable name; becomes the URL slug at `varity.app/<name>/` |
+| `env` | object | No | none | Environment variables for the agent container (pass the agent's required env from `varity_agent_info`) |
+
+**Annotations:** `destructiveHint: true` (deploys real infrastructure)
+
+**Example prompt:** "Deploy the hermes Telegram bot with my bot token"
 
 ---
 
@@ -330,6 +379,13 @@ Here is the practical build-and-deploy flow using the MCP tools:
 1. **"Check if my environment is ready"** → `varity_doctor`
 2. **"Migrate my Vercel app at https://github.com/user/my-app"** → `varity_migrate`
 3. *(Done. The app is live on Varity infrastructure.)*
+
+**Deploying a curated AI agent:**
+
+1. **"What agents can I deploy?"** → `varity_list_agents`
+2. **"What does the hermes agent need?"** → `varity_agent_info`
+3. **"Deploy hermes with my bot token"** → `varity_deploy_agent`
+4. **"Did it come up?"** → `varity_deploy_status`
 
 ## Troubleshooting
 

--- a/src/content/docs/ai-tools/overview.mdx
+++ b/src/content/docs/ai-tools/overview.mdx
@@ -26,6 +26,11 @@ Varity is built to be driven from your AI coding tool. Add the MCP server once, 
   <Card title="LLM-Optimized Docs" icon="open-book">
     Machine-readable documentation for AI assistants. Available in two formats: `/llms.txt` (summary) and `/llms-full.txt` (detailed).
   </Card>
+  <Card title="API Reference" icon="document">
+    Deploy and operate apps programmatically. Machine-readable [`/openapi.yaml`](/openapi.yaml) (HTTP API) and [`/mcp-schema.json`](/mcp-schema.json) (MCP tools).
+
+    [View API Reference →](/ai-tools/api-reference)
+  </Card>
 </CardGrid>
 
 ## Quick Start: MCP Server


### PR DESCRIPTION
**Lane U** — agent-first API documentation. Publishes the agent-facing API surface to docs.varity.so so the OpenAPI spec and MCP schemas *are* the agent's docs (and are true).

## What's added
- **`public/openapi.yaml`** — published OpenAPI 3.0 for the public `/v1` deploy contract (deploy / status / SSE logs / stop) plus public reads (`/api/pricing`, `/health`). Grounded in the real 34 gateway routes; the internal control-plane routes (Privy identity, Stripe billing, the deployment registry, telemetry ingest, provider/akash internals) are **intentionally excluded** — public-safe per `POSITIONING.md`. Verified live: `/v1/*` → 401 unauth, `/api/pricing` → 200.
- **`public/mcp-schema.json`** — the exact `tools/list` catalog (17 tools) introspected from the **published `@varity-labs/mcp` 2.1.1** package. Machine-readable MCP contract.
- **`ai-tools/api-reference.mdx`** — new page documenting the deploy/operate loop in both HTTP and MCP, linking the two schemas. Added to the sidebar.
- **`ai-tools/mcp-server-spec.mdx`** — reconciled with the real schema (it had drifted): fixed `varity_login` (removed a nonexistent `method` param), `varity_delete_deployment` (`deployment_id` → `name`), `varity_deploy` (added `repo_url`/`app_name`/`image`/`image_credentials`/`port`); **added the 3 agent tools** (`varity_list_agents`, `varity_agent_info`, `varity_deploy_agent`) that were undocumented.
- **`llms.txt`** — added the HTTP API + machine-readable schema links; corrected the tool list (17).

## Verification
- `npm run build` green (47 pages); `openapi.yaml` validates (swagger-cli); `mcp-schema.json` valid JSON (17 tools).
- All new internal links + artifacts resolve in `dist/`.
- Positioning test: **no new violations** (the 10 pre-existing `VAR-389`/`VAR-506` warnings are on untouched files).
- New page cloak-rendered locally — title, surface table, tabbed operate-loop code, endpoint summary all render; zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)