### PR TITLE
docs: document S3-compatible object storage auto-wired sidecar (MinIO)

### DIFF
--- a/src/content/docs/ai-tools/api-reference.mdx
+++ b/src/content/docs/ai-tools/api-reference.mdx
@@ -102,7 +102,7 @@ The full lifecycle is four calls: **deploy → poll status → stream logs → s
   </TabItem>
 </Tabs>
 
-The framework, static-vs-dynamic hosting, and any backend services (Postgres, Redis, MongoDB, MySQL, Ollama) are detected and configured automatically — normally from your dependencies. See [Auto-wired Services](/deploy/auto-wired-services/).
+The framework, static-vs-dynamic hosting, and any backend services (Postgres, Redis, MongoDB, MySQL, Ollama, S3-compatible object storage) are detected and configured automatically — normally from your dependencies. See [Auto-wired Services](/deploy/auto-wired-services/).
 
 ### 2. Poll status
 

--- a/src/content/docs/deploy/auto-wired-services.mdx
+++ b/src/content/docs/deploy/auto-wired-services.mdx
@@ -47,6 +47,7 @@ You do not configure ports, credentials, or connection strings. Varity handles a
 | `mongodb` | MongoDB database | `MONGODB_URI` |
 | `mysql` | MySQL database | `MYSQL_URL` |
 | `mysql2` | MySQL database | `MYSQL_URL` |
+| `@aws-sdk/client-s3` | Object storage (S3-compatible) | `MINIO_URL`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY` |
 
 ### Python (requirements.txt)
 
@@ -60,6 +61,8 @@ You do not configure ports, credentials, or connection strings. Varity handles a
 | `ollama` | AI model server | `OLLAMA_URL` |
 | `pymongo` | MongoDB database | `MONGODB_URI` |
 | `pymysql` | MySQL database | `MYSQL_URL` |
+| `boto3` | Object storage (S3-compatible) | `MINIO_URL`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY` |
+| `minio` | Object storage (S3-compatible) | `MINIO_URL`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY` |
 
 ### Prisma Schema Detection
 
@@ -101,6 +104,12 @@ If your project includes a `prisma/schema.prisma` file, Varity reads the `dataso
     A relational database for apps and frameworks that expect MySQL. Auto-provisioned alongside your app when a MySQL client is in your dependencies.
 
     Your app receives `MYSQL_URL` automatically.
+  </Card>
+
+  <Card title="Object Storage" icon="open-book">
+    An S3-compatible object store for files, uploads, and assets. Use it with the AWS S3 SDK or any MinIO client — no separate bucket to provision. Auto-wired when your dependencies include an S3 client (`@aws-sdk/client-s3`, `boto3`, or `minio`).
+
+    Your app receives `MINIO_URL`, `MINIO_ACCESS_KEY`, and `MINIO_SECRET_KEY` automatically.
   </Card>
 </CardGrid>
 
@@ -166,6 +175,20 @@ import os
 from motor.motor_asyncio import AsyncIOMotorClient
 
 client = AsyncIOMotorClient(os.environ["MONGODB_URI"])
+```
+
+The object store speaks the S3 protocol, so point any S3 client at the injected endpoint and credentials:
+
+```python title="Object storage (boto3)"
+import os
+import boto3
+
+s3 = boto3.client(
+    "s3",
+    endpoint_url=os.environ["MINIO_URL"],
+    aws_access_key_id=os.environ["MINIO_ACCESS_KEY"],
+    aws_secret_access_key=os.environ["MINIO_SECRET_KEY"],
+)
 ```
 
 You do not need to add these variables to `.env` files yourself. Varity injects them at deploy time.

--- a/src/content/docs/deploy/databases.mdx
+++ b/src/content/docs/deploy/databases.mdx
@@ -34,7 +34,7 @@ Varity detects these from your dependencies and provisions them alongside your a
   </Card>
 </CardGrid>
 
-Varity also provisions an **Ollama** model server (`OLLAMA_URL`) when your app uses one. Detection and the full env-var list are covered in [Auto-wired Services](/deploy/auto-wired-services/).
+Varity also provisions an **Ollama** model server (`OLLAMA_URL`) and an **S3-compatible object store** (`MINIO_URL`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`) when your app uses one. Detection and the full env-var list are covered in [Auto-wired Services](/deploy/auto-wired-services/).
 
 Your app reads these from its environment — no connection strings to manage:
 

