### PR TITLE
Close APIDOCS public API reference gate

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,6 +1,3 @@
-# .github/workflows/test-docs.yml
-# Runs the docs tester on every push, PR, and daily schedule.
-
 name: Docs Quality Check
 
 on:
@@ -9,105 +6,71 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    # Run daily at 8am UTC to catch external link rot
     - cron: '0 8 * * *'
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  VARITY_WORKSPACE_ROOT: ${{ github.workspace }}/varity-workspace
 
 jobs:
-  test-docs:
+  docs-quality:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: Checkout docs
         uses: actions/checkout@v4
+        with:
+          path: varity-workspace/varity-docs
+
+      - name: Checkout ops verifier
+        uses: actions/checkout@v4
+        with:
+          repository: varity-labs/varity-ops
+          path: varity-workspace/varity-ops
+
+      - name: Checkout MCP source
+        uses: actions/checkout@v4
+        with:
+          repository: varity-labs/varity-mcp
+          path: varity-workspace/varity-mcp-standalone
+
+      - name: Checkout private SDK source
+        uses: actions/checkout@v4
+        with:
+          repository: Michael-Abril/varity-sdk-private
+          path: varity-workspace/varity-sdk-private
+          token: ${{ secrets.VARITY_PRIVATE_REPO_TOKEN || github.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: npm
+          cache-dependency-path: varity-workspace/varity-docs/package-lock.json
 
-      - name: Install dependencies
+      - name: Install docs dependencies
+        working-directory: ${{ env.VARITY_WORKSPACE_ROOT }}/varity-docs
         run: npm ci
 
-      - name: Run all docs tests
-        run: npm test
-        continue-on-error: true
+      - name: Build docs
+        working-directory: ${{ env.VARITY_WORKSPACE_ROOT }}/varity-docs
+        run: npm run build
 
-      - name: Upload test report
+      - name: Run propagation docs gate
+        working-directory: ${{ env.VARITY_WORKSPACE_ROOT }}/varity-ops/scripts/docs-accuracy
+        env:
+          DOCS_ACCURACY_FAIL_ON: high
+          DOCS_ACCURACY_REPORT_DIR: ${{ runner.temp }}/varity-docs-accuracy
+          VARITY_WORKSPACE_ROOT: ${{ env.VARITY_WORKSPACE_ROOT }}
+        run: node docs-accuracy-gate.mjs
+
+      - name: Upload propagation reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: docs-test-report
-          path: tests/reports/
-
-      - name: Check for critical issues
-        run: |
-          if [ -f tests/reports/*.json ]; then
-            CRITICAL=$(cat tests/reports/*.json | node -e "
-              const fs = require('fs');
-              const data = JSON.parse(fs.readFileSync('/dev/stdin','utf8'));
-              console.log(data.summary.critical);
-            ")
-            if [ "$CRITICAL" -gt 0 ]; then
-              echo "::error::$CRITICAL critical issues found in docs. See test report."
-              exit 1
-            fi
-          fi
-
-      - name: Comment on PR with results
-        if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const reportsDir = 'tests/reports';
-
-            if (!fs.existsSync(reportsDir)) {
-              console.log('No reports directory found');
-              return;
-            }
-
-            const reports = fs.readdirSync(reportsDir).filter(f => f.endsWith('.json'));
-            if (reports.length === 0) {
-              console.log('No report files found');
-              return;
-            }
-
-            const report = JSON.parse(fs.readFileSync(path.join(reportsDir, reports[0]), 'utf8'));
-            const s = report.summary;
-
-            let body = `## 📋 Docs Quality Check\n\n`;
-            body += `| Metric | Count |\n|--------|-------|\n`;
-            body += `| Pages crawled | ${report.pages_crawled} |\n`;
-            body += `| Tests passed | ${s.pass} |\n`;
-            body += `| Critical issues | ${s.critical} |\n`;
-            body += `| High issues | ${s.high} |\n`;
-            body += `| Medium issues | ${s.medium} |\n`;
-            body += `| Low issues | ${s.low} |\n\n`;
-
-            if (s.critical > 0) {
-              body += `### 🚨 Critical Issues\n\n`;
-              report.all_issues.filter(i => i.severity === 'CRITICAL').forEach(i => {
-                body += `- **${i.type}** on ${i.page || 'multiple pages'}: ${i.found || i.word || ''}\n`;
-              });
-              body += `\n`;
-            }
-
-            if (s.high > 0) {
-              body += `### ⚠️ High Issues\n\n`;
-              report.all_issues.filter(i => i.severity === 'HIGH').slice(0, 5).forEach(i => {
-                body += `- **${i.type}** on ${i.page || 'multiple pages'}: ${i.found || i.word || ''}\n`;
-              });
-              if (s.high > 5) body += `- ... and ${s.high - 5} more\n`;
-            }
-
-            body += `\n---\n*Full report available in workflow artifacts*`;
-
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body
-            });
+          name: varity-docs-accuracy-reports
+          path: ${{ runner.temp }}/varity-docs-accuracy/*.json
+          if-no-files-found: warn

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -13,6 +13,10 @@ on:
         description: varity-ops ref to test against
         required: false
         default: master
+      sdk_ref:
+        description: varity-sdk-private ref to test against
+        required: false
+        default: main
 
 permissions:
   contents: read
@@ -58,6 +62,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Michael-Abril/varity-sdk-private
+          ref: ${{ github.event.inputs.sdk_ref || 'main' }}
           path: varity-workspace/varity-sdk-private
           token: ${{ secrets.VARITY_PRIVATE_REPO_TOKEN }}
 

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '0 8 * * *'
   workflow_dispatch:
+    inputs:
+      ops_ref:
+        description: varity-ops ref to test against
+        required: false
+        default: master
 
 permissions:
   contents: read
@@ -29,13 +34,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: varity-labs/varity-ops
+          ref: ${{ github.event.inputs.ops_ref || 'master' }}
           path: varity-workspace/varity-ops
+          token: ${{ secrets.VARITY_PRIVATE_REPO_TOKEN || github.token }}
 
       - name: Checkout MCP source
         uses: actions/checkout@v4
         with:
           repository: varity-labs/varity-mcp
           path: varity-workspace/varity-mcp-standalone
+          token: ${{ secrets.VARITY_PRIVATE_REPO_TOKEN || github.token }}
 
       - name: Checkout private SDK source
         uses: actions/checkout@v4

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -30,27 +30,36 @@ jobs:
         with:
           path: varity-workspace/varity-docs
 
+      - name: Require cross-repo checkout token
+        env:
+          VARITY_PRIVATE_REPO_TOKEN: ${{ secrets.VARITY_PRIVATE_REPO_TOKEN }}
+        run: |
+          if [ -z "$VARITY_PRIVATE_REPO_TOKEN" ]; then
+            echo "::error::Set VARITY_PRIVATE_REPO_TOKEN with read access to varity-ops, varity-mcp, and varity-sdk-private before enabling the full docs propagation gate."
+            exit 1
+          fi
+
       - name: Checkout ops verifier
         uses: actions/checkout@v4
         with:
           repository: varity-labs/varity-ops
           ref: ${{ github.event.inputs.ops_ref || 'master' }}
           path: varity-workspace/varity-ops
-          token: ${{ secrets.VARITY_PRIVATE_REPO_TOKEN || github.token }}
+          token: ${{ secrets.VARITY_PRIVATE_REPO_TOKEN }}
 
       - name: Checkout MCP source
         uses: actions/checkout@v4
         with:
           repository: varity-labs/varity-mcp
           path: varity-workspace/varity-mcp-standalone
-          token: ${{ secrets.VARITY_PRIVATE_REPO_TOKEN || github.token }}
+          token: ${{ secrets.VARITY_PRIVATE_REPO_TOKEN }}
 
       - name: Checkout private SDK source
         uses: actions/checkout@v4
         with:
           repository: Michael-Abril/varity-sdk-private
           path: varity-workspace/varity-sdk-private
-          token: ${{ secrets.VARITY_PRIVATE_REPO_TOKEN || github.token }}
+          token: ${{ secrets.VARITY_PRIVATE_REPO_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -32,174 +32,224 @@ claude mcp add varity -- npx -y @varity-labs/mcp
 - Legacy aliases: `varity_list_agents`, `varity_agent_info`, `varity_deploy_agent`
 
 
-## Varity HTTP API Reference
+## Varity Public API Reference
 
 URL: https://docs.varity.so/ai-tools/api-reference/
-Description: Agent-facing Varity HTTP API and MCP schemas for deploying, monitoring, streaming logs, and stopping apps programmatically.
+Description: Public resource API for deploying and operating apps, templates, pricing, credits, API keys, and webhooks programmatically.
 
-Varity is built to be driven by AI agents. There are two equivalent ways to deploy and operate apps programmatically, and both are published as machine-readable schemas:
+Varity's public API is a resource API for apps, deployments, templates, pricing, credits, API keys, and webhooks. Use it for direct integrations, custom agents, launchpads, internal tools, and backend services that need to deploy or operate Varity apps without the dashboard.
 
-| Surface | Best for | Schema |
-|---------|----------|--------|
-| **MCP tools** | Agents inside an AI editor (Claude Code, Cursor, Windsurf, VS Code) | [`/mcp-schema.json`](/mcp-schema.json) |
-| **HTTP API** | Direct integrations, custom agents, backend services | [`/openapi.yaml`](/openapi.yaml) |
+The machine-readable source is:
 
-If your agent runs inside an AI editor, prefer the [MCP server](/ai-tools/mcp-server-spec/). `varity_deploy`, `varity_deploy_status`, `varity_deploy_logs`, and `varity_delete_deployment` wrap the HTTP API and handle auth, framework detection, and result parsing for you. The raw HTTP API below is for everything else.
+- `https://docs.varity.so/openapi.yaml`
+- `https://varity.app/api/openapi.json`
 
-## Machine-readable schemas
+Older thin-client compatibility routes are not the public resource contract. New direct integrations should use the `/api/*` routes below.
 
-Point your tooling directly at these URLs. They are generated from the shipped code, so they never drift from reality:
+## Base URL And Auth
 
-- **`https://docs.varity.so/openapi.yaml`**: the public HTTP API (OpenAPI 3.0). Import into Postman, an OpenAPI client generator, or an agent's tool layer.
-- **`https://docs.varity.so/mcp-schema.json`**: the machine-readable Varity MCP tool catalog, including each tool's JSON Schema and annotations.
+All public API calls use:
 
-## Base URL & authentication
-
-All HTTP API calls go to:
-
-```
-https://varity.app
+```text
+https://varity.app/api
 ```
 
-The `/v1` deploy endpoints require your **deploy key**, sent as a bearer token:
+For non-browser callers, send your Varity API key as a bearer credential:
 
+```text
+Authorization: Bearer $VARITY_API_KEY
 ```
-Authorization: Bearer <your-deploy-key>
-```
 
-Get a deploy key by running `varitykit login` (the CLI stores and sends it for you) or from the developer portal at `developer.store.varity.so/dashboard/settings`. The pricing and health endpoints are public and need no auth.
+Create API keys in the Developer Portal settings page. API key plaintext is shown once. Listing and revoking keys require an authenticated Developer Portal session; plaintext keys are never returned after creation.
 
-## The operate loop
+## Deploy
 
-The full lifecycle: **deploy → poll status → stream logs → update env → redeploy → stop**. Deploy and read the result; operate the live app in place (env, redeploy) without creating a new deployment; stop it when you're done.
+`POST /api/deployments` creates a deployment from one source: repository, image, or template. Use `Idempotency-Key` on create requests so normal retries and replays cannot create duplicate deployments. Do not fire concurrent create requests with the same idempotency key; atomic concurrent idempotency is a backend hardening follow-up for v1.
 
-### 1. Deploy
-
-`POST /v1/deploy` deploys from a GitHub repo or a prebuilt image. It returns a `run_id` immediately. Exactly one of `repo_url` or `image` is required.
-
-<Tabs>
-
-    ```bash
-    curl -X POST https://varity.app/v1/deploy \
-      -H "Authorization: Bearer $VARITY_DEPLOY_KEY" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "app_name": "my-app",
-        "source": "cli",
-        "repo_url": "https://github.com/me/my-app"
-      }'
-    # → { "run_id": "..." }
-    ```
-
-
-    ```bash
-    curl -X POST https://varity.app/v1/deploy \
-      -H "Authorization: Bearer $VARITY_DEPLOY_KEY" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "app_name": "my-api",
-        "source": "cli",
-        "image": "ghcr.io/me/my-api:latest",
-        "port": 8080
-      }'
-    ```
-
-
-    ```bash
-    curl -X POST https://varity.app/v1/deploy \
-      -H "Authorization: Bearer $VARITY_DEPLOY_KEY" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "app_name": "my-api",
-        "source": "cli",
-        "image": "ghcr.io/me/private-api:latest",
-        "port": 8080,
-        "image_credentials": {
-          "host": "ghcr.io",
-          "username": "me",
-          "password": "<token>"
-        }
-      }'
-    ```
-
-
-The framework, hosting mode, and any backend services (Postgres, Redis, MongoDB, MySQL, Ollama, object storage) are detected and configured automatically, normally from your dependencies. See [Auto-wired Services](/deploy/auto-wired-services/).
-
-### 2. Poll status
-
-`GET /v1/deploy/{run_id}` returns the run's `status` (`queued` → `running` → `succeeded` / `failed`), the current `stage`, and on success the live `frontend_url`. On failure it returns a redacted `error_message` and a `failure_stage`.
+### Repository deploy
 
 ```bash
-curl https://varity.app/v1/deploy/$RUN_ID \
-  -H "Authorization: Bearer $VARITY_DEPLOY_KEY"
-# → { "run_id": "...", "status": "succeeded", "frontend_url": "https://varity.app/my-app/", ... }
-```
-
-### 3. Stream logs
-
-`GET /v1/deploy/{run_id}/logs` returns a Server-Sent Events stream of deploy progress (`detect` → `build` → `package` → `start` → `health` → `done`). The stream ends when the run reaches a terminal status.
-
-```bash
-curl -N https://varity.app/v1/deploy/$RUN_ID/logs \
-  -H "Authorization: Bearer $VARITY_DEPLOY_KEY"
-```
-
-This streams **deploy-time** progress, not the running container's runtime stdout/stderr.
-
-### 4. Update env vars (and redeploy)
-
-`PUT /v1/deployments/{app_name}/env` sets or updates environment variables on a live app, then redeploys it **in place**: same URL and same reserved hardware. Variables are merged over the current set by default; pass `"replace": true` to overwrite the whole set. Values are write-only and are never returned.
-
-```bash
-curl -X PUT https://varity.app/v1/deployments/my-app/env \
-  -H "Authorization: Bearer $VARITY_DEPLOY_KEY" \
+curl -X POST https://varity.app/api/deployments \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"envVars": {"DATABASE_URL": "postgres://...", "FEATURE_X": "on"}}'
+  -H "Idempotency-Key: deploy-my-app-001" \
+  -d '{
+    "name": "my-app",
+    "repository": {
+      "url": "https://github.com/me/my-app"
+    }
+  }'
 ```
 
-### 5. Redeploy in place
-
-`POST /v1/deployments/{app_name}/redeploy` re-pulls the image (or rebuilds from source) and restarts the container on the **same** deployment: same URL and same reserved hardware. No body; keeps the current env vars.
+### Image deploy
 
 ```bash
-curl -X POST https://varity.app/v1/deployments/my-app/redeploy \
-  -H "Authorization: Bearer $VARITY_DEPLOY_KEY"
+curl -X POST https://varity.app/api/deployments \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: deploy-my-api-001" \
+  -d '{
+    "name": "my-api",
+    "image": {
+      "ref": "ghcr.io/me/my-api:latest",
+      "port": 8080
+    }
+  }'
 ```
 
-### 6. Stop (and stop billing)
-
-`DELETE /v1/deployments/{app_name}` permanently stops the app and ends its billing, freeing the reserved hardware.
+### Template deploy
 
 ```bash
-curl -X DELETE https://varity.app/v1/deployments/my-app \
-  -H "Authorization: Bearer $VARITY_DEPLOY_KEY"
+curl -X POST https://varity.app/api/templates/agent-zero/deploy \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: deploy-agent-zero-001" \
+  -d '{ "name": "my-agent" }'
 ```
 
-## Pricing (public)
-
-`GET /api/pricing?profile=<profile>` returns the flat monthly price for a workload profile plus a comparison against usage-metered hosts. No auth required.
+The response includes a Varity deployment id, public URL, run id, and `status_url`. Poll the run until it reaches `succeeded` or `failed`:
 
 ```bash
-curl "https://varity.app/api/pricing?profile=web"
-# → { "profile": "web", "varityMonthly": 6, "varityIsFlat": true, ... }
+curl "https://varity.app/api/deployments/runs/$RUN_ID?app=my-app" \
+  -H "Authorization: Bearer $VARITY_API_KEY"
 ```
 
-Pricing is a flat hardware reservation. It does not change with traffic, bandwidth, invocations, or build minutes.
+## Operate
+
+List deployments:
+
+```bash
+curl https://varity.app/api/deployments \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+Read one deployment:
+
+```bash
+curl https://varity.app/api/deployments/$DEPLOYMENT_ID \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+Read logs and events:
+
+```bash
+curl https://varity.app/api/deployments/$DEPLOYMENT_ID/logs \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+
+curl https://varity.app/api/deployments/$DEPLOYMENT_ID/events \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+List environment variable keys. Values are write-only and are not returned:
+
+```bash
+curl https://varity.app/api/deployments/$DEPLOYMENT_ID/env \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+Update environment variables and redeploy in place:
+
+```bash
+curl -X PATCH https://varity.app/api/deployments/$DEPLOYMENT_ID/env \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "env": { "FEATURE_FLAG": "on" } }'
+```
+
+Redeploy, restart, or delete:
+
+```bash
+curl -X POST https://varity.app/api/deployments/$DEPLOYMENT_ID/redeploy \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+
+curl -X POST https://varity.app/api/deployments/$DEPLOYMENT_ID/restart \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+
+curl -X DELETE https://varity.app/api/deployments/$DEPLOYMENT_ID \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+## Templates, Pricing, And Credits
+
+Templates are deployable app starters. Pricing is estimated from the live API, not a hardcoded table, and returns fixed monthly hardware-reservation cost for the requested profile. Credits show whether the caller can deploy with a payment method or active starter credit.
+
+```bash
+curl https://varity.app/api/templates \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+
+curl "https://varity.app/api/pricing/estimate?profile=web-app" \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+
+curl https://varity.app/api/credits \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+## Webhooks
+
+Create a webhook:
+
+```bash
+curl -X POST https://varity.app/api/webhooks \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com/varity/webhook",
+    "events": ["deployment.accepted", "deployment.live", "deployment.failed"]
+  }'
+```
+
+The response includes `signing_secret` once. Store it to verify webhook deliveries. Varity signs each delivery with:
+
+- `X-Varity-Event-Id`
+- `X-Varity-Timestamp`
+- `X-Varity-Signature`
+
+The signature is `v1=` plus an HMAC-SHA256 over `timestamp.body` using the webhook signing secret. Webhook endpoint URLs must be public HTTPS URLs; local and private hosts are rejected.
+
+Webhook handlers should be idempotent. Delivery-time DNS/IP revalidation, durable delivery queue hardening, and additional signing-secret custody hardening remain non-blocking v1 follow-ups.
+
+List webhooks and delivery status:
+
+```bash
+curl "https://varity.app/api/webhooks?include_deliveries=true" \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+Delete a webhook:
+
+```bash
+curl -X DELETE https://varity.app/api/webhooks/$WEBHOOK_ID \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
 
 ## Endpoint summary
 
-| Method | Path | Auth | Purpose |
-|--------|------|------|---------|
-| `POST` | `/v1/deploy` | deploy key | Start a deploy |
-| `GET` | `/v1/deploy/{run_id}` | deploy key | Get status + result |
-| `GET` | `/v1/deploy/{run_id}/logs` | deploy key | Stream deploy logs (SSE) |
-| `PUT` | `/v1/deployments/{app_name}/env` | deploy key | Set env vars + redeploy in place |
-| `POST` | `/v1/deployments/{app_name}/redeploy` | deploy key | Redeploy/restart in place |
-| `DELETE` | `/v1/deployments/{app_name}` | deploy key | Stop a deployment + billing |
-| `GET` | `/api/pricing` | public | Live flat pricing |
-| `GET` | `/health` | public | Service health |
+The OpenAPI document contains these 18 public paths:
 
-This is the complete public, agent-facing surface. Internal control-plane routes (identity, billing, the deployment registry, telemetry, and infrastructure plumbing) are intentionally not part of this contract and may change without notice.
+| Methods | Path | Purpose |
+|---------|------|---------|
+| `GET`, `POST` | `/api/deployments` | List or create deployments |
+| `GET` | `/api/deployments/runs/{run_id}` | Get deployment run status |
+| `GET`, `DELETE` | `/api/deployments/{deployment_id}` | Read or delete a deployment |
+| `GET` | `/api/deployments/{deployment_id}/logs` | Read deployment logs |
+| `GET` | `/api/deployments/{deployment_id}/events` | Read deployment events |
+| `GET`, `PATCH` | `/api/deployments/{deployment_id}/env` | List environment variable keys or update values |
+| `POST` | `/api/deployments/{deployment_id}/redeploy` | Redeploy in place |
+| `POST` | `/api/deployments/{deployment_id}/restart` | Restart in place |
+| `GET` | `/api/templates` | List templates |
+| `GET` | `/api/templates/{template_id}` | Read a template |
+| `POST` | `/api/templates/{template_id}/deploy` | Deploy a template |
+| `GET` | `/api/pricing/estimate` | Estimate fixed monthly cost |
+| `GET` | `/api/credits` | Read credit and deploy eligibility |
+| `GET`, `POST` | `/api/webhooks` | List or create webhooks |
+| `DELETE` | `/api/webhooks/{webhook_id}` | Delete a webhook |
+| `GET`, `POST` | `/api/api-keys` | List or create API keys in the Developer Portal |
+| `DELETE` | `/api/api-keys/{key_id}` | Revoke an API key in the Developer Portal |
+| `GET` | `/api/openapi.json` | Read the live OpenAPI contract |
+
+Public API responses use Varity product resources only. Internal implementation details are not part of this contract.
+
+API-key management endpoints are Developer Portal session routes in v1. API keys authenticate non-browser API callers, but API keys cannot create, list, or revoke other API keys. Revoked keys can have a short cache-propagation window before every edge rejects them.
 
 ## Next steps
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -33,7 +33,7 @@ claude mcp add varity -- npx -y @varity-labs/mcp
 
 ## Pages
 
-- [Varity HTTP API Reference](https://docs.varity.so/ai-tools/api-reference/): Agent-facing Varity HTTP API and MCP schemas for deploying, monitoring, streaming logs, and stopping apps programmatically.
+- [Varity Public API Reference](https://docs.varity.so/ai-tools/api-reference/): Public resource API for deploying and operating apps, templates, pricing, credits, API keys, and webhooks programmatically.
 - [Varity MCP Server Reference](https://docs.varity.so/ai-tools/mcp-server-spec/): Install and configure the Varity MCP server for AI editors. A full set of tools for building, deploying, and managing apps via Cursor or Claude Code.
 - [AI Tools for Varity Deploys](https://docs.varity.so/ai-tools/overview/): Accelerate Varity development with AI tools. Copy-paste prompts, Cursor rules, MCP server integration, and LLM-optimized documentation.
 - [AI Prompts for Varity Deploys](https://docs.varity.so/ai-tools/prompts/): Ready-to-paste prompts for deploying to Varity from Claude Code, Cursor, Windsurf, or ChatGPT. No commands to memorize.

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -1,581 +1,1720 @@
-openapi: 3.0.3
-info:
-  title: Varity HTTP API
-  description: >
-    The public, agent-facing HTTP contract for Varity. AI agents, CLIs, and integrators
-    call these endpoints to deploy a project, poll its status, stream deploy logs, update
-    its environment variables, redeploy it in place, stop a deployment, and read live
-    pricing. This is the same stable `/v1` contract the
-    `varitykit` CLI and `@varity-labs/mcp` server use under the hood. Point your agent at
-    it directly, or use the MCP server (see https://docs.varity.so/ai-tools/mcp-server-spec/).
-
-
-    Most agents should prefer the MCP tools (`varity_deploy`, `varity_deploy_status`,
-    `varity_deploy_logs`, `varity_delete_deployment`). They wrap this API and handle
-    framework detection, auth, and result parsing. The raw HTTP API below is for direct
-    integrations.
-
-
-    Scope note: this spec documents only the endpoints intended for external/agent use.
-    Internal control-plane routes (identity callbacks, billing, the deployment registry,
-    telemetry ingest, and infrastructure plumbing) are intentionally not part of this
-    public contract and may change without notice.
-  version: 1.2.0
-servers:
-  - url: https://varity.app
-    description: Production API (the Varity gateway)
-tags:
-  - name: Deploy
-    description: Create, monitor, and stop deployments.
-  - name: Pricing
-    description: Read live, flat per-app pricing.
-  - name: Service
-    description: Service health.
-paths:
-  /v1/templates:
-    get:
-      operationId: listTemplates
-      tags: [Deploy]
-      summary: List certified deploy templates
-      description: >
-        Returns the gateway-owned certified template catalog used by the Developer
-        Portal, varitykit CLI, and MCP server. Raw image references are intentionally
-        omitted; deploy templates by passing `template_id` to `POST /v1/deploy`.
-      security:
-        - deployKey: []
-      responses:
-        '200':
-          description: Certified template catalog.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TemplateCatalog'
-        '401':
-          description: Missing or invalid deploy key.
-  /v1/deploy:
-    post:
-      operationId: createDeploy
-      tags: [Deploy]
-      summary: Start a deploy
-      description: >
-        Deploy a project from a GitHub repo (`repo_url`), a prebuilt Docker/OCI image
-        (`image`), or a certified Varity template (`template_id`). The framework,
-        hosting mode (static vs dynamic), and any backend services your code needs
-        (Postgres, Redis, MongoDB, MySQL, Ollama) are detected and configured
-        automatically for repo/image deploys. Template deploys use the certified
-        gateway-owned runtime profile. Returns immediately with a `run_id`; poll
-        `GET /v1/deploy/{run_id}` for status and stream `GET /v1/deploy/{run_id}/logs` for
-        progress. Exactly one of `repo_url`, `image`, or `template_id` must be supplied.
-      security:
-        - deployKey: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DeployRequest'
-      responses:
-        '202':
-          description: Deploy run accepted and queued.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeployAccepted'
-        '400':
-          description: Invalid request (none or multiple deploy sources supplied, uncertified template, or a bad manifest).
-        '401':
-          description: Missing or invalid deploy key.
-  /v1/deploy/{run_id}:
-    get:
-      operationId: getDeploy
-      tags: [Deploy]
-      summary: Get deploy status and result
-      description: >
-        Returns the current status of a deploy run and, once it reaches a terminal state,
-        the result (live URL, deployment id, selected hardware, and, on failure, a
-        redacted reason and failure stage).
-      security:
-        - deployKey: []
-      parameters:
-        - name: run_id
-          in: path
-          required: true
-          description: The `run_id` returned by POST /v1/deploy.
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Current status and (when terminal) the result.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeployStatus'
-        '401':
-          description: Missing or invalid deploy key.
-        '404':
-          description: Unknown run_id.
-  /v1/deploy/{run_id}/logs:
-    get:
-      operationId: getDeployLogs
-      tags: [Deploy]
-      summary: Stream deploy logs (Server-Sent Events)
-      description: >
-        Server-Sent Events stream of deploy progress (detect → build → bid → lease →
-        health → done) for the run. Each event is a `data:` line; the stream terminates
-        when the run reaches a terminal status. Note: this streams deploy-time progress,
-        not the running container's runtime stdout/stderr.
-      security:
-        - deployKey: []
-      parameters:
-        - name: run_id
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: text/event-stream of log lines.
-          content:
-            text/event-stream:
-              schema:
-                type: string
-                description: "SSE-framed log lines, each as a data: event."
-        '401':
-          description: Missing or invalid deploy key.
-        '404':
-          description: Unknown run_id.
-  /v1/deployments/{subdomain}:
-    delete:
-      operationId: deleteDeployment
-      tags: [Deploy]
-      summary: Stop a deployment and its billing
-      description: >
-        Permanently stops the deployment identified by its app name (subdomain) and ends
-        its billing. This frees the reserved hardware; the app stops serving immediately.
-      security:
-        - deployKey: []
-      parameters:
-        - name: subdomain
-          in: path
-          required: true
-          description: The app name (the `{name}` in https://varity.app/{name}/).
-          schema:
-            type: string
-            pattern: '^[a-z0-9-]{1,63}$'
-      responses:
-        '200':
-          description: Deployment stopped.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success: { type: boolean }
-                  deleted: { type: boolean }
-                  subdomain: { type: string }
-                  appName: { type: string }
-        '401':
-          description: Missing or invalid deploy key.
-        '403':
-          description: The deploy key does not own this deployment.
-        '404':
-          description: Unknown deployment.
-  /v1/deployments/{subdomain}/env:
-    put:
-      operationId: setDeploymentEnv
-      tags: [Deploy]
-      summary: Set environment variables and redeploy in place
-      description: >
-        Set or update environment variables on an existing deployment, then redeploy it in
-        place. Same URL, same reserved hardware, no new bid. By default the supplied
-        variables are merged over the current set; pass `replace: true` to overwrite the
-        entire set. Values are write-only and are never returned. The change goes live in
-        about a minute with no URL change.
-      security:
-        - deployKey: []
-      parameters:
-        - name: subdomain
-          in: path
-          required: true
-          description: The app name (the `{name}` in https://varity.app/{name}/).
-          schema:
-            type: string
-            pattern: '^[a-z0-9-]{1,63}$'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                envVars:
-                  type: object
-                  additionalProperties:
-                    type: string
-                  description: Environment variables to set, as a map of UPPER_SNAKE_CASE name to value.
-                replace:
-                  type: boolean
-                  default: false
-                  description: When true, replace the entire variable set instead of merging.
-              required: [envVars]
-      responses:
-        '200':
-          description: Variables applied; redeploy of the same deployment started.
-        '400':
-          description: Missing subdomain or an invalid env map.
-        '401':
-          description: Missing or invalid deploy key.
-        '403':
-          description: The deploy key does not own this deployment.
-        '404':
-          description: Unknown deployment.
-  /v1/deployments/{subdomain}/redeploy:
-    post:
-      operationId: redeployDeployment
-      tags: [Deploy]
-      summary: Redeploy an existing deployment in place
-      description: >
-        Redeploy or restart an existing app in place. It re-pulls the image (or rebuilds
-        from source) and restarts the container on the SAME deployment: same URL, same
-        reserved hardware, no new bid. Takes no body and keeps the current environment
-        variables; use PUT `/v1/deployments/{subdomain}/env` to change config at the same
-        time. Goes live in about a minute with no URL change.
-      security:
-        - deployKey: []
-      parameters:
-        - name: subdomain
-          in: path
-          required: true
-          description: The app name (the `{name}` in https://varity.app/{name}/).
-          schema:
-            type: string
-            pattern: '^[a-z0-9-]{1,63}$'
-      responses:
-        '200':
-          description: Redeploy of the same deployment started.
-        '400':
-          description: Missing subdomain.
-        '401':
-          description: Missing or invalid deploy key.
-        '403':
-          description: The deploy key does not own this deployment.
-        '404':
-          description: Unknown deployment.
-  /api/pricing:
-    get:
-      operationId: getPricing
-      tags: [Pricing]
-      summary: Get live flat per-app pricing
-      description: >
-        Returns Varity's flat monthly price for a workload profile (or an existing app)
-        plus a comparison against usage-metered hosts. Public. No authentication required.
-        Pricing is a flat hardware reservation; it does not change with traffic, bandwidth,
-        invocations, or build minutes.
-      parameters:
-        - name: profile
-          in: query
-          required: false
-          description: A workload profile to price (e.g. `static`, `web`, `agent`, `gpu`).
-          schema:
-            type: string
-        - name: subdomain
-          in: query
-          required: false
-          description: Price an existing deployed app by name instead of a profile.
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Pricing for the requested profile or app.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pricing'
-        '404':
-          description: Unknown app/profile.
-  /health:
-    get:
-      operationId: getHealth
-      tags: [Service]
-      summary: Service health
-      description: Liveness check for the Varity API. Public. No authentication required.
-      responses:
-        '200':
-          description: Service is healthy.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  status: { type: string, example: healthy }
-                  service: { type: string, example: varity-gateway }
-                  version: { type: string }
-components:
-  securitySchemes:
-    deployKey:
-      type: http
-      scheme: bearer
-      description: >
-        Your Varity deploy key, sent as `Authorization: Bearer <key>`. Obtain it by running
-        `varitykit login` (the CLI stores it and sends it for you). Required on all `/v1`
-        deploy endpoints.
-  schemas:
-    TemplateCatalog:
-      type: object
-      properties:
-        templates:
-          type: array
-          items:
-            $ref: '#/components/schemas/TemplateSummary'
-        count:
-          type: integer
-      required: [templates, count]
-    TemplateSummary:
-      type: object
-      properties:
-        id:
-          type: string
-          description: Template ID to pass as `template_id` in `POST /v1/deploy`.
-        name:
-          type: string
-        description:
-          type: string
-        framework:
-          type: string
-        language:
-          type: string
-        tags:
-          type: array
-          items:
-            type: string
-        category:
-          type: string
-        requiredEnv:
-          type: array
-          items:
-            type: string
-        hardware:
-          type: object
-          properties:
-            cpu:
-              type: number
-            memory_gb:
-              type: number
-            ephemeral_gb:
-              type: number
-        volume:
-          nullable: true
-          type: object
-          properties:
-            sizeGb:
-              type: integer
-            path:
-              type: string
-        private:
-          type: boolean
-          description: Whether the template deploys behind owner-only access by default.
-        resources:
-          type: array
-          items:
-            type: object
-            properties:
-              kind:
-                type: string
-              engine:
-                type: string
-              label:
-                type: string
-        certification:
-          type: object
-          properties:
-            state:
-              type: string
-              enum: [certified]
-            reason:
-              type: string
-            evidence:
-              type: string
-      required: [id, name, description, category, requiredEnv, hardware, private, resources, certification]
-    DeployRequest:
-      type: object
-      description: >
-        The deploy manifest. Exactly one of `repo_url`, `image`, or `template_id` is
-        required. Resource fields (`port`, `cpu_units`, `memory_mb`, `storage_mb`) apply
-        to the Docker/OCI image path; for repo builds, hosting and size are decided
-        automatically. Template deploys use the gateway-owned certified profile.
-      properties:
-        app_name:
-          type: string
-          pattern: '^[a-z0-9-]{1,63}$'
-          description: Deployment / subdomain name. Controls the URL https://varity.app/{app_name}/.
-        source:
-          type: string
-          enum: [cli, portal, mcp, sandbox, staging]
-          description: Which client originated the deploy (used for telemetry).
-        repo_url:
-          type: string
-          description: GitHub https repo URL (alternative to `image` or `template_id`).
-        template_id:
-          type: string
-          description: Certified template ID from `GET /v1/templates` (alternative to `repo_url` or `image`).
-        commit:
-          type: string
-          maxLength: 64
-          default: HEAD
-          description: Commit/ref to build. SHA or simple ref.
-        framework:
-          type: string
-          description: Optional framework override; auto-detected if omitted.
-        hosting:
-          type: string
-          enum: [static, dynamic]
-          description: Optional hosting-mode override; auto-decided if omitted.
-        services:
-          type: array
-          items:
-            type: string
-            enum: [postgres, redis, ollama, mongodb, mysql, minio]
-          description: >
-            Backend services to attach. Normally inferred from your dependencies
-            (e.g. `pg` → Postgres, `redis` → Redis); set explicitly to override.
-        env_vars:
-          type: object
-          additionalProperties:
-            type: string
-          description: >
-            Build/runtime environment variables. Values may reference auto-attached service
-            env as ${KEY} (e.g. MONGO_URI=${MONGODB_URI}).
-        package_manager:
-          type: string
-          enum: [npm, yarn, pnpm]
-          description: Optional package manager for Node projects; auto-detected if omitted.
-        python_start_command:
-          type: string
-          maxLength: 512
-          description: Optional start command for Python apps; derived from the framework if omitted.
-        image:
-          type: string
-          maxLength: 512
-          description: >
-            OCI image ref for a direct Docker-image deploy (alternative to `repo_url` or `template_id`).
-            Bare Docker Hub refs are normalized (e.g. "nginx:alpine" →
-            "docker.io/library/nginx:alpine").
-        image_credentials:
-          $ref: '#/components/schemas/ImageCredentials'
-        port:
-          type: integer
-          minimum: 1
-          maximum: 65535
-          description: Container listen port for an image deploy (default 80).
-        cpu_units:
-          type: number
-          minimum: 0.25
-          maximum: 4
-          description: Reserved CPU units, image/prebuilt paths only (default 0.5).
-        memory_mb:
-          type: integer
-          minimum: 256
-          maximum: 8192
-          description: Reserved memory in MiB, image/prebuilt paths only (default 512).
-        storage_mb:
-          type: integer
-          minimum: 512
-          maximum: 20480
-          description: Reserved storage in MiB, image/prebuilt paths only (default 1024).
-      required: [app_name, source]
-    ImageCredentials:
-      type: object
-      description: Pull credentials for a PRIVATE registry image. Omit for a public image.
-      properties:
-        host:
-          type: string
-          maxLength: 255
-          description: Bare registry host, e.g. ghcr.io / docker.io.
-        username:
-          type: string
-          maxLength: 255
-        password:
-          type: string
-          description: Write-only; never returned or logged.
-      required: [host, username, password]
-    DeployAccepted:
-      type: object
-      properties:
-        run_id:
-          type: string
-          description: Opaque id for polling status and streaming logs.
-      required: [run_id]
-    DeployStatus:
-      type: object
-      properties:
-        run_id:
-          type: string
-        status:
-          type: string
-          enum: [queued, running, succeeded, failed]
-        stage:
-          type: string
-          nullable: true
-          enum: [detect, build, bid, lease, health, done, failed]
-          description: Where the run is right now (progress). Null until the first stage-bearing log line.
-        deployment_id:
-          type: string
-          nullable: true
-          description: Stable deployment id once the app is live.
-        frontend_url:
-          type: string
-          nullable: true
-          description: Live URL of the deployed app.
-        memory_mb:
-          type: integer
-          nullable: true
-        error_message:
-          type: string
-          nullable: true
-          description: Redacted, bounded reason the run failed; null on success.
-        failure_stage:
-          type: string
-          nullable: true
-          enum:
-            - repo_access
-            - framework_detection
-            - build_execution
-            - ipfs_upload
-            - sdl_submission
-            - bid_collection
-            - lease_acceptance
-            - container_health
-            - gateway_registration
-            - orchestration
-      required: [run_id, status]
-    Pricing:
-      type: object
-      description: >
-        Live pricing for a profile or app. Field set is additive and may grow; the stable
-        fields are `varityMonthly` (flat USD/month) and `varityIsFlat` (always true).
-      properties:
-        profile:
-          type: string
-          nullable: true
-        subdomain:
-          type: string
-          nullable: true
-        varityMonthly:
-          type: number
-          description: Flat monthly price in USD.
-        varityIsFlat:
-          type: boolean
-          description: Always true. The bill does not change with usage.
-        mode:
-          type: string
-          enum: [static, dynamic]
-        competitors:
-          type: array
-          description: Usage-metered comparison points.
-          items:
-            type: object
-            properties:
-              id: { type: string }
-              label: { type: string }
-              atLaunch: { type: number }
-              atTraction: { type: number }
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Varity Public Platform API",
+    "version": "2026-07-10",
+    "description": "Gateway-owned resource API for deploying and operating Varity apps."
+  },
+  "servers": [
+    {
+      "url": "https://varity.app/api"
+    }
+  ],
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ],
+  "paths": {
+    "/deployments": {
+      "get": {
+        "operationId": "listDeployments",
+        "summary": "List deployments",
+        "responses": {
+          "200": {
+            "description": "Deployment list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeploymentList"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createDeployment",
+        "summary": "Create a deployment",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdempotencyKey"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateDeploymentRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Deployment accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptedDeployment"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/deployments/runs/{run_id}": {
+      "get": {
+        "operationId": "getDeploymentRun",
+        "summary": "Get deployment run status",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/RunId"
+          },
+          {
+            "name": "app",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deployment run status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeploymentRunStatus"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/deployments/{deployment_id}": {
+      "get": {
+        "operationId": "getDeployment",
+        "summary": "Get a deployment",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/DeploymentId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deployment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "deployment"
+                  ],
+                  "properties": {
+                    "deployment": {
+                      "$ref": "#/components/schemas/Deployment"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteDeployment",
+        "summary": "Delete a deployment",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/DeploymentId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deployment deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "status",
+                    "deleted"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "const": "deleted"
+                    },
+                    "deleted": {
+                      "const": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/deployments/{deployment_id}/redeploy": {
+      "post": {
+        "operationId": "redeployDeployment",
+        "summary": "Redeploy in place",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/DeploymentId"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Redeploy accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptedMutation"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/deployments/{deployment_id}/restart": {
+      "post": {
+        "operationId": "restartDeployment",
+        "summary": "Restart in place",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/DeploymentId"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Restart accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptedMutation"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/deployments/{deployment_id}/logs": {
+      "get": {
+        "operationId": "listDeploymentLogs",
+        "summary": "Read deployment logs",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/DeploymentId"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 200
+            }
+          },
+          {
+            "name": "since_seq",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deployment logs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogList"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/deployments/{deployment_id}/events": {
+      "get": {
+        "operationId": "listDeploymentEvents",
+        "summary": "Read deployment events",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/DeploymentId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deployment events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventList"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/deployments/{deployment_id}/env": {
+      "get": {
+        "operationId": "listDeploymentEnv",
+        "summary": "List environment variable keys",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/DeploymentId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Environment variable keys",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnvKeyList"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "patchDeploymentEnv",
+        "summary": "Update environment variables",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/DeploymentId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnvUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Update accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptedMutation"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/templates": {
+      "get": {
+        "operationId": "listTemplates",
+        "summary": "List templates",
+        "responses": {
+          "200": {
+            "description": "Template list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateList"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/templates/{template_id}": {
+      "get": {
+        "operationId": "getTemplate",
+        "summary": "Get a template",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TemplateId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Template",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "template"
+                  ],
+                  "properties": {
+                    "template": {
+                      "$ref": "#/components/schemas/Template"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/templates/{template_id}/deploy": {
+      "post": {
+        "operationId": "deployTemplate",
+        "summary": "Deploy a template",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/TemplateId"
+          },
+          {
+            "$ref": "#/components/parameters/IdempotencyKey"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TemplateDeployRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Deployment accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptedDeployment"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/pricing/estimate": {
+      "get": {
+        "operationId": "estimatePricing",
+        "summary": "Estimate fixed monthly cost",
+        "parameters": [
+          {
+            "name": "profile",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "examples": [
+                "web-app",
+                "static-site",
+                "web-app-db"
+              ]
+            }
+          },
+          {
+            "name": "cpu",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "minimum": 0.25
+            }
+          },
+          {
+            "name": "memory_gb",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "minimum": 0.25
+            }
+          },
+          {
+            "name": "ephemeral_gb",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "persistent_gb",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "has_db",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pricing estimate",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricingEstimate"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/credits": {
+      "get": {
+        "operationId": "getCredits",
+        "summary": "Get credit and payment state",
+        "responses": {
+          "200": {
+            "description": "Credit and payment state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreditState"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/webhooks": {
+      "get": {
+        "operationId": "listWebhooks",
+        "summary": "List webhooks",
+        "parameters": [
+          {
+            "name": "include_deliveries",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Webhook list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookList"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createWebhook",
+        "summary": "Create a webhook",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateWebhookRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Webhook created; signing_secret is shown once",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatedWebhook"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/webhooks/{webhook_id}": {
+      "delete": {
+        "operationId": "deleteWebhook",
+        "summary": "Delete a webhook",
+        "parameters": [
+          {
+            "name": "webhook_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Webhook deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "deleted"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "deleted": {
+                      "const": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/api-keys": {
+      "get": {
+        "security": [
+          {
+            "PortalSession": []
+          }
+        ],
+        "operationId": "listApiKeys",
+        "summary": "List API keys in the Developer Portal",
+        "description": "Requires an authenticated Developer Portal session. Plaintext API keys are never returned.",
+        "responses": {
+          "200": {
+            "description": "API key metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyList"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "PortalSession": []
+          }
+        ],
+        "operationId": "createApiKey",
+        "summary": "Create an API key in the Developer Portal",
+        "description": "Requires an authenticated Developer Portal session and active deploy eligibility. The plaintext key is shown once.",
+        "responses": {
+          "200": {
+            "description": "New API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssuedApiKey"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/api-keys/{key_id}": {
+      "delete": {
+        "security": [
+          {
+            "PortalSession": []
+          }
+        ],
+        "operationId": "deleteApiKey",
+        "summary": "Revoke an API key in the Developer Portal",
+        "description": "Requires an authenticated Developer Portal session. Revocation is owner-scoped.",
+        "parameters": [
+          {
+            "name": "key_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "API key revoked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "revoked": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/openapi.json": {
+      "get": {
+        "security": [],
+        "operationId": "getOpenApiDocument",
+        "summary": "Get the public API contract",
+        "responses": {
+          "200": {
+            "description": "OpenAPI document"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "Varity API key"
+      },
+      "PortalSession": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "Developer Portal session credential"
+      }
+    },
+    "parameters": {
+      "DeploymentId": {
+        "name": "deployment_id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "RunId": {
+        "name": "run_id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "TemplateId": {
+        "name": "template_id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "IdempotencyKey": {
+        "name": "Idempotency-Key",
+        "in": "header",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "maxLength": 160
+        }
+      }
+    },
+    "responses": {
+      "PublicError": {
+        "description": "Public API error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PublicError"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "PublicError": {
+        "type": "object",
+        "required": [
+          "code",
+          "message",
+          "action",
+          "retryable",
+          "docs_url"
+        ],
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string"
+          },
+          "retryable": {
+            "type": "boolean"
+          },
+          "docs_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "field": {
+            "type": "string"
+          },
+          "correlation_id": {
+            "type": "string"
+          }
+        }
+      },
+      "Deployment": {
+        "type": "object",
+        "required": [
+          "id",
+          "app_name",
+          "subdomain",
+          "status",
+          "runtime",
+          "public_url"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "app_name": {
+            "type": "string"
+          },
+          "subdomain": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "deploying",
+              "live",
+              "deleted",
+              "unknown"
+            ]
+          },
+          "runtime": {
+            "type": "string",
+            "enum": [
+              "static",
+              "dynamic"
+            ]
+          },
+          "public_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "deleted_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "closure_reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "source": {
+            "$ref": "#/components/schemas/DeploymentSource"
+          },
+          "resource_profile": {
+            "$ref": "#/components/schemas/ResourceProfile"
+          },
+          "billing": {
+            "$ref": "#/components/schemas/DeploymentBilling"
+          }
+        }
+      },
+      "DeploymentSource": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "repository",
+              "image",
+              "template",
+              "unknown"
+            ]
+          },
+          "template_id": {
+            "type": "string"
+          }
+        }
+      },
+      "ResourceProfile": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "cpu_units": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "memory_mb": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "storage_mb": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "persistent_storage_gb": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "attached_resources": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "DeploymentBilling": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+          "fixed_monthly_cost_usd": {
+            "type": "number"
+          },
+          "fixed_monthly_usd": {
+            "type": "number"
+          },
+          "accrued_this_month_usd": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          }
+        }
+      },
+      "DeploymentList": {
+        "type": "object",
+        "required": [
+          "deployments"
+        ],
+        "properties": {
+          "deployments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Deployment"
+            }
+          }
+        }
+      },
+      "AcceptedDeployment": {
+        "type": "object",
+        "required": [
+          "id",
+          "app_name",
+          "status",
+          "runtime",
+          "public_url",
+          "run_id",
+          "status_url"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "app_name": {
+            "type": "string"
+          },
+          "subdomain": {
+            "type": "string"
+          },
+          "status": {
+            "const": "deploying"
+          },
+          "runtime": {
+            "type": "string",
+            "enum": [
+              "static",
+              "dynamic"
+            ]
+          },
+          "public_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "status_url": {
+            "type": "string"
+          }
+        }
+      },
+      "AcceptedMutation": {
+        "type": "object",
+        "required": [
+          "id",
+          "status"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "app_name": {
+            "type": "string"
+          },
+          "subdomain": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "run_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "DeploymentRunStatus": {
+        "type": "object",
+        "properties": {
+          "runId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "queued",
+              "running",
+              "succeeded",
+              "failed"
+            ]
+          },
+          "stage": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "frontendUrl": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri"
+          },
+          "errorMessage": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "LogList": {
+        "type": "object",
+        "required": [
+          "lines",
+          "count"
+        ],
+        "properties": {
+          "lines": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "count": {
+            "type": "integer"
+          }
+        }
+      },
+      "EventList": {
+        "type": "object",
+        "required": [
+          "events"
+        ],
+        "properties": {
+          "events": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "type",
+                "message",
+                "created_at"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "EnvKeyList": {
+        "type": "object",
+        "required": [
+          "keys",
+          "variables",
+          "count"
+        ],
+        "properties": {
+          "keys": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "variables": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "key",
+                "value",
+                "write_only"
+              ],
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "null"
+                },
+                "write_only": {
+                  "const": true
+                }
+              }
+            }
+          },
+          "count": {
+            "type": "integer"
+          }
+        }
+      },
+      "EnvUpdateRequest": {
+        "type": "object",
+        "required": [
+          "env"
+        ],
+        "properties": {
+          "env": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "replace": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      },
+      "CreateDeploymentRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "repository": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "ref": {
+                "type": "string"
+              },
+              "dockerfile_path": {
+                "type": "string"
+              },
+              "docker_context_path": {
+                "type": "string"
+              }
+            }
+          },
+          "image": {
+            "type": "object",
+            "properties": {
+              "ref": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer"
+              },
+              "credentials": {
+                "type": "object",
+                "writeOnly": true
+              }
+            }
+          },
+          "template_id": {
+            "type": "string"
+          },
+          "env": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "writeOnly": true
+          },
+          "port": {
+            "type": "integer"
+          },
+          "command": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "health_path": {
+            "type": "string"
+          },
+          "resource_profile": {
+            "$ref": "#/components/schemas/ResourceProfile"
+          }
+        }
+      },
+      "TemplateDeployRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "subdomain": {
+            "type": "string"
+          },
+          "env": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "writeOnly": true
+          }
+        }
+      },
+      "Template": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "description",
+          "required_env",
+          "resource_profile",
+          "certification"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "framework": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "logo": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "category": {
+            "type": "string"
+          },
+          "required_env": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "resource_profile": {
+            "type": "object"
+          },
+          "resources": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "private": {
+            "type": "boolean"
+          },
+          "certification": {
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "TemplateList": {
+        "type": "object",
+        "required": [
+          "templates",
+          "count"
+        ],
+        "properties": {
+          "templates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Template"
+            }
+          },
+          "count": {
+            "type": "integer"
+          }
+        }
+      },
+      "PricingEstimate": {
+        "type": "object",
+        "required": [
+          "profile",
+          "currency",
+          "fixed_monthly_cost_usd",
+          "billing_model"
+        ],
+        "properties": {
+          "profile": {
+            "type": "string"
+          },
+          "verified": {
+            "type": "boolean"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "fixed_monthly_cost_usd": {
+            "type": "number"
+          },
+          "billing_model": {
+            "const": "fixed_monthly_resource_reservation"
+          },
+          "mode": {
+            "type": "string"
+          }
+        }
+      },
+      "CreditState": {
+        "type": "object",
+        "properties": {
+          "has_payment_method": {
+            "type": "boolean"
+          },
+          "deploy_allowed": {
+            "type": "boolean"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "starter_credit": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "billing_summary": {
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        }
+      },
+      "ApiKeyList": {
+        "type": "object",
+        "required": [
+          "api_keys"
+        ],
+        "properties": {
+          "api_keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiKey"
+            }
+          }
+        }
+      },
+      "ApiKey": {
+        "type": "object",
+        "required": [
+          "id",
+          "tier",
+          "active"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "tier": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "last_used_at": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "revoked_at": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "active": {
+            "type": "boolean"
+          }
+        }
+      },
+      "IssuedApiKey": {
+        "type": "object",
+        "required": [
+          "api_key",
+          "tier"
+        ],
+        "properties": {
+          "api_key": {
+            "type": "string",
+            "writeOnly": true
+          },
+          "tier": {
+            "type": "string"
+          }
+        }
+      },
+      "WebhookEventType": {
+        "type": "string",
+        "enum": [
+          "deployment.accepted",
+          "deployment.progress",
+          "deployment.live",
+          "deployment.failed",
+          "deployment.unhealthy",
+          "deployment.env_updated",
+          "deployment.redeploy_requested",
+          "deployment.redeploy_completed",
+          "deployment.restart_requested",
+          "deployment.deleted",
+          "credit.updated"
+        ]
+      },
+      "Webhook": {
+        "type": "object",
+        "required": [
+          "id",
+          "url",
+          "events",
+          "active",
+          "created_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WebhookEventType"
+            }
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "WebhookDelivery": {
+        "type": "object",
+        "required": [
+          "id",
+          "webhook_id",
+          "event_id",
+          "event_type",
+          "status",
+          "attempts"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "webhook_id": {
+            "type": "string"
+          },
+          "event_id": {
+            "type": "string"
+          },
+          "event_type": {
+            "$ref": "#/components/schemas/WebhookEventType"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "delivered",
+              "retrying",
+              "failed"
+            ]
+          },
+          "attempts": {
+            "type": "integer"
+          },
+          "status_code": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "last_error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "next_retry_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        }
+      },
+      "WebhookList": {
+        "type": "object",
+        "required": [
+          "webhooks",
+          "count"
+        ],
+        "properties": {
+          "webhooks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Webhook"
+            }
+          },
+          "count": {
+            "type": "integer"
+          },
+          "deliveries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WebhookDelivery"
+            }
+          }
+        }
+      },
+      "CreateWebhookRequest": {
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Absolute HTTPS endpoint URL. Private and local hosts are rejected."
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WebhookEventType"
+            }
+          }
+        }
+      },
+      "CreatedWebhook": {
+        "type": "object",
+        "required": [
+          "webhook",
+          "signing_secret"
+        ],
+        "properties": {
+          "webhook": {
+            "$ref": "#/components/schemas/Webhook"
+          },
+          "signing_secret": {
+            "type": "string",
+            "writeOnly": true,
+            "description": "Shown once. Store it to verify X-Varity-Signature."
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/Accordion.astro
+++ b/src/components/Accordion.astro
@@ -39,7 +39,7 @@ const accordionId = `accordion-${Math.random().toString(36).slice(2, 11)}`
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.varity-accordion').forEach(accordion => {
       const summary = accordion.querySelector('summary')
-      const content = accordion.querySelector('.accordion-content')
+      const content = accordion.querySelector<HTMLElement>('.accordion-content')
 
       if (!summary || !content) return
 

--- a/src/components/CodeBlock.astro
+++ b/src/components/CodeBlock.astro
@@ -58,8 +58,12 @@ const id = `code-${Math.random().toString(36).slice(2, 11)}`
     document.querySelectorAll('.copy-button').forEach(button => {
       button.addEventListener('click', async () => {
         const codeId = button.getAttribute('data-code-id')
+        if (!codeId) return
+
         const codeBlock = document.getElementById(codeId)
         if (!codeBlock) return
+        const copyText = button.querySelector<HTMLElement>('.copy-text')
+        if (!copyText) return
 
         const code = codeBlock.textContent || ''
 
@@ -68,11 +72,11 @@ const id = `code-${Math.random().toString(36).slice(2, 11)}`
 
           // Visual feedback
           button.classList.add('copied')
-          button.querySelector('.copy-text').textContent = 'Copied!'
+          copyText.textContent = 'Copied!'
 
           setTimeout(() => {
             button.classList.remove('copied')
-            button.querySelector('.copy-text').textContent = 'Copy'
+            copyText.textContent = 'Copy'
           }, 2000)
         } catch (err) {
           console.error('Failed to copy:', err)

--- a/src/components/DocsHome.astro
+++ b/src/components/DocsHome.astro
@@ -34,7 +34,7 @@ const entryPaths = [
     action: 'Deploy an image',
     command: 'varitykit app deploy --image <ref>',
   },
-];
+] as const;
 
 const platformGroups = [
   {
@@ -97,7 +97,7 @@ const platformGroups = [
       ['Glossary', '/resources/glossary/'],
     ],
   },
-];
+] as const;
 
 const commonTasks = [
   ['Deploy a Next.js app', '/guides/deploy-nextjs/'],

--- a/src/components/Tabs.astro
+++ b/src/components/Tabs.astro
@@ -39,7 +39,6 @@ const tabsId = `tabs-${Math.random().toString(36).slice(2, 11)}`
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.varity-tabs').forEach(tabsContainer => {
-      const tabsId = tabsContainer.getAttribute('data-tabs-id')
       const defaultTab = tabsContainer.getAttribute('data-default-tab')
       const queryGroup = tabsContainer.getAttribute('data-query-group')
 
@@ -50,6 +49,7 @@ const tabsId = `tabs-${Math.random().toString(36).slice(2, 11)}`
 
       // Initialize active tab
       const activeTab = defaultTab || tabButtons[0].getAttribute('data-tab-id')
+      if (!activeTab) return
 
       function activateTab(tabId: string) {
         tabButtons.forEach(button => {
@@ -81,7 +81,8 @@ const tabsId = `tabs-${Math.random().toString(36).slice(2, 11)}`
       })
 
       // Keyboard navigation
-      tabsContainer.addEventListener('keydown', (e) => {
+      tabsContainer.addEventListener('keydown', (event) => {
+        const e = event as KeyboardEvent
         const target = e.target as HTMLElement
         if (target.getAttribute('role') !== 'tab') return
 

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -70,16 +70,30 @@ const article = {
   isPartOf: { "@id": `${SITE}/#website` },
 };
 
+type SidebarItem = {
+  type?: string;
+  label?: string;
+  entries?: SidebarItem[];
+  isCurrent?: boolean;
+};
+
+type BreadcrumbItem = {
+  "@type": string;
+  position: number;
+  name: string;
+  item?: string;
+};
+
 // BreadcrumbList: Home -> [section group] -> current page, derived from the
 // Starlight sidebar. Find the group containing the current entry.
-function findSection(sidebar) {
+function findSection(sidebar: unknown): string | null {
   if (!Array.isArray(sidebar)) return null;
-  for (const item of sidebar) {
+  for (const item of sidebar as SidebarItem[]) {
     if (item?.type === "group" && Array.isArray(item.entries)) {
       const hit = item.entries.some(
-        (e) => e?.type === "link" && e.isCurrent
+        (entry) => entry?.type === "link" && entry.isCurrent
       );
-      if (hit) return item.label;
+      if (hit) return item.label ?? null;
       // Nested groups (rare in this docs set, but handle gracefully).
       const nested = findSection(item.entries);
       if (nested) return nested;
@@ -90,7 +104,7 @@ function findSection(sidebar) {
 
 const sectionLabel = findSection(route?.sidebar);
 
-const breadcrumbItems = [
+const breadcrumbItems: BreadcrumbItem[] = [
   {
     "@type": "ListItem",
     position: 1,

--- a/src/content/docs/ai-tools/api-reference.mdx
+++ b/src/content/docs/ai-tools/api-reference.mdx
@@ -39,7 +39,7 @@ All HTTP API calls go to:
 https://varity.app
 ```
 
-The `/v1` deploy endpoints require your **deploy key**, sent as a bearer token:
+The `/v1` deploy endpoints require your **deploy key**, sent in the Authorization header:
 
 ```
 Authorization: Bearer <your-deploy-key>
@@ -95,7 +95,7 @@ The full lifecycle: **deploy → poll status → stream logs → update env → 
         "image_credentials": {
           "host": "ghcr.io",
           "username": "me",
-          "password": "<token>"
+          "password": "<registry-password>"
         }
       }'
     ```

--- a/src/content/docs/ai-tools/api-reference.mdx
+++ b/src/content/docs/ai-tools/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
-title: Varity HTTP API Reference
-description: Agent-facing Varity HTTP API and MCP schemas for deploying, monitoring, streaming logs, and stopping apps programmatically.
+title: Varity Public API Reference
+description: Varity public API for deploying, operating, and integrating apps programmatically.
 ---
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -9,183 +9,238 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="June 2026"
-  stability="stable"
+  lastUpdated="July 2026"
+  stability="beta"
 />
 
-Varity is built to be driven by AI agents. There are two equivalent ways to deploy and operate apps programmatically, and both are published as machine-readable schemas:
+Varity's public API is a resource API for apps, deployments, templates, pricing, credits, API keys, and webhooks. Use it for direct integrations, custom agents, launchpads, internal tools, and backend services that need to deploy or operate Varity apps without the dashboard.
 
-| Surface | Best for | Schema |
-|---------|----------|--------|
-| **MCP tools** | Agents inside an AI editor (Claude Code, Cursor, Windsurf, VS Code) | [`/mcp-schema.json`](/mcp-schema.json) |
-| **HTTP API** | Direct integrations, custom agents, backend services | [`/openapi.yaml`](/openapi.yaml) |
+The machine-readable source is:
 
-<Aside type="tip">
-If your agent runs inside an AI editor, prefer the [MCP server](/ai-tools/mcp-server-spec/). `varity_deploy`, `varity_deploy_status`, `varity_deploy_logs`, and `varity_delete_deployment` wrap the HTTP API and handle auth, framework detection, and result parsing for you. The raw HTTP API below is for everything else.
+- `https://docs.varity.so/openapi.yaml`
+- `https://varity.app/api/openapi.json`
+
+<Aside type="note">
+Older thin-client compatibility routes are not the public resource contract. New direct integrations should use the `/api/*` routes below.
 </Aside>
 
-## Machine-readable schemas
+## Base URL And Auth
 
-Point your tooling directly at these URLs. They are generated from the shipped code, so they never drift from reality:
+All public API calls use:
 
-- **`https://docs.varity.so/openapi.yaml`**: the public HTTP API (OpenAPI 3.0). Import into Postman, an OpenAPI client generator, or an agent's tool layer.
-- **`https://docs.varity.so/mcp-schema.json`**: the machine-readable Varity MCP tool catalog, including each tool's JSON Schema and annotations.
-
-## Base URL & authentication
-
-All HTTP API calls go to:
-
-```
-https://varity.app
+```text
+https://varity.app/api
 ```
 
-The `/v1` deploy endpoints require your **deploy key**, sent in the Authorization header:
+For non-browser callers, send your Varity API key as a bearer credential:
 
+```text
+Authorization: Bearer $VARITY_API_KEY
 ```
-Authorization: Bearer <your-deploy-key>
-```
 
-Get a deploy key by running `varitykit login` (the CLI stores and sends it for you) or from the developer portal at `developer.store.varity.so/dashboard/settings`. The pricing and health endpoints are public and need no auth.
+Create API keys in the Developer Portal settings page. API key plaintext is shown once. Listing and revoking keys require an authenticated Developer Portal session; plaintext keys are never returned after creation.
 
-## The operate loop
+## Deploy
 
-The full lifecycle: **deploy → poll status → stream logs → update env → redeploy → stop**. Deploy and read the result; operate the live app in place (env, redeploy) without creating a new deployment; stop it when you're done.
-
-### 1. Deploy
-
-`POST /v1/deploy` deploys from a GitHub repo or a prebuilt image. It returns a `run_id` immediately. Exactly one of `repo_url` or `image` is required.
+`POST /api/deployments` creates a deployment from one source: repository, image, or template. Use `Idempotency-Key` on create requests so normal retries and replays cannot create duplicate deployments. Do not fire concurrent create requests with the same idempotency key; atomic concurrent idempotency is a backend hardening follow-up for v1.
 
 <Tabs>
-  <TabItem label="From a repo">
+  <TabItem label="Repository">
+
     ```bash
-    curl -X POST https://varity.app/v1/deploy \
-      -H "Authorization: Bearer $VARITY_DEPLOY_KEY" \
+    curl -X POST https://varity.app/api/deployments \
+      -H "Authorization: Bearer $VARITY_API_KEY" \
       -H "Content-Type: application/json" \
+      -H "Idempotency-Key: deploy-my-app-001" \
       -d '{
-        "app_name": "my-app",
-        "source": "cli",
-        "repo_url": "https://github.com/me/my-app"
-      }'
-    # → { "run_id": "..." }
-    ```
-  </TabItem>
-  <TabItem label="From an image">
-    ```bash
-    curl -X POST https://varity.app/v1/deploy \
-      -H "Authorization: Bearer $VARITY_DEPLOY_KEY" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "app_name": "my-api",
-        "source": "cli",
-        "image": "ghcr.io/me/my-api:latest",
-        "port": 8080
-      }'
-    ```
-  </TabItem>
-  <TabItem label="Private image">
-    ```bash
-    curl -X POST https://varity.app/v1/deploy \
-      -H "Authorization: Bearer $VARITY_DEPLOY_KEY" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "app_name": "my-api",
-        "source": "cli",
-        "image": "ghcr.io/me/private-api:latest",
-        "port": 8080,
-        "image_credentials": {
-          "host": "ghcr.io",
-          "username": "me",
-          "password": "<registry-password>"
+        "name": "my-app",
+        "repository": {
+          "url": "https://github.com/me/my-app"
         }
       }'
     ```
+
+  </TabItem>
+  <TabItem label="Image">
+
+    ```bash
+    curl -X POST https://varity.app/api/deployments \
+      -H "Authorization: Bearer $VARITY_API_KEY" \
+      -H "Content-Type: application/json" \
+      -H "Idempotency-Key: deploy-my-api-001" \
+      -d '{
+        "name": "my-api",
+        "image": {
+          "ref": "ghcr.io/me/my-api:latest",
+          "port": 8080
+        }
+      }'
+    ```
+
+  </TabItem>
+  <TabItem label="Template">
+
+    ```bash
+    curl -X POST https://varity.app/api/templates/agent-zero/deploy \
+      -H "Authorization: Bearer $VARITY_API_KEY" \
+      -H "Content-Type: application/json" \
+      -H "Idempotency-Key: deploy-agent-zero-001" \
+      -d '{ "name": "my-agent" }'
+    ```
+
   </TabItem>
 </Tabs>
 
-The framework, hosting mode, and any backend services (Postgres, Redis, MongoDB, MySQL, Ollama, object storage) are detected and configured automatically, normally from your dependencies. See [Auto-wired Services](/deploy/auto-wired-services/).
-
-### 2. Poll status
-
-`GET /v1/deploy/{run_id}` returns the run's `status` (`queued` → `running` → `succeeded` / `failed`), the current `stage`, and on success the live `frontend_url`. On failure it returns a redacted `error_message` and a `failure_stage`.
+The response includes a Varity deployment id, public URL, run id, and `status_url`. Poll the run until it reaches `succeeded` or `failed`:
 
 ```bash
-curl https://varity.app/v1/deploy/$RUN_ID \
-  -H "Authorization: Bearer $VARITY_DEPLOY_KEY"
-# → { "run_id": "...", "status": "succeeded", "frontend_url": "https://varity.app/my-app/", ... }
+curl "https://varity.app/api/deployments/runs/$RUN_ID?app=my-app" \
+  -H "Authorization: Bearer $VARITY_API_KEY"
 ```
 
-### 3. Stream logs
+## Operate
 
-`GET /v1/deploy/{run_id}/logs` returns a Server-Sent Events stream of deploy progress (`detect` → `build` → `package` → `start` → `health` → `done`). The stream ends when the run reaches a terminal status.
+List deployments:
 
 ```bash
-curl -N https://varity.app/v1/deploy/$RUN_ID/logs \
-  -H "Authorization: Bearer $VARITY_DEPLOY_KEY"
+curl https://varity.app/api/deployments \
+  -H "Authorization: Bearer $VARITY_API_KEY"
 ```
 
-<Aside type="note">
-This streams **deploy-time** progress, not the running container's runtime stdout/stderr.
-</Aside>
-
-### 4. Update env vars (and redeploy)
-
-`PUT /v1/deployments/{app_name}/env` sets or updates environment variables on a live app, then redeploys it **in place**: same URL and same reserved hardware. Variables are merged over the current set by default; pass `"replace": true` to overwrite the whole set. Values are write-only and are never returned.
+Read one deployment:
 
 ```bash
-curl -X PUT https://varity.app/v1/deployments/my-app/env \
-  -H "Authorization: Bearer $VARITY_DEPLOY_KEY" \
+curl https://varity.app/api/deployments/$DEPLOYMENT_ID \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+Read logs and events:
+
+```bash
+curl https://varity.app/api/deployments/$DEPLOYMENT_ID/logs \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+
+curl https://varity.app/api/deployments/$DEPLOYMENT_ID/events \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+List environment variable keys. Values are write-only and are not returned:
+
+```bash
+curl https://varity.app/api/deployments/$DEPLOYMENT_ID/env \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+Update environment variables and redeploy in place:
+
+```bash
+curl -X PATCH https://varity.app/api/deployments/$DEPLOYMENT_ID/env \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"envVars": {"DATABASE_URL": "postgres://...", "FEATURE_X": "on"}}'
+  -d '{ "env": { "FEATURE_FLAG": "on" } }'
 ```
 
-### 5. Redeploy in place
-
-`POST /v1/deployments/{app_name}/redeploy` re-pulls the image (or rebuilds from source) and restarts the container on the **same** deployment: same URL and same reserved hardware. No body; keeps the current env vars.
+Redeploy, restart, or delete:
 
 ```bash
-curl -X POST https://varity.app/v1/deployments/my-app/redeploy \
-  -H "Authorization: Bearer $VARITY_DEPLOY_KEY"
+curl -X POST https://varity.app/api/deployments/$DEPLOYMENT_ID/redeploy \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+
+curl -X POST https://varity.app/api/deployments/$DEPLOYMENT_ID/restart \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+
+curl -X DELETE https://varity.app/api/deployments/$DEPLOYMENT_ID \
+  -H "Authorization: Bearer $VARITY_API_KEY"
 ```
 
-### 6. Stop (and stop billing)
+## Templates, Pricing, And Credits
 
-`DELETE /v1/deployments/{app_name}` permanently stops the app and ends its billing, freeing the reserved hardware.
+Templates are deployable app starters. Pricing is estimated from the live API, not a hardcoded table, and returns fixed monthly hardware-reservation cost for the requested profile. Credits show whether the caller can deploy with a payment method or active starter credit.
 
 ```bash
-curl -X DELETE https://varity.app/v1/deployments/my-app \
-  -H "Authorization: Bearer $VARITY_DEPLOY_KEY"
+curl https://varity.app/api/templates \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+
+curl "https://varity.app/api/pricing/estimate?profile=web-app" \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+
+curl https://varity.app/api/credits \
+  -H "Authorization: Bearer $VARITY_API_KEY"
 ```
 
-## Pricing (public)
+## Webhooks
 
-`GET /api/pricing?profile=<profile>` returns the flat monthly price for a workload profile plus a comparison against usage-metered hosts. No auth required.
+Create a webhook:
 
 ```bash
-curl "https://varity.app/api/pricing?profile=web"
-# → { "profile": "web", "varityMonthly": 6, "varityIsFlat": true, ... }
+curl -X POST https://varity.app/api/webhooks \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com/varity/webhook",
+    "events": ["deployment.accepted", "deployment.live", "deployment.failed"]
+  }'
 ```
 
-Pricing is a flat hardware reservation. It does not change with traffic, bandwidth, invocations, or build minutes.
+The response includes `signing_secret` once. Store it to verify webhook deliveries. Varity signs each delivery with:
 
-## Endpoint summary
+- `X-Varity-Event-Id`
+- `X-Varity-Timestamp`
+- `X-Varity-Signature`
 
-| Method | Path | Auth | Purpose |
-|--------|------|------|---------|
-| `POST` | `/v1/deploy` | deploy key | Start a deploy |
-| `GET` | `/v1/deploy/{run_id}` | deploy key | Get status + result |
-| `GET` | `/v1/deploy/{run_id}/logs` | deploy key | Stream deploy logs (SSE) |
-| `PUT` | `/v1/deployments/{app_name}/env` | deploy key | Set env vars + redeploy in place |
-| `POST` | `/v1/deployments/{app_name}/redeploy` | deploy key | Redeploy/restart in place |
-| `DELETE` | `/v1/deployments/{app_name}` | deploy key | Stop a deployment + billing |
-| `GET` | `/api/pricing` | public | Live flat pricing |
-| `GET` | `/health` | public | Service health |
+The signature is `v1=` plus an HMAC-SHA256 over `timestamp.body` using the webhook signing secret. Webhook endpoint URLs must be public HTTPS URLs; local and private hosts are rejected.
+
+Webhook handlers should be idempotent. Delivery-time DNS/IP revalidation, durable delivery queue hardening, and additional signing-secret custody hardening remain non-blocking v1 follow-ups.
+
+List webhooks and delivery status:
+
+```bash
+curl "https://varity.app/api/webhooks?include_deliveries=true" \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+Delete a webhook:
+
+```bash
+curl -X DELETE https://varity.app/api/webhooks/$WEBHOOK_ID \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+## Endpoint Summary
+
+The OpenAPI document contains these 18 public paths:
+
+| Methods | Path | Purpose |
+|---------|------|---------|
+| `GET`, `POST` | `/api/deployments` | List or create deployments |
+| `GET` | `/api/deployments/runs/{run_id}` | Get deployment run status |
+| `GET`, `DELETE` | `/api/deployments/{deployment_id}` | Read or delete a deployment |
+| `GET` | `/api/deployments/{deployment_id}/logs` | Read deployment logs |
+| `GET` | `/api/deployments/{deployment_id}/events` | Read deployment events |
+| `GET`, `PATCH` | `/api/deployments/{deployment_id}/env` | List environment variable keys or update values |
+| `POST` | `/api/deployments/{deployment_id}/redeploy` | Redeploy in place |
+| `POST` | `/api/deployments/{deployment_id}/restart` | Restart in place |
+| `GET` | `/api/templates` | List templates |
+| `GET` | `/api/templates/{template_id}` | Read a template |
+| `POST` | `/api/templates/{template_id}/deploy` | Deploy a template |
+| `GET` | `/api/pricing/estimate` | Estimate fixed monthly cost |
+| `GET` | `/api/credits` | Read credit and deploy eligibility |
+| `GET`, `POST` | `/api/webhooks` | List or create webhooks |
+| `DELETE` | `/api/webhooks/{webhook_id}` | Delete a webhook |
+| `GET`, `POST` | `/api/api-keys` | List or create API keys in the Developer Portal |
+| `DELETE` | `/api/api-keys/{key_id}` | Revoke an API key in the Developer Portal |
+| `GET` | `/api/openapi.json` | Read the live OpenAPI contract |
 
 <Aside type="caution">
-This is the complete public, agent-facing surface. Internal control-plane routes (identity, billing, the deployment registry, telemetry, and infrastructure plumbing) are intentionally not part of this contract and may change without notice.
+Public API responses use Varity product resources only. Internal implementation details are not part of this contract.
 </Aside>
 
-## Next steps
+<Aside type="note">
+API-key management endpoints are Developer Portal session routes in v1. API keys authenticate non-browser API callers, but API keys cannot create, list, or revoke other API keys. Revoked keys can have a short cache-propagation window before every edge rejects them.
+</Aside>
 
-- **[MCP Server Spec](/ai-tools/mcp-server-spec/)**: the full tool reference for AI editors
+## Next Steps
+
+- **[MCP Server Spec](/ai-tools/mcp-server-spec/)**: the tool reference for AI editors
 - **[Deploy a Docker Image](/deploy/deploy-docker-image/)**: image-deploy details
-- **[Auto-wired Services](/deploy/auto-wired-services/)**: how databases and caches get attached
+- **[Environment Variables](/deploy/env-variables/)**: runtime configuration

--- a/src/content/docs/ai-tools/mcp-server-spec.mdx
+++ b/src/content/docs/ai-tools/mcp-server-spec.mdx
@@ -208,7 +208,7 @@ Create a new GitHub repository and push your project to it. Useful for getting y
 | `description` | string | No | none | Short description for the repo |
 | `path` | string | No | Current directory | Absolute path to the local project to push (e.g. `/home/user/my-app`) |
 | `visibility` | `"public"` \| `"private"` | No | `"public"` | Repository visibility |
-| `github_token` | string | No | none | GitHub personal access token with `repo` scope (or set `GITHUB_TOKEN`) |
+| `github_token` | string | No | none | GitHub personal access credential with `repo` scope (or set `GITHUB_TOKEN`) |
 
 **Annotations:** `destructiveHint: true` (creates an external GitHub repository)
 

--- a/src/content/docs/cli/commands/deploy.mdx
+++ b/src/content/docs/cli/commands/deploy.mdx
@@ -82,7 +82,7 @@ Dynamic hosting is powered by cloud compute. Use `--hosting dynamic` for server-
 | `--image` | None | Deploy a prebuilt OCI image instead of building from source |
 | `--image-registry` | None | Registry host for a private `--image` |
 | `--image-username` | None | Username for a private `--image` |
-| `--image-password` | None | Password/token for a private `--image` |
+| `--image-password` | None | Password or secret value for a private `--image` |
 | `--port` | `80` | Port your dynamic app listens on |
 | `--dry-run` | `false` | Preview the deployment without shipping (not compatible with `--image`) |
 

--- a/src/content/docs/deploy/deploy-docker-image.mdx
+++ b/src/content/docs/deploy/deploy-docker-image.mdx
@@ -47,7 +47,7 @@ Public and private Docker/OCI images are supported when the image starts a runna
     --image registry.example.com/acme/my-api:1.4.2 \
     --image-registry registry.example.com \
     --image-username my-user \
-    --image-password my-token
+    --image-password my-password
   ```
 
   </TabItem>
@@ -56,7 +56,7 @@ Public and private Docker/OCI images are supported when the image starts a runna
   1. Open [developer.store.varity.so/dashboard/deploy](https://developer.store.varity.so/dashboard/deploy)
   2. Select the **Docker image** tab
   3. Enter the image reference (for example `ghcr.io/acme/my-api:1.4.2`) and, optionally, the container port
-  4. For a private image, add the registry host, username, and token/password
+  4. For a private image, add the registry host, username, and password or secret value
   5. Click deploy
 
   </TabItem>

--- a/src/content/docs/deploy/deployment-troubleshooting.mdx
+++ b/src/content/docs/deploy/deployment-troubleshooting.mdx
@@ -148,7 +148,7 @@ Compute was reserved but the container exited immediately after launch.
 
 2. **Port mismatch**: the container isn't listening on the expected port. Confirm your app listens on `0.0.0.0`, not `127.0.0.1`.
 
-3. **Out-of-memory (OOM)**: the process was killed by the kernel during startup. Check your `package.json` for memory-intensive build steps.
+3. **Out-of-memory (OOM)**: the process was killed by the operating system during startup. Check your `package.json` for memory-intensive build steps.
 
 **Get more detail from logs:**
 

--- a/src/content/docs/guides/deploy-from-ai-ide.mdx
+++ b/src/content/docs/guides/deploy-from-ai-ide.mdx
@@ -169,6 +169,9 @@ The Varity MCP server gives your AI editor a full set of tools. Here are the mos
 | `varity_list_templates` | "What templates can Varity deploy?" |
 | `varity_template_info` | "What does the Agent Zero template need?" |
 | `varity_deploy_template` | "Deploy Agent Zero with these environment variables" |
+| `varity_list_agents` | "What agent templates can Varity deploy?" |
+| `varity_agent_info` | "What does the Agent Zero template need?" |
+| `varity_deploy_agent` | "Deploy Agent Zero" |
 
 Full reference at [MCP Server Spec](/ai-tools/mcp-server-spec).
 

--- a/src/content/docs/resources/glossary.mdx
+++ b/src/content/docs/resources/glossary.mdx
@@ -23,7 +23,7 @@ A web application deployed on Varity. Static apps get a URL at `https://varity.a
 
 ### Deploy Key
 
-A secret token that authenticates your deploys. Required when deploying from CI/CD or non-interactive environments.
+A secret key that authenticates your deploys. Required when deploying from CI/CD or non-interactive environments.
 
 Generate one at [developer.store.varity.so](https://developer.store.varity.so) or with:
 

--- a/src/content/docs/tutorials/deploy-ai-agent.mdx
+++ b/src/content/docs/tutorials/deploy-ai-agent.mdx
@@ -30,10 +30,9 @@ If you prefer the terminal or your AI editor, deploy the same certified template
 <Tabs>
   <TabItem label="CLI">
 
-  List the certified catalog, then deploy by template ID. Pass any required environment variables with repeated `--env` flags:
+  Use the portal or MCP tools to find the certified template ID, then deploy it from the CLI. Pass any required environment variables with repeated `--env` flags:
 
   ```bash
-  varitykit app templates
   varitykit app deploy --template flowise --name my-flowise
   ```
 


### PR DESCRIPTION
## Scope

Close Wave 2 APIDOCS only for docs.varity.so:

- Refresh `public/openapi.yaml` to match live `https://varity.app/api/openapi.json`.
- Replace stale `/v1/*` API reference prose with the shipped `/api/*` public platform API.
- Document auth, base URL, repo/image/template deploys, logs/events/env/redeploy/restart/delete, templates, pricing, credits, webhooks, idempotency caveat, API-key portal-only management, and short revocation-cache caveat.
- Refresh LLM-readable API entries in `llms.txt` and the API block in `llms-full.txt`.
- Apply type-only docs component fixes required for `npm run lint` to pass.

No gateway/backend code, no API_GATE reopen, no provider/orchestration mechanics, and no new API website/repo.

## Validation

- `node /home/macoding/varity-workspace/varity-ops/scripts/cloak-portal.mjs --doctor --check-path /dashboard/deploy` -> pass (`authed=true`).
- `curl -sS https://varity.app/api/openapi.json -o /tmp/varity-openapi.json` -> pass.
- Live OpenAPI vs source/built docs OpenAPI -> exact match: OpenAPI `3.1.0`, title `Varity Public Platform API`, version `2026-07-10`, server `https://varity.app/api`, security schemes `ApiKeyAuth` + `PortalSession`, 18 paths, no live-only/docs-only paths.
- APIDOCS denylist scan on `api-reference.mdx` + `public/openapi.yaml` -> no hits.
- Stale `/v1/*` / `Varity HTTP API` / `OpenAPI 3.0` / `VARITY_DEPLOY_KEY` scan on API reference materials -> no APIDOCS hits.
- API shell snippets extracted from `api-reference.mdx` and the `llms-full` API block -> `bash -n` pass.
- `npm run lint` -> pass (0 errors; existing warnings/hints only).
- `npm run build` -> pass; 47 pages built and sitemap generated.
- Local static preview: `/ai-tools/api-reference/` HTTP 200; `/openapi.yaml` serves OpenAPI `3.1.0`, title `Varity Public Platform API`, version `2026-07-10`, server `https://varity.app/api`, 18 paths.
- Cloak local preview screenshots at 1440x1000 and 390x844 -> no console errors and clean layout.
- Build artifacts: sitemap contains `/ai-tools/api-reference/`, canonical URL is present, `llms.txt` contains `Varity Public API Reference`.

## Notes

API_GATE remains closed separately. APIDOCS is the only gate this PR intends to close.