### PR TITLE
docs(api): publish resource envelope constraints

### DIFF
--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -963,19 +963,25 @@
             "type": [
               "number",
               "null"
-            ]
+            ],
+            "minimum": 0.25,
+            "maximum": 4
           },
           "memory_mb": {
             "type": [
               "integer",
               "null"
-            ]
+            ],
+            "minimum": 256,
+            "maximum": 8192
           },
           "storage_mb": {
             "type": [
               "integer",
               "null"
-            ]
+            ],
+            "minimum": 512,
+            "maximum": 20480
           },
           "persistent_storage_gb": {
             "type": [

--- a/tests/test-contract-artifacts.cjs
+++ b/tests/test-contract-artifacts.cjs
@@ -68,6 +68,18 @@ if (openapi) {
       errors.push(`OpenAPI reference does not resolve: ${object.$ref}`);
     }
   });
+
+  const resources = openapi.components?.schemas?.ResourceProfile?.properties;
+  const expectedResourceBounds = {
+    cpu_units: [0.25, 4],
+    memory_mb: [256, 8192],
+    storage_mb: [512, 20480],
+  };
+  for (const [field, [minimum, maximum]] of Object.entries(expectedResourceBounds)) {
+    if (resources?.[field]?.minimum !== minimum || resources?.[field]?.maximum !== maximum) {
+      errors.push(`OpenAPI ResourceProfile ${field} must declare ${minimum}..${maximum}`);
+    }
+  }
 }
 
 const mcp = parseJson('public/mcp-schema.json');


### PR DESCRIPTION
## What changed

Published the CPU, memory, and storage limits already enforced by the gateway-owned Varity public deployment API. Added contract-artifact assertions so those limits cannot silently disappear from the documentation projection.

## Why

AK-007 centralizes the provider-neutral resource envelope across ingress, durable validation, placement, and adapter capabilities. Public API consumers need the same exact limits in the checked-in OpenAPI contract.

## Related issues

Companion implementation: https://github.com/Michael-Abril/varity-sdk-private/pull/211

## Architecture impact

Architecture impact: none
Reason: This updates the existing public API documentation projection without changing runtime service ownership or topology.
Affected runtime services/modules: none; documentation projection of varity-gateway public API
Interfaces/data/security/topology changed: yes, OpenAPI now declares existing numeric limits; no runtime data, security-boundary, or topology change
Architecture/ADR files: none

## Checklist

- [x] Contract examples and artifact assertions are tested
- [x] No internal provider terminology was added
- [x] No em-dashes were added
- [x] Build passes: npm run build
- [x] Repository check passes: npm run check
- [x] Links are valid
- [x] Spelling and grammar reviewed

No production infrastructure, credentials, provider resources, or customer deployments are changed.
