### PR TITLE
docs(api): keep agent docs current — /v1 operate endpoints + MCP 2.2.0 (Lane APIDOCS)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -106,7 +106,7 @@ Install for Claude Code:
 claude mcp add varity -- npx -y @varity-labs/mcp
 ```
 
-Tools (17): varity_doctor, varity_login, varity_search_docs, varity_cost_calculator, varity_install_deps, varity_build, varity_dev_server, varity_open_browser, varity_create_repo, varity_deploy, varity_deploy_status, varity_deploy_logs, varity_delete_deployment, varity_migrate, varity_list_agents, varity_agent_info, varity_deploy_agent
+Tools (19): varity_doctor, varity_login, varity_search_docs, varity_cost_calculator, varity_install_deps, varity_build, varity_dev_server, varity_open_browser, varity_create_repo, varity_deploy, varity_deploy_status, varity_deploy_logs, varity_set_env, varity_redeploy, varity_delete_deployment, varity_migrate, varity_list_agents, varity_agent_info, varity_deploy_agent
 
 Machine-readable MCP tool schema (exact tools/list from the published package): https://docs.varity.so/mcp-schema.json
 
@@ -119,6 +119,8 @@ Agents and integrations can deploy and operate apps directly over HTTP. Machine-
 - POST /v1/deploy — start a deploy (body: app_name, source, and one of repo_url or image). Returns { run_id }.
 - GET /v1/deploy/{run_id} — status + result (frontend_url on success; error_message + failure_stage on failure).
 - GET /v1/deploy/{run_id}/logs — SSE stream of deploy progress.
+- PUT /v1/deployments/{app_name}/env — set/update env vars (body: envVars map, optional replace) and redeploy in place.
+- POST /v1/deployments/{app_name}/redeploy — redeploy/restart an existing app in place (same URL, no new bid).
 - DELETE /v1/deployments/{app_name} — stop a deployment and its billing.
 - GET /api/pricing?profile=web — live flat pricing (public).
 

--- a/public/mcp-schema.json
+++ b/public/mcp-schema.json
@@ -4,7 +4,7 @@
   "server": {
     "name": "varity",
     "package": "@varity-labs/mcp",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "docs": "https://docs.varity.so/ai-tools/mcp-server-spec/",
     "install": {
       "claudeCode": "claude mcp add varity -- npx -y @varity-labs/mcp",
@@ -26,7 +26,7 @@
       "http"
     ]
   },
-  "toolCount": 17,
+  "toolCount": 19,
   "tools": [
     {
       "name": "varity_search_docs",
@@ -338,6 +338,14 @@
           "port": {
             "type": "integer",
             "description": "Container listen port for an --image deploy (default 80)."
+          },
+          "volume_size": {
+            "type": "integer",
+            "description": "Persistent volume size in GB for the app container (survives restart/redeploy). Use for stateful apps (databases, n8n, Ghost, etc.). Requires volume_path."
+          },
+          "volume_path": {
+            "type": "string",
+            "description": "Absolute container path to mount the persistent volume (e.g. '/data', '/home/node/.n8n'). Requires volume_size."
           }
         },
         "additionalProperties": false,
@@ -425,6 +433,62 @@
           "name": {
             "type": "string",
             "description": "The subdomain / app name of the deployment to delete. This is the slug in https://varity.app/<name>/. Example: 'my-hermes-bot' or 'mvp-static-test'."
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_set_env",
+      "title": "Set Environment Variables on an Existing Deployment",
+      "description": "Set or update environment variables (config + secrets) on an app that is ALREADY deployed, then redeploy it in place. Use this when a developer says 'add an env var to <name>', 'change the API key on <name>', 'set DATABASE_URL on my app', or 'update the config and redeploy'. The variables are applied to the SAME deployment — same URL, same reserved hardware, no new bid — so the change goes live in about a minute with no downtime churn. By default the new variables are MERGED over the existing set; pass replace=true to overwrite the entire set. Variable values are write-only and are never echoed back. To create a NEW deployment instead, use varity_deploy.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The subdomain / app name of the existing deployment to update, the slug in https://varity.app/<name>/. Example: 'my-api'."
+          },
+          "env": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Environment variables to set as a map of NAME to value, e.g. { \"DATABASE_URL\": \"postgres://...\", \"FEATURE_X\": \"on\" }. Names must be UPPER_SNAKE_CASE."
+          },
+          "replace": {
+            "type": "boolean",
+            "description": "When true, replace the entire variable set with `env` instead of merging it over the current set. Default false (merge)."
+          }
+        },
+        "required": [
+          "name",
+          "env"
+        ],
+        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      },
+      "execution": {
+        "taskSupport": "forbidden"
+      }
+    },
+    {
+      "name": "varity_redeploy",
+      "title": "Redeploy or Restart an Existing Deployment In Place",
+      "description": "Redeploy or restart an app that is ALREADY deployed, in place. Use this when a developer says 'redeploy <name>', 'restart <name>', 'my app is stuck — restart it', or 'pull the latest image and redeploy'. The app is re-deployed on the SAME deployment — same URL, same reserved hardware, no new bid — re-pulling the image (or rebuilding from source) and restarting the container, so it goes live in about a minute with no URL change. To change env vars at the same time, use varity_set_env. To create a NEW deployment instead, use varity_deploy.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The subdomain / app name of the existing deployment to redeploy, the slug in https://varity.app/<name>/. Example: 'my-api'."
           }
         },
         "required": [

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -3,8 +3,9 @@ info:
   title: Varity HTTP API
   description: >
     The public, agent-facing HTTP contract for Varity. AI agents, CLIs, and integrators
-    call these endpoints to deploy a project, poll its status, stream deploy logs, stop a
-    deployment, and read live pricing. This is the same stable `/v1` contract the
+    call these endpoints to deploy a project, poll its status, stream deploy logs, update
+    its environment variables, redeploy it in place, stop a deployment, and read live
+    pricing. This is the same stable `/v1` contract the
     `varitykit` CLI and `@varity-labs/mcp` server use under the hood — point your agent at
     it directly, or use the MCP server (see https://docs.varity.so/ai-tools/mcp-server-spec/).
 
@@ -19,7 +20,7 @@ info:
     Internal control-plane routes (identity callbacks, billing, the deployment registry,
     telemetry ingest, and infrastructure plumbing) are intentionally not part of this
     public contract and may change without notice.
-  version: 1.0.0
+  version: 1.1.0
 servers:
   - url: https://varity.app
     description: Production API (the Varity gateway)
@@ -151,6 +152,87 @@ paths:
                   deleted: { type: boolean }
                   subdomain: { type: string }
                   appName: { type: string }
+        '401':
+          description: Missing or invalid deploy key.
+        '403':
+          description: The deploy key does not own this deployment.
+        '404':
+          description: Unknown deployment.
+  /v1/deployments/{subdomain}/env:
+    put:
+      operationId: setDeploymentEnv
+      tags: [Deploy]
+      summary: Set environment variables and redeploy in place
+      description: >
+        Set or update environment variables on an existing deployment, then redeploy it in
+        place — same URL, same reserved hardware, no new bid. By default the supplied
+        variables are merged over the current set; pass `replace: true` to overwrite the
+        entire set. Values are write-only and are never returned. The change goes live in
+        about a minute with no URL change.
+      security:
+        - deployKey: []
+      parameters:
+        - name: subdomain
+          in: path
+          required: true
+          description: The app name (the `{name}` in https://varity.app/{name}/).
+          schema:
+            type: string
+            pattern: '^[a-z0-9-]{1,63}$'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                envVars:
+                  type: object
+                  additionalProperties:
+                    type: string
+                  description: Environment variables to set, as a map of UPPER_SNAKE_CASE name to value.
+                replace:
+                  type: boolean
+                  default: false
+                  description: When true, replace the entire variable set instead of merging.
+              required: [envVars]
+      responses:
+        '200':
+          description: Variables applied; redeploy of the same deployment started.
+        '400':
+          description: Missing subdomain or an invalid env map.
+        '401':
+          description: Missing or invalid deploy key.
+        '403':
+          description: The deploy key does not own this deployment.
+        '404':
+          description: Unknown deployment.
+  /v1/deployments/{subdomain}/redeploy:
+    post:
+      operationId: redeployDeployment
+      tags: [Deploy]
+      summary: Redeploy an existing deployment in place
+      description: >
+        Redeploy or restart an existing app in place — re-pulling the image (or rebuilding
+        from source) and restarting the container on the SAME deployment: same URL, same
+        reserved hardware, no new bid. Takes no body and keeps the current environment
+        variables; use PUT `/v1/deployments/{subdomain}/env` to change config at the same
+        time. Goes live in about a minute with no URL change.
+      security:
+        - deployKey: []
+      parameters:
+        - name: subdomain
+          in: path
+          required: true
+          description: The app name (the `{name}` in https://varity.app/{name}/).
+          schema:
+            type: string
+            pattern: '^[a-z0-9-]{1,63}$'
+      responses:
+        '200':
+          description: Redeploy of the same deployment started.
+        '400':
+          description: Missing subdomain.
         '401':
           description: Missing or invalid deploy key.
         '403':

--- a/src/content/docs/ai-tools/api-reference.mdx
+++ b/src/content/docs/ai-tools/api-reference.mdx
@@ -49,7 +49,7 @@ Get a deploy key by running `varitykit login` (the CLI stores and sends it for y
 
 ## The operate loop
 
-The full lifecycle is four calls: **deploy → poll status → stream logs → stop**.
+The full lifecycle: **deploy → poll status → stream logs → update env → redeploy → stop**. Deploy and read the result; operate the live app in place (env, redeploy) without a new bid; stop it when you're done.
 
 ### 1. Deploy
 
@@ -127,7 +127,27 @@ curl -N https://varity.app/v1/deploy/$RUN_ID/logs \
 This streams **deploy-time** progress, not the running container's runtime stdout/stderr.
 </Aside>
 
-### 4. Stop (and stop billing)
+### 4. Update env vars (and redeploy)
+
+`PUT /v1/deployments/{app_name}/env` — set or update environment variables on a live app, then redeploy it **in place**: same URL, same reserved hardware, no new bid. Variables are merged over the current set by default; pass `"replace": true` to overwrite the whole set. Values are write-only and are never returned.
+
+```bash
+curl -X PUT https://varity.app/v1/deployments/my-app/env \
+  -H "Authorization: Bearer $VARITY_DEPLOY_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"envVars": {"DATABASE_URL": "postgres://...", "FEATURE_X": "on"}}'
+```
+
+### 5. Redeploy in place
+
+`POST /v1/deployments/{app_name}/redeploy` — re-pull the image (or rebuild from source) and restart the container on the **same** deployment: same URL, same reserved hardware, no new bid. No body; keeps the current env vars.
+
+```bash
+curl -X POST https://varity.app/v1/deployments/my-app/redeploy \
+  -H "Authorization: Bearer $VARITY_DEPLOY_KEY"
+```
+
+### 6. Stop (and stop billing)
 
 `DELETE /v1/deployments/{app_name}` — permanently stops the app and ends its billing, freeing the reserved hardware.
 
@@ -154,6 +174,8 @@ Pricing is a flat hardware reservation — it does not change with traffic, band
 | `POST` | `/v1/deploy` | deploy key | Start a deploy |
 | `GET` | `/v1/deploy/{run_id}` | deploy key | Get status + result |
 | `GET` | `/v1/deploy/{run_id}/logs` | deploy key | Stream deploy logs (SSE) |
+| `PUT` | `/v1/deployments/{app_name}/env` | deploy key | Set env vars + redeploy in place |
+| `POST` | `/v1/deployments/{app_name}/redeploy` | deploy key | Redeploy/restart in place |
 | `DELETE` | `/v1/deployments/{app_name}` | deploy key | Stop a deployment + billing |
 | `GET` | `/api/pricing` | public | Live flat pricing |
 | `GET` | `/health` | public | Service health |

--- a/src/content/docs/ai-tools/mcp-server-spec.mdx
+++ b/src/content/docs/ai-tools/mcp-server-spec.mdx
@@ -266,6 +266,36 @@ Get build and deployment logs for debugging failed or recent deployments.
 
 ---
 
+### `varity_set_env`: Set env vars on a live app
+
+Set or update environment variables (config + secrets) on an app that is **already deployed**, then redeploy it in place — same URL, same reserved hardware, no new bid, no downtime churn. By default the supplied variables are merged over the current set; pass `replace: true` to overwrite the entire set. Values are write-only and are never echoed back.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | string | Yes | none | The app name / subdomain — the `<name>` in `https://varity.app/<name>/` |
+| `env` | object | Yes | none | Variables to set, as a map of UPPER_SNAKE_CASE name to value |
+| `replace` | boolean | No | `false` | When true, replace the entire variable set instead of merging |
+
+**Annotations:** `destructiveHint: true` (redeploys live infrastructure)
+
+**Example prompt:** "Set DATABASE_URL on my-api and redeploy" or "Rotate the API key on hermes-bot"
+
+---
+
+### `varity_redeploy`: Redeploy an app in place
+
+Redeploy or restart an app that is **already deployed**, in place — re-pulling the image (or rebuilding from source) and restarting the container on the **same** deployment: same URL, same reserved hardware, no new bid. Takes no body and keeps the current environment variables; use `varity_set_env` to change config at the same time.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | string | Yes | none | The app name / subdomain — the `<name>` in `https://varity.app/<name>/` |
+
+**Annotations:** `destructiveHint: true` (restarts live infrastructure)
+
+**Example prompt:** "Redeploy my-api" or "My app is stuck — restart hermes-bot"
+
+---
+
 ### `varity_delete_deployment`: Tear down a deployment
 
 Permanently remove a deployment by its app name and stop its billing immediately. Use when you no longer need an app you deployed.
