### PR TITLE
docs(architecture): govern documentation provenance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,12 +10,28 @@ _Context: what problem does this solve or what was missing?_
 
 Closes #<!-- issue number -->
 
+## Architecture impact
+
+Architecture impact: none
+Reason: <!-- one concrete sentence -->
+Affected runtime services/modules: none
+Interfaces/data/security/topology changed: no
+Architecture/ADR files: none
+
+<!--
+Use exactly "Architecture impact: none" or "Architecture impact: updated".
+If updated, name the affected modules and architecture or ADR files. An
+implementation-only or copy-only change behind unchanged interfaces may use
+none. Reviewers compare this declaration with the diff.
+-->
+
 ## Checklist
 
 - [ ] Code examples are tested and working
 - [ ] No forbidden vocabulary in prose (no blockchain/crypto/DePIN/wallet/Akash/IPFS terms — see [terminology guide](CONTRIBUTING.md#terminology))
 - [ ] No em-dashes in prose (use "and", "or", "with", or a colon instead)
 - [ ] Build passes (`npm run build`)
+- [ ] Repository check passes (`npm run check`)
 - [ ] Links are valid
 - [ ] Spelling and grammar reviewed
 

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -29,5 +29,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify architecture, public contracts, and positioning
+        run: npm test
+
+      - name: Check Astro project
+        run: npm run lint
+
       - name: Build docs
         run: npm run build
+
+      - name: Verify built contract copies
+        run: npm run test:built-contracts

--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ coverage/
 # Local dev / agent scratch — not for the public docs repo
 .playwright-mcp/
 drafts/
-CLAUDE.md
 
 # Internal dev artifacts / reports / screenshots — never in the public docs repo
 /Screenshot*.png

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,167 @@
+# Varity Documentation Architecture
+
+Status: current repository architecture
+Last code-grounded audit: 2026-07-18
+
+This document is the repository-level architecture layer for
+`varity-docs`. The workspace-level system map owns cross-repository runtime
+relationships. This file owns how public documentation and machine-readable
+artifacts are authored, verified, and published.
+
+## Context and responsibility
+
+`varity-docs` is a static publishing surface. Developers and AI tools consume
+content from `docs.varity.so`; maintainers author checked-in content and GitHub
+Actions verifies the repository before the hosting platform publishes the
+static build.
+
+The repository owns:
+
+- public product documentation and navigation;
+- the public OpenAPI projection;
+- the public MCP tool-catalog projection;
+- LLM-readable summary and full-context projections;
+- static-site composition, metadata, redirects, and public assets;
+- deterministic repository-local documentation verification.
+
+It does not own shipped capability, pricing values, authentication, deployment
+execution, durable state, the MCP implementation, or the public gateway
+implementation.
+
+```mermaid
+flowchart LR
+  A[Root product and positioning authorities]
+  B[Gateway public interface source]
+  C[MCP implementation source]
+  H[Human maintainers]
+  D[Checked-in docs and contract projections]
+  V[Repository-local verification]
+  S[Astro static build]
+  P[docs.varity.so]
+  U[Developers and AI tools]
+
+  A --> D
+  B --> D
+  C --> D
+  H --> D
+  D --> V
+  D --> S
+  V --> S
+  S --> P
+  P --> U
+```
+
+The arrows from runtime repositories are semantic provenance, not runtime
+calls. The built site does not depend on those repositories or their secrets.
+
+## Modules and interfaces
+
+### Human documentation module
+
+- **Interface:** routable pages, frontmatter, links, examples, user-visible
+  terminology, and navigation configured in `astro.config.mjs`.
+- **Implementation:** `src/content/docs/`, `src/components/`, `src/styles/`,
+  `src/assets/`, `src/content.config.ts`, and `astro.config.mjs`.
+- **Seam:** Astro's content loader and static route generation.
+- **Test surface:** Astro type checking/build, positioning checks, link review,
+  and local browser verification.
+
+### Machine-readable publication module
+
+- **Interface:** stable public URLs `/openapi.yaml`, `/mcp-schema.json`,
+  `/llms.txt`, and `/llms-full.txt`.
+- **Implementation:** checked-in files under `public/` which Astro copies into
+  `dist/` without transformation.
+- **Seam:** static public-file publication.
+- **Test surface:** `tests/test-contract-artifacts.cjs`, followed by the Astro
+  build and `npm run test:built-contracts`.
+
+This module intentionally makes no generation claim. The four artifacts are
+checked-in projections and must be reconciled manually from their narrower
+authorities in the same pull request. A future generator is acceptable only if
+its source and deterministic verification are checked in with it.
+
+### Verification module
+
+- **Interface:** `npm test` for deterministic repository tests and
+  `npm run check` for the complete merge check.
+- **Implementation:** `tests/test-contract-artifacts.cjs`,
+  `tests/test-positioning-static.cjs`,
+  `tests/test-architecture-governance.cjs`, package scripts, and
+  `.github/workflows/test-docs.yml`.
+- **Seam:** process exit status in local development and GitHub Actions.
+- **Test surface:** the same commands maintainers and CI run.
+
+The older `tests/test-docs.cjs` live crawler is outside this interface. It is
+network-dependent, refers to retired product surfaces, and is retained only as
+historical diagnostic material until a separate cleanup change proves which
+checks should be ported or deleted.
+
+## Content and artifact provenance
+
+| Published surface | Checked-in owner | Narrower authority to reconcile | Required verification |
+|---|---|---|---|
+| Human pages | `src/content/docs/` | Workspace manifest, positioning, pricing, security, and current public behavior | `npm run check` plus browser review when visual/navigation behavior changes |
+| OpenAPI | `public/openapi.yaml` | Gateway-owned public platform interface and its current implementation tests | JSON/OpenAPI structure, internal references, unique operation IDs, API-reference link, build copy |
+| MCP catalog | `public/mcp-schema.json` | Canonical `@varity-labs/mcp` implementation and published package contract | JSON/schema structure, tool-count/name uniqueness, reference-page links, build copy |
+| LLM summary | `public/llms.txt` | Current public pages and supported product claims | Required identity/artifact links, no placeholder content, build copy |
+| LLM full context | `public/llms-full.txt` | Current public pages and supported product claims | Required identity/artifact links, nontrivial full-content size, build copy |
+| Redirects and static assets | `public/` | Current hosting behavior and brand assets | Redirect invariant, Astro build, visual review where applicable |
+
+The contract projections are public documentation artifacts. They must not
+contain infrastructure credentials, private provider details, internal
+orchestration logic, customer data, or claims that exceed the shipped product.
+
+## Build and publication flow
+
+```text
+source content + components + public artifacts
+  -> npm test
+     -> architecture governance
+     -> contract projection conformance
+     -> positioning guardrails
+  -> npm run lint
+  -> npm run build
+  -> dist/
+  -> verify unchanged built contract copies
+  -> static hosting release
+```
+
+`dist/`, `.astro/`, and `node_modules/` are generated and never authoritative.
+The repository CI uses only `contents: read`, checks out no private repository,
+and requires no production credential.
+
+## Failure semantics
+
+- A malformed or internally inconsistent contract projection fails `npm test`.
+- A high-severity public terminology violation fails `npm test`.
+- A missing architecture declaration fails pull-request CI, but local and push
+  runs still validate the required architecture files.
+- An Astro type or rendering error fails lint/build.
+- External-link availability is not a deterministic merge assertion. Verify
+  relevant external links during review or a separately governed scheduled
+  check.
+- A green static build does not prove that product claims match live behavior.
+  The author must reconcile the narrower product authority before editing.
+
+## Change navigation
+
+| Change | Inspect and update together |
+|---|---|
+| Public deployment field or route | Gateway interface, OpenAPI, API reference, affected guides, MCP/CLI/portal consumers outside this repo |
+| MCP tool name or input/output contract | MCP implementation, MCP catalog, MCP reference, LLM artifacts |
+| Supported capability | Workspace manifest and gate evidence first, then affected pages and LLM artifacts |
+| Pricing language | Root pricing/positioning authority, affected pages and LLM artifacts; never hardcode live values |
+| Page or information architecture | Page source, `astro.config.mjs`, links, metadata, sitemap behavior, local responsive review |
+| Publishing topology or artifact provenance | This file, CI/workflows, pull-request architecture declaration, and a workspace ADR when load-bearing |
+
+## Security and privacy
+
+- The static site holds no runtime secret and repository CI has no private
+  checkout token.
+- All content in this public repository must be safe for public disclosure.
+- Examples use environment-variable names and non-secret sample values only.
+- Public interface documentation must stay provider-neutral and must not expose
+  proprietary orchestration logic.
+- Security incidents and sensitive reports follow `SECURITY.md`, not public
+  issues or documentation pages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md - Varity Documentation
+
+Status: repository entrypoint
+Last updated: 2026-07-18
+
+This repository publishes the public documentation at `docs.varity.so`. It is
+a static Astro/Starlight surface, not a control-plane runtime.
+
+## Read first
+
+When this checkout is inside the Varity workspace, read the workspace root
+`CLAUDE.md`, `varity.manifest.yaml`, `POSITIONING.md`, and
+`PRICING-MODEL-CANONICAL.md` before changing product claims. Then read
+`ARCHITECTURE.md` here for content and artifact provenance.
+
+Authority rules:
+
+- The workspace manifest and live code own shipped capability and public
+  interface reality. Documentation projects that truth; it does not create it.
+- The root positioning and pricing authorities own public language and claim
+  structure. Never hardcode live pricing numbers.
+- `src/content/docs/` owns human-facing pages.
+- `public/openapi.yaml`, `public/mcp-schema.json`, `public/llms.txt`, and
+  `public/llms-full.txt` are checked-in public contract projections. Update and
+  verify every affected projection in the same pull request.
+- Do not expose providers, credentials, infrastructure mechanics, private
+  orchestration logic, or unshipped features in public prose.
+
+## Verification
+
+Run the repository's complete local check before merge:
+
+```bash
+npm ci
+npm run check
+```
+
+For visual or navigation changes, also inspect the local site at
+`http://localhost:4321` and verify the affected pages on desktop and mobile.
+
+Every pull request must complete the `Architecture impact` block in the pull
+request template. Update `ARCHITECTURE.md` only when ownership, an interface,
+artifact provenance, security posture, or publishing topology changes.
+
+## Scope guardrails
+
+- Do not edit backend, portal, CLI, or MCP implementation from this repository.
+- Do not copy gate status, live version literals, or temporary release evidence
+  into architecture files.
+- Do not restore the retired cross-repository PROPAGATION workflow. Repository
+  CI is intentionally unprivileged and checks only this checkout.
+- Do not treat the legacy live-crawl harness in `tests/test-docs.cjs` as a merge
+  gate. It is network-dependent and contains historical checks; the deterministic
+  merge gate is `npm run check`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,10 +49,10 @@ Edit files in `src/content/docs/`. The site will hot-reload as you make changes.
 
 - Verify the page renders correctly in your browser
 - Check that all code examples work (copy-paste and test them)
-- Run the build to catch any errors:
+- Run the complete repository check:
 
 ```bash
-npm run build
+npm run check
 ```
 
 ### 6. Submit a Pull Request

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Other commands:
 npm run build      # production build to ./dist
 npm run preview    # preview the production build
 npm run lint       # astro check
+npm test           # architecture, contract, and positioning checks
+npm run check      # complete merge check
 ```
 
 Documentation content lives in `src/content/docs/`:
@@ -81,6 +83,9 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR. Two rules matter mo
 
 - Every documented command, flag, and code example must be accurate and tested against the current product.
 - Document only shipped capabilities. Never describe a feature that is not yet available.
+
+Repository structure, machine-readable artifact provenance, and verification
+ownership are documented in [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Community
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,13 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "lint": "astro check"
+    "lint": "astro check",
+    "test": "npm run test:architecture && npm run test:contracts && npm run test:positioning",
+    "test:architecture": "node tests/test-architecture-governance.cjs",
+    "test:contracts": "node tests/test-contract-artifacts.cjs",
+    "test:built-contracts": "VERIFY_DIST=1 node tests/test-contract-artifacts.cjs",
+    "test:positioning": "node tests/test-positioning-static.cjs",
+    "check": "npm test && npm run lint && npm run build && npm run test:built-contracts"
   },
   "dependencies": {
     "@astrojs/sitemap": "3.6.0",

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,204 +1,29 @@
-# Varity Docs Automated Tester v4.0 (World-Class Edition)
+# Documentation verification
 
-Enterprise-grade documentation testing for [docs.varity.so](https://docs.varity.so). **Auto-discovers** all pages by crawling, extracts every code snippet, and runs **nine test suites** to catch issues before your users do — just like Vercel and Supabase test their docs.
-
-## What it tests
-
-| Suite | What it checks | Why it matters |
-|-------|---------------|----------------|
-| **1. Page Discovery** | Auto-crawls to find ALL pages | No manual list maintenance |
-| **2. Link Checker** | Every internal and external link | Broken links = broken trust |
-| **3. Anchor Validator** | Every `#section` link | Catches broken heading links |
-| **4. Code Extractor** | Extracts and categorizes every code block | Baseline for all code tests |
-| **5. Import Validator** | Every import/require against real npm packages | Wrong package names = instant developer churn |
-| **6. SDK Version Check** | Verifies packages exist on npm | Catches references to unpublished packages |
-| **7. Positioning Compliance** | Scans for forbidden words (blockchain, wallet, Web3, etc.) | Maintains the "invisible infrastructure" positioning |
-| **8. Consistency Check** | Package names, CLI commands, revenue %, pricing across all pages | Contradictions destroy credibility |
-| **9. TypeScript Compiler** | Compiles TS/TSX against REAL @varity-labs/sdk types | Catches type errors before users copy-paste |
-
-## Quick start
+The deterministic merge gate is:
 
 ```bash
-git clone <this-repo>
-cd varity-docs-tester
-npm install
-npm test
+npm run check
 ```
 
-## Run specific suites
+It runs:
 
-```bash
-# Run all tests (with auto-discovery)
-npm test
+1. `test-architecture-governance.cjs`: required architecture entrypoints and
+   pull-request impact declaration.
+2. `test-contract-artifacts.cjs`: checked-in OpenAPI, MCP, and LLM publication
+   artifacts.
+3. `test-positioning-static.cjs`: high-severity public terminology and hosting
+   redirect invariants.
+4. `astro check`: Astro and content typing.
+5. `astro build`: production static-site composition.
+6. `test:built-contracts`: verifies Astro copied each public contract artifact
+   into `dist/` unchanged.
 
-# Run individual suites
-npm run test:links        # Check all links
-npm run test:anchors      # Check #section links
-npm run test:imports      # Validate import statements
-npm run test:versions     # Check SDK versions on npm
-npm run test:positioning  # Check for forbidden words
-npm run test:consistency  # Check for contradictions
-npm run test:typescript   # TypeScript compilation
+The checks are repository-local, deterministic, unprivileged, and require no
+private checkout or production credential.
 
-# Skip auto-discovery (use hardcoded page list - faster)
-npm run test:fast
-
-# Or with node directly
-node test-docs.js --only links
-node test-docs.js --only anchors
-node test-docs.js --only versions
-node test-docs.js --no-discover    # Skip auto-discovery
-```
-
-## Enterprise Mode (Real SDK Type Checking)
-
-For full type checking against the actual `@varity-labs/sdk` package:
-
-```bash
-# One-time setup: installs SDK packages locally
-npm run setup
-
-# Now run tests with real SDK types
-npm test
-```
-
-This installs the SDK in an isolated `.sdk-test-env/` directory and validates:
-- All imports resolve to real exports
-- TypeScript types match the SDK's actual types
-- No "Property does not exist" or "has no exported member" errors
-
-## Output
-
-The tester generates two reports:
-
-1. **`reports/docs-test-YYYY-MM-DD.json`** — Full machine-readable report
-2. **`reports/CLAUDE-CODE-FIX-LIST.md`** — Paste into Claude Code to auto-fix all issues
-
-### Example output
-
-```
-╔══════════════════════════════════════════════════════════╗
-║     VARITY DOCS AUTOMATED TESTER v4.0 (World-Class)      ║
-║   Auto-Discovery • SDK Validation • Anchor Checking      ║
-╚══════════════════════════════════════════════════════════╝
-
-🔍 AUTO-DISCOVERING all documentation pages...
-
-  ✓ Found: /
-  ✓ Found: /getting-started/introduction/
-  ✓ Found: /getting-started/quickstart/
-  ...
-
-  📄 Discovered 24 documentation pages
-
-━━━ SDK VERSION CHECK ━━━
-  ✓ @varity-labs/sdk@1.2.3 (published on npm)
-  ✓ @varity-labs/ui-kit@0.9.0 (published on npm)
-
-━━━ ANCHOR LINK VALIDATOR ━━━
-  ✓ 156 anchor links OK
-  ✗ 3 broken anchor links
-
-━━━ IMPORT VALIDATOR ━━━
-  ✓ 89 imports/installs OK
-  ✗ 1 wrong package name
-    → CRITICAL: "@varity/sdk" should be "@varity-labs/sdk"
-
-═══════════════════════════════════════════════════════════
-  VARITY DOCS TEST REPORT
-═══════════════════════════════════════════════════════════
-  Pages crawled:    24/24
-  Tests passed:     1,247
-  Tests failed:     4
-  CRITICAL issues:  1
-  HIGH issues:      2
-  MEDIUM issues:    1
-═══════════════════════════════════════════════════════════
-```
-
-## CI/CD Integration
-
-Copy `.github/workflows/test-docs.yml` into your docs repo:
-
-- Runs on every push to `main`
-- Runs on every PR
-- Runs daily at 8am UTC (catches external link rot)
-- Posts results as PR comments
-- Fails the build on critical issues
-- Uploads full test report as artifact
-
-## Configuration
-
-Edit `test-docs.js` to customize:
-
-### Fallback docs pages (line ~72)
-Used when auto-discovery is disabled or fails:
-```javascript
-const DOCS_PAGES = [
-  '/',
-  '/getting-started/introduction/',
-  '/getting-started/installation/',
-  // ... add your pages
-];
-```
-
-### Valid npm packages (line ~125)
-```javascript
-const VALID_NPM_PACKAGES = {
-  '@varity-labs/sdk': true,
-  '@varity-labs/ui-kit': true,
-  '@varity-labs/types': true,
-  // ... add your packages
-};
-```
-
-### Forbidden words for positioning (line ~143)
-```javascript
-const FORBIDDEN_WORDS = [
-  { word: 'blockchain', severity: 'HIGH', context: 'Use "distributed infrastructure" instead' },
-  { word: 'web3', severity: 'HIGH', context: 'Use "next-generation infrastructure" instead' },
-  // ... customize for your brand
-];
-```
-
-### Links to ignore (line ~62)
-```javascript
-const IGNORED_LINK_PATTERNS = [
-  /^https:\/\/chat\.openai\.com/,  // Known to block bots
-  /^http:\/\/localhost/,            // Expected in docs
-  // ... add false positives
-];
-```
-
-## Exit codes
-
-| Code | Meaning |
-|------|---------|
-| `0` | No critical issues |
-| `1` | Critical issues found |
-| `2` | Fatal error |
-
-## Requirements
-
-- Node.js >= 18.0.0
-- npm (for installing dependencies)
-- Network access to docs.varity.so
-
-## What makes this "world-class"?
-
-This tester implements the same patterns used by top developer documentation sites:
-
-| Feature | Vercel | Supabase | Varity Tester |
-|---------|--------|----------|---------------|
-| Auto page discovery | ✓ | ✓ | ✓ |
-| Link validation | ✓ | ✓ | ✓ |
-| Anchor link checking | ✓ | ✓ | ✓ |
-| Code syntax validation | ✓ | ✓ | ✓ |
-| Import verification | ✓ | ✓ | ✓ |
-| SDK type checking | ✓ | ✓ | ✓ |
-| CI/CD integration | ✓ | ✓ | ✓ |
-| Auto-fix report | - | - | ✓ (Claude Code) |
-
-## License
-
-MIT
+`test-docs.cjs` is a retained historical live-crawl harness. It depends on the
+network and contains checks for retired product surfaces, so it is not part of
+`npm test` or CI. Do not cite it as proof that the current docs are correct. A
+separate cleanup change may port still-useful checks into deterministic tests
+before deleting it.

--- a/tests/test-architecture-governance.cjs
+++ b/tests/test-architecture-governance.cjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const required = {
+  'CLAUDE.md': [
+    '# CLAUDE.md - Varity Documentation',
+    '## Verification',
+    'ARCHITECTURE.md',
+  ],
+  'ARCHITECTURE.md': [
+    '# Varity Documentation Architecture',
+    '## Modules and interfaces',
+    '## Content and artifact provenance',
+    '## Build and publication flow',
+    '## Failure semantics',
+    '## Security and privacy',
+  ],
+};
+
+const errors = [];
+
+for (const [relativePath, markers] of Object.entries(required)) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    errors.push(`missing required architecture entrypoint: ${relativePath}`);
+    continue;
+  }
+
+  const content = fs.readFileSync(absolutePath, 'utf8');
+  for (const marker of markers) {
+    if (!content.includes(marker)) {
+      errors.push(`${relativePath} is missing required marker: ${marker}`);
+    }
+  }
+}
+
+const eventName = process.env.GITHUB_EVENT_NAME;
+const eventPath = process.env.GITHUB_EVENT_PATH;
+
+if (eventName === 'pull_request') {
+  if (!eventPath || !fs.existsSync(eventPath)) {
+    errors.push('pull_request event is missing GITHUB_EVENT_PATH');
+  } else {
+    const event = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+    const body = event.pull_request?.body || '';
+    const impact = body.match(/^Architecture impact:\s*(none|updated)\s*$/im);
+    const reason = body.match(/^Reason:\s*(.+)\s*$/im);
+    const affected = body.match(/^Affected runtime services\/modules:\s*(.+)\s*$/im);
+    const changed = body.match(/^Interfaces\/data\/security\/topology changed:\s*(.+)\s*$/im);
+    const files = body.match(/^Architecture\/ADR files:\s*(.+)\s*$/im);
+
+    if (!impact) errors.push('PR body must contain exactly "Architecture impact: none" or "Architecture impact: updated"');
+    if (!reason || reason[1].includes('<!--')) errors.push('PR body must contain a concrete Reason');
+    if (!affected) errors.push('PR body must name affected runtime services/modules or none');
+    if (!changed) errors.push('PR body must declare interface/data/security/topology impact');
+    if (!files) errors.push('PR body must name architecture/ADR files or none');
+  }
+}
+
+if (errors.length > 0) {
+  for (const error of errors) console.error(`FAIL ${error}`);
+  process.exit(1);
+}
+
+console.log('PASS architecture governance entrypoints and declaration');

