### PR TITLE
ci: make Docs Quality Check unprivileged (drop private checkouts)

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,3 +1,25 @@
+# Docs Quality Check — repo-local, UNPRIVILEGED build gate.
+#
+# SECURITY (PROPAGATION gate §3, §4 finding 6, §13): this public repository's PR
+# CI must NOT check out private source or hold a cross-repo credential. The prior
+# version of this workflow cloned varity-labs/varity-ops, varity-labs/varity-mcp,
+# and the PRIVATE Michael-Abril/varity-sdk-private into the same runner that then
+# ran PR-controlled `npm ci` / `npm run build`, and executed the ops
+# docs-accuracy propagation gate against them. GitHub's guidance treats
+# PR install/build scripts as untrusted code, so that design let a malicious docs
+# PR read the private SDK source or exfiltrate VARITY_OPS_REPO_TOKEN /
+# VARITY_SDK_PRIVATE_REPO_TOKEN.
+#
+# The universal cross-surface docs propagation evaluation (docs accuracy, OpenAPI
+# parity, command/tool references, restricted vocabulary) now runs OUTSIDE
+# PR-controlled code: the private GitHub App publishes `Propagation / decision`,
+# and the private sweep runner covers scheduled drift. This workflow is only the
+# repo-local proof that the docs site builds.
+#
+# The VARITY_OPS_REPO_TOKEN and VARITY_SDK_PRIVATE_REPO_TOKEN secrets are no
+# longer referenced by any workflow here and are staged for founder removal/
+# rotation once the App check is live (gate §11 action 6). Do not re-introduce a
+# private checkout or a cross-repo secret into this public repository's CI.
 name: Docs Quality Check
 
 on:
@@ -5,99 +27,26 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-  schedule:
-    - cron: '0 8 * * *'
   workflow_dispatch:
-    inputs:
-      ops_ref:
-        description: varity-ops ref to test against
-        required: false
-        default: master
-      sdk_ref:
-        description: varity-sdk-private ref to test against
-        required: false
-        default: main
 
 permissions:
   contents: read
 
-env:
-  VARITY_WORKSPACE_ROOT: ${{ github.workspace }}/varity-workspace
-
 jobs:
-  docs-quality:
+  docs-build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout docs
         uses: actions/checkout@v4
-        with:
-          path: varity-workspace/varity-docs
-
-      - name: Require cross-repo checkout tokens
-        env:
-          VARITY_OPS_REPO_TOKEN: ${{ secrets.VARITY_OPS_REPO_TOKEN }}
-          VARITY_SDK_PRIVATE_REPO_TOKEN: ${{ secrets.VARITY_SDK_PRIVATE_REPO_TOKEN }}
-        run: |
-          if [ -z "$VARITY_OPS_REPO_TOKEN" ]; then
-            echo "::error::Set VARITY_OPS_REPO_TOKEN with read access to varity-labs/varity-ops and varity-labs/varity-mcp before enabling the full docs propagation gate."
-            exit 1
-          fi
-          if [ -z "$VARITY_SDK_PRIVATE_REPO_TOKEN" ]; then
-            echo "::error::Set VARITY_SDK_PRIVATE_REPO_TOKEN with read access to Michael-Abril/varity-sdk-private before enabling the full docs propagation gate."
-            exit 1
-          fi
-
-      - name: Checkout ops verifier
-        uses: actions/checkout@v4
-        with:
-          repository: varity-labs/varity-ops
-          ref: ${{ github.event.inputs.ops_ref || 'master' }}
-          path: varity-workspace/varity-ops
-          token: ${{ secrets.VARITY_OPS_REPO_TOKEN }}
-
-      - name: Checkout MCP source
-        uses: actions/checkout@v4
-        with:
-          repository: varity-labs/varity-mcp
-          path: varity-workspace/varity-mcp-standalone
-          token: ${{ secrets.VARITY_OPS_REPO_TOKEN }}
-
-      - name: Checkout private SDK source
-        uses: actions/checkout@v4
-        with:
-          repository: Michael-Abril/varity-sdk-private
-          ref: ${{ github.event.inputs.sdk_ref || 'main' }}
-          path: varity-workspace/varity-sdk-private
-          token: ${{ secrets.VARITY_SDK_PRIVATE_REPO_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: npm
-          cache-dependency-path: varity-workspace/varity-docs/package-lock.json
 
-      - name: Install docs dependencies
-        working-directory: ${{ env.VARITY_WORKSPACE_ROOT }}/varity-docs
+      - name: Install dependencies
         run: npm ci
 
       - name: Build docs
-        working-directory: ${{ env.VARITY_WORKSPACE_ROOT }}/varity-docs
         run: npm run build
-
-      - name: Run propagation docs gate
-        working-directory: ${{ env.VARITY_WORKSPACE_ROOT }}/varity-ops/scripts/docs-accuracy
-        env:
-          DOCS_ACCURACY_FAIL_ON: high
-          DOCS_ACCURACY_REPORT_DIR: ${{ runner.temp }}/varity-docs-accuracy
-          VARITY_WORKSPACE_ROOT: ${{ env.VARITY_WORKSPACE_ROOT }}
-        run: node docs-accuracy-gate.mjs
-
-      - name: Upload propagation reports
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: varity-docs-accuracy-reports
-          path: ${{ runner.temp }}/varity-docs-accuracy/*.json
-          if-no-files-found: warn


### PR DESCRIPTION
Replaces the private-checkout docs CI with a **repo-local, unprivileged** build gate (PROPAGATION gate §4 finding 6, §8 R2.4).

**Problem**: the prior `Docs Quality Check` cloned `varity-ops`, `varity-mcp`, and the **private** `Michael-Abril/varity-sdk-private` into the runner, then ran PR-controlled `npm ci`/`npm run build` and the ops docs-accuracy gate against them. GitHub treats PR install/build scripts as untrusted code, so a malicious docs PR could read the private SDK source or exfiltrate `VARITY_OPS_REPO_TOKEN`/`VARITY_SDK_PRIVATE_REPO_TOKEN`.

**Now**: `permissions: contents: read`, checks out only the docs repo, runs `npm ci` + `astro build` (green on master). No private checkout, no cross-repo secret.

The universal cross-surface docs propagation evaluation (docs accuracy, OpenAPI parity, command/tool references, restricted vocabulary) moves **outside PR-controlled code** to the private GitHub App's `Propagation / decision` check and the private sweep runner.

`VARITY_OPS_REPO_TOKEN` / `VARITY_SDK_PRIVATE_REPO_TOKEN` are no longer referenced and are **staged for founder removal/rotation** once the App check is live (gate §11 action 6) — not deleted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)