--- a/src/content/docs/deploy/intelligent-orchestration.mdx
+++ b/src/content/docs/deploy/intelligent-orchestration.mdx
@@ -183,7 +183,7 @@ When you deploy, Varity automatically handles:
 - ✅ App URL and routing (`varity.app/<your-app>/` for static, `<your-app>.varity.app/` for dynamic)
 - ✅ Global CDN for static assets
 - ✅ Managed hosting defaults
-- ✅ Sidecars: Postgres+pgvector, Redis, MongoDB, MySQL, Ollama (when detected in your config)
+- ✅ Sidecars: Postgres+pgvector, Redis, MongoDB, MySQL, Ollama, S3-compatible object storage (when detected in your config)
 
 **Not yet supported:** Go, Rust, Ruby / Rails, Elixir / Phoenix, Java / Spring, Deno, PHP / Laravel, .NET. Deploying these source stacks returns a clear unsupported-language error with a feature-request link. (You can still deploy any of these by providing a prebuilt Docker image.) [Request support for your framework](https://github.com/varity-labs).
 

--- a/src/content/docs/deploy/what-you-can-deploy.mdx
+++ b/src/content/docs/deploy/what-you-can-deploy.mdx
@@ -34,7 +34,7 @@ Varity is a newly launched platform in active beta. This page is the honest snap
 
 See [Supported Frameworks](/deploy/supported-frameworks/) for the full detection matrix.
 
-**Auto-wired services** (provisioned in the same deployment when your code needs them): Postgres (with pgvector), Redis, MongoDB, MySQL, and Ollama. See [Auto-wired Services](/deploy/auto-wired-services/).
+**Auto-wired services** (provisioned in the same deployment when your code needs them): Postgres (with pgvector), Redis, MongoDB, MySQL, Ollama, and S3-compatible object storage. See [Auto-wired Services](/deploy/auto-wired-services/).
 
 **Where your app lives:**
 - Static sites → `https://varity.app/<your-app>/`

--- a/src/content/docs/getting-started/how-varity-works.mdx
+++ b/src/content/docs/getting-started/how-varity-works.mdx
@@ -105,6 +105,7 @@ When you deploy, Varity inspects your project and makes all infrastructure decis
 | `mongoose`, `mongodb`, `pymongo` | MongoDB |
 | `mysql`, `mysql2`, `PyMySQL` | MySQL database |
 | `@langchain/ollama`, `ollama` | Ollama AI runtime |
+| `@aws-sdk/client-s3`, `boto3`, `minio` | S3-compatible object storage |
 
 You do not write connection strings or provision databases. Varity handles it.
 


### PR DESCRIPTION
## What

Object storage (S3-compatible / MinIO) shipped 2026-06-23 via the `has_minio` dependency signal (Lane V) but was documented nowhere. This brings docs.varity.so current with shipped state — Lane DOCS scope.

## Grounded against code (deploy-api)
- **Detector** (`detector.py` `detect_dependency_signals`): `has_minio = _any("minio", "boto3", "@aws-sdk/client-s3")`
- **SDL injection** (`sdl.py`): `MINIO_URL=http://minio:9000`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`
- Heavy sizing signal alongside `has_ollama`

## Changes (docs-only, surgical)
- `deploy/auto-wired-services`: JS + Python detection tables, an Object Storage service card, a boto3 usage snippet
- Added object storage to every other sidecar enumeration: `databases`, `what-you-can-deploy`, `intelligent-orchestration`, `getting-started/how-varity-works`, `ai-tools/api-reference`

## Verify
- `astro build` clean (47 pages); MinIO content confirmed present in built HTML across all 5 pages.
- Merge→master auto-propagates to docs.varity.so via Bunny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)