@@ -372,7 +402,8 @@ Here is the practical build-and-deploy flow using the MCP tools:
 6. **"Deploy this"** → `varity_deploy`
 7. **"Did the deploy succeed?"** → `varity_deploy_status`
 8. **"Show me the build logs"** → `varity_deploy_logs` (if needed)
-9. **"Tear down this deployment"** → `varity_delete_deployment` (when you no longer need it)
+9. **"Update an env var and redeploy"** → `varity_set_env`; **"restart it"** → `varity_redeploy` (operate in place — same URL, no new bid)
+10. **"Tear down this deployment"** → `varity_delete_deployment` (when you no longer need it)
 
 **Migrating from Vercel:**
 


### PR DESCRIPTION
**Lane APIDOCS** — keep-current pass over the agent-first API docs (Lane U / PR #76 was the initial pass). Two drifts since then:

1. The gateway gained two **public deploy-key operate endpoints** (`PUT /v1/deployments/{name}/env`, `POST /v1/deployments/{name}/redeploy`) — both live but undocumented.
2. **`@varity-labs/mcp` shipped 2.2.0** adding `varity_set_env` + `varity_redeploy`; the published machine-readable schema still said 2.1.1 / 17 tools.

## Changes
- **`public/openapi.yaml`** — add the two operate paths (deploy-key auth, full request/response). Verified live (`401` unauth), grounded in the gateway route handlers. `1.0.0 → 1.1.0`.
- **`public/mcp-schema.json`** — regenerated from the **published 2.2.0** `tools/list` (real MCP handshake against the published tarball). `17 → 19` tools, `2.1.1 → 2.2.0`.
- **`mcp-server-spec.mdx`** — document `varity_set_env` + `varity_redeploy`; add an operate step to the workflow.
- **`api-reference.mdx`** — add env + redeploy to the operate loop and endpoint summary.
- **`llms.txt`** — 19 tools; two HTTP operate endpoints.

## Live verification (both operate surfaces)
Deployed `traefik/whoami`, then exercised the new endpoints against the **live** gateway:
- **CLI `varitykit app env`** (→ `PUT /v1/.../env`): pod rolled `app-685886c6c7 → app-5b4fcb6c58`, same URL, stays `200`.
- **MCP `varity_set_env`** (→ `PUT /v1/.../env`): pod rolled `→ app-5df9c6cb78`, same URL, `200`.
- **MCP `varity_redeploy`** (→ `POST /v1/.../redeploy`): success, same URL, stays `200` (identical-spec redeploy = expected k8s no-op roll).
- Cloak-rendered the live URL (real served content via Caddy gateway, zero console errors); lease torn down (`404`).

## Checks
- `npm run build` green (47 pages); `openapi.yaml` structurally valid (swagger-cli); `mcp-schema.json` valid JSON (19 tools).
- Positioning: **no new violations** — the 10 pre-existing `VAR-389`/`VAR-506` are on untouched files (same set noted in #76).

Note (out of lane scope, flagging not fixing): `.github/workflows/test-docs.yml` is scoped to `branches: [main]` while the repo default is `master`, so it does not trigger on master-targeted PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)