--- a/tests/test-contract-artifacts.cjs
+++ b/tests/test-contract-artifacts.cjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const errors = [];
+
+function read(relativePath) {
+  const absolutePath = path.join(root, relativePath);
+  if (!fs.existsSync(absolutePath)) {
+    errors.push(`missing ${relativePath}`);
+    return '';
+  }
+  return fs.readFileSync(absolutePath, 'utf8');
+}
+
+function parseJson(relativePath) {
+  const raw = read(relativePath);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    errors.push(`${relativePath} is not valid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function visit(value, callback) {
+  if (Array.isArray(value)) {
+    for (const item of value) visit(item, callback);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+  callback(value);
+  for (const child of Object.values(value)) visit(child, callback);
+}
+
+function resolvePointer(document, reference) {
+  if (!reference.startsWith('#/')) return undefined;
+  return reference.slice(2).split('/').reduce((current, part) => {
+    const key = part.replace(/~1/g, '/').replace(/~0/g, '~');
+    return current && current[key];
+  }, document);
+}
+
+const openapi = parseJson('public/openapi.yaml');
+if (openapi) {
+  if (openapi.openapi !== '3.1.0') errors.push('public/openapi.yaml must declare OpenAPI 3.1.0');
+  if (!openapi.info?.title || !openapi.info?.version) errors.push('OpenAPI info title and version are required');
+  if (!Array.isArray(openapi.servers) || openapi.servers.length === 0) errors.push('OpenAPI must declare a public server');
+  if (!openapi.paths || Object.keys(openapi.paths).length === 0) errors.push('OpenAPI must declare at least one path');
+
+  const operationIds = [];
+  const httpMethods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
+  for (const pathItem of Object.values(openapi.paths || {})) {
+    for (const [method, operation] of Object.entries(pathItem || {})) {
+      if (httpMethods.has(method) && operation?.operationId) operationIds.push(operation.operationId);
+    }
+  }
+  if (new Set(operationIds).size !== operationIds.length) errors.push('OpenAPI operationId values must be unique');
+
+  visit(openapi, (object) => {
+    if (typeof object.$ref !== 'string') return;
+    if (!object.$ref.startsWith('#/')) {
+      errors.push(`OpenAPI contains unsupported external reference: ${object.$ref}`);
+    } else if (resolvePointer(openapi, object.$ref) === undefined) {
+      errors.push(`OpenAPI reference does not resolve: ${object.$ref}`);
+    }
+  });
+}
+
+const mcp = parseJson('public/mcp-schema.json');
+if (mcp) {
+  if (!mcp.server?.name || !mcp.server?.package || !mcp.server?.version) errors.push('MCP schema server identity is incomplete');
+  if (!Array.isArray(mcp.tools) || mcp.tools.length === 0) errors.push('MCP schema must declare tools');
+  if (mcp.toolCount !== mcp.tools?.length) errors.push('MCP schema toolCount must equal tools.length');
+
+  const toolNames = (mcp.tools || []).map((tool) => tool.name);
+  if (toolNames.some((name) => typeof name !== 'string' || !name.startsWith('varity_'))) {
+    errors.push('every MCP tool must have a varity_ prefixed name');
+  }
+  if (new Set(toolNames).size !== toolNames.length) errors.push('MCP tool names must be unique');
+  if ((mcp.tools || []).some((tool) => !tool.description || !tool.inputSchema)) {
+    errors.push('every MCP tool must declare description and inputSchema');
+  }
+}
+
+const apiReference = read('src/content/docs/ai-tools/api-reference.mdx');
+const mcpReference = read('src/content/docs/ai-tools/mcp-server-spec.mdx');
+const aiOverview = read('src/content/docs/ai-tools/overview.mdx');
+const llms = read('public/llms.txt');
+const llmsFull = read('public/llms-full.txt');
+
+if (!apiReference.includes('/openapi.yaml')) errors.push('API reference must link /openapi.yaml');
+if (!mcpReference.includes('/mcp-schema.json')) errors.push('MCP reference must link /mcp-schema.json');
+if (!mcpReference.includes('/openapi.yaml')) errors.push('MCP reference must link /openapi.yaml');
+for (const artifact of ['/openapi.yaml', '/mcp-schema.json', '/llms.txt', '/llms-full.txt']) {
+  if (!aiOverview.includes(artifact)) errors.push(`AI tools overview must link ${artifact}`);
+}
+
+for (const [name, content] of [['public/llms.txt', llms], ['public/llms-full.txt', llmsFull]]) {
+  if (!content.startsWith('# Varity Docs')) errors.push(`${name} must identify Varity Docs`);
+  if (!content.includes('https://docs.varity.so')) errors.push(`${name} must link the canonical docs origin`);
+  if (/\b(TODO|TBD|PLACEHOLDER)\b/i.test(content)) errors.push(`${name} contains unresolved placeholder text`);
+}
+if (llmsFull.length <= llms.length) errors.push('public/llms-full.txt must contain more context than public/llms.txt');
+
+if (process.env.VERIFY_DIST === '1') {
+  for (const artifact of ['openapi.yaml', 'mcp-schema.json', 'llms.txt', 'llms-full.txt']) {
+    const publicPath = path.join(root, 'public', artifact);
+    const distPath = path.join(root, 'dist', artifact);
+    if (!fs.existsSync(distPath)) {
+      errors.push(`missing built contract artifact: dist/${artifact}`);
+    } else if (fs.readFileSync(publicPath).compare(fs.readFileSync(distPath)) !== 0) {
+      errors.push(`dist/${artifact} must be an unchanged copy of public/${artifact}`);
+    }
+  }
+}
+
+if (errors.length > 0) {
+  for (const error of errors) console.error(`FAIL ${error}`);
+  process.exit(1);
+}
+
+console.log(`PASS public contract artifacts (${Object.keys(openapi?.paths || {}).length} OpenAPI paths, ${mcp?.tools?.length || 0} MCP tools)`);

--- a/tests/test-positioning-static.cjs
+++ b/tests/test-positioning-static.cjs
@@ -87,17 +87,18 @@ for (const file of files) {
   }
 }
 
-// VAR-389: ensure tutorial code examples use path-prefix format, not subdomain format.
-// db.varity.app is a legitimate subdomain (SDK technical docs) and is already excluded via TECHNICAL_PATHS.
-const SUBDOMAIN_URL_RE = /https?:\/\/[a-zA-Z0-9][a-zA-Z0-9-]*\.varity\.app/i;
-for (const file of files) {
-  if (isTechnicalFile(file)) continue;
-  const rel = path.relative(DOCS_SRC, file);
-  const fullSrc = fs.readFileSync(file, 'utf8');
-  if (SUBDOMAIN_URL_RE.test(fullSrc)) {
-    console.error(`FAIL [${rel}] uses subdomain URL format (*.varity.app) — use path-prefix format https://varity.app/{name}/ instead (VAR-389)`);
-    totalViolations++;
-  }
+// Route projection invariant: static apps use a path and dynamic apps use a
+// subdomain. The old blanket ban on subdomains predated the current split and
+// incorrectly rejected valid dynamic-app documentation.
+const URL_DOC_PATH = path.join(DOCS_SRC, 'deploy/custom-domains.mdx');
+const urlDoc = fs.readFileSync(URL_DOC_PATH, 'utf8');
+if (!urlDoc.includes('https://varity.app/my-app/')) {
+  console.error('FAIL [deploy/custom-domains.mdx] must document the static path URL format');
+  totalViolations++;
+}
+if (!urlDoc.includes('https://my-app.varity.app/')) {
+  console.error('FAIL [deploy/custom-domains.mdx] must document the dynamic subdomain URL format');
+  totalViolations++;
 }
 
 // VAR-506: ensure _redirects exists so 4everland CDN never falls through to raw IPFS gateway
@@ -107,8 +108,8 @@ if (!fs.existsSync(REDIRECTS_PATH)) {
   totalViolations++;
 } else {
   const redirectsContent = fs.readFileSync(REDIRECTS_PATH, 'utf8');
-  if (!redirectsContent.includes('/* /index.html 200')) {
-    console.error('FAIL [public/_redirects] must contain "/* /index.html 200" catch-all rule (VAR-506)');
+  if (!redirectsContent.includes('/* /404.html 404')) {
+    console.error('FAIL [public/_redirects] must contain "/* /404.html 404" catch-all rule');
     totalViolations++;
   }
 }


### PR DESCRIPTION
## Summary

- Adds tracked repository context and documentation/artifact provenance architecture.
- Makes architecture, OpenAPI, MCP, LLM, positioning, Astro, build, and built-copy checks deterministic CI requirements.
- Corrects stale routing and redirect assertions.
- Replaces the overstated historical test README with the actual merge contract.

## Architecture impact

Architecture impact: updated
Reason: Defines ownership and verification for human documentation and machine-readable public contract projections.
Affected runtime services/modules: static documentation publishing, OpenAPI projection, MCP schema projection, LLM artifacts, documentation CI
Interfaces/data/security/topology changed: Documentation publishing governance and CI changed; Varity runtime interfaces and hosting topology are unchanged.
Architecture/ADR files: ARCHITECTURE.md, CLAUDE.md

## Verification

- [x] `npm run check`
- [x] 44 documentation files pass positioning checks
- [x] 18 OpenAPI paths validate
- [x] 22 MCP tools validate
- [x] Astro check and 47-page production build
- [x] Built artifacts match checked-in public artifacts

## Follow-ups

- Canonical MCP is published at 2.3.7 while `public/mcp-schema.json` still reports 2.3.6; reconcile from the canonical MCP source in a separate contract-update PR.
- Existing dependency audit findings remain a separate dependency/security task.
