### PR TITLE
docs(api): correct restart and redeploy contract

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -156,18 +156,20 @@ curl -X PATCH https://varity.app/api/deployments/$DEPLOYMENT_ID/env \
   -d '{ "env": { "FEATURE_FLAG": "on" } }'
 ```
 
-Redeploy, restart, or delete:
+Redeploy or delete:
 
 ```bash
 curl -X POST https://varity.app/api/deployments/$DEPLOYMENT_ID/redeploy \
   -H "Authorization: Bearer $VARITY_API_KEY"
 
-curl -X POST https://varity.app/api/deployments/$DEPLOYMENT_ID/restart \
-  -H "Authorization: Bearer $VARITY_API_KEY"
-
 curl -X DELETE https://varity.app/api/deployments/$DEPLOYMENT_ID \
   -H "Authorization: Bearer $VARITY_API_KEY"
 ```
+
+A verified restart operation is not currently available. `POST
+/api/deployments/{deployment_id}/restart` fails closed with HTTP `501` and
+`code: restart_unavailable`; Varity does not present a potentially no-op
+configuration redeploy as a restart.
 
 ## Templates, Pricing, And Credits
 
@@ -206,6 +208,8 @@ The response includes `signing_secret` once. Store it to verify webhook deliveri
 
 The signature is `v1=` plus an HMAC-SHA256 over `timestamp.body` using the webhook signing secret. Webhook endpoint URLs must be public HTTPS URLs; local and private hosts are rejected.
 
+`deployment.restart_requested` remains an accepted subscription value only for backward compatibility. Varity does not emit that event while verified restart is unavailable.
+
 Webhook handlers should be idempotent. Delivery-time DNS/IP revalidation, durable delivery queue hardening, and additional signing-secret custody hardening remain non-blocking v1 follow-ups.
 
 List webhooks and delivery status:
@@ -235,7 +239,7 @@ The OpenAPI document contains these 18 public paths:
 | `GET` | `/api/deployments/{deployment_id}/events` | Read deployment events |
 | `GET`, `PATCH` | `/api/deployments/{deployment_id}/env` | List environment variable keys or update values |
 | `POST` | `/api/deployments/{deployment_id}/redeploy` | Redeploy in place |
-| `POST` | `/api/deployments/{deployment_id}/restart` | Restart in place |
+| `POST` | `/api/deployments/{deployment_id}/restart` | Returns `501 restart_unavailable` until verified restart ships |
 | `GET` | `/api/templates` | List templates |
 | `GET` | `/api/templates/{template_id}` | Read a template |
 | `POST` | `/api/templates/{template_id}/deploy` | Deploy a template |
@@ -530,15 +534,15 @@ Set or update environment variables (config + secrets) on an app that is **alrea
 
 ### `varity_redeploy`: Redeploy an app in place
 
-Redeploy or restart an app that is **already deployed**, in place. This re-pulls the image (or rebuilds from source) and restarts the container on the **same** deployment with the same URL and same reserved hardware. Takes no body and keeps the current environment variables; use `varity_set_env` to change config at the same time.
+Reapply the saved configuration for an app that is **already deployed**. The app keeps the same URL and reserved hardware. An unchanged configuration may be a no-op, so this tool is not a verified restart for a stuck app. Use `varity_set_env` to change environment variables at the same time.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `name` | string | Yes | none | The app name or subdomain. The `<name>` in `https://varity.app/<name>/` |
 
-**Annotations:** `destructiveHint: true` (restarts live infrastructure)
+**Annotations:** `destructiveHint: true` (re-applies live deployment configuration)
 
-**Example prompt:** "Redeploy my-api" or "My app is stuck. Restart worker-bot"
+**Example prompt:** "Reapply the saved deployment configuration for my-api"
 
 ---
 

--- a/public/mcp-schema.json
+++ b/public/mcp-schema.json
@@ -481,8 +481,8 @@
     },
     {
       "name": "varity_redeploy",
-      "title": "Redeploy or Restart an Existing Deployment In Place",
-      "description": "Redeploy or restart an app that is ALREADY deployed, in place. Use this when a developer says 'redeploy <name>', 'restart <name>', 'my app is stuck, restart it', or 'pull the latest image and redeploy'. The app is re-deployed on the SAME deployment. Same URL, same reserved hardware, no new bid. It re-pulls the image (or rebuilds from source) and restarts the container, so it goes live in about a minute with no URL change. To change env vars at the same time, use varity_set_env. To create a NEW deployment instead, use varity_deploy.",
+      "title": "Reapply an Existing Deployment Configuration",
+      "description": "Reapply the saved configuration for an app that is ALREADY deployed. Use this when a developer explicitly asks to reapply or redeploy that saved configuration. The app keeps the same URL and reserved hardware, with no extra reservation. An unchanged configuration may be a no-op, so this tool must not be presented as a verified restart for a stuck app. To change environment variables at the same time, use varity_set_env. To create a NEW deployment instead, use varity_deploy.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -208,22 +208,15 @@
     "/deployments/{deployment_id}/restart": {
       "post": {
         "operationId": "restartDeployment",
-        "summary": "Restart in place",
+        "summary": "Restart a deployment (not currently available)",
         "parameters": [
           {
             "$ref": "#/components/parameters/DeploymentId"
           }
         ],
         "responses": {
-          "202": {
-            "description": "Restart accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AcceptedMutation"
-                }
-              }
-            }
+          "501": {
+            "$ref": "#/components/responses/PublicError"
           },
           "default": {
             "$ref": "#/components/responses/PublicError"
@@ -1552,6 +1545,7 @@
       },
       "WebhookEventType": {
         "type": "string",
+        "description": "deployment.restart_requested is accepted only for backward-compatible subscription storage; it is not emitted while verified restart is unavailable.",
         "enum": [
           "deployment.accepted",
           "deployment.progress",

--- a/src/content/docs/ai-tools/api-reference.mdx
+++ b/src/content/docs/ai-tools/api-reference.mdx
@@ -140,18 +140,20 @@ curl -X PATCH https://varity.app/api/deployments/$DEPLOYMENT_ID/env \
   -d '{ "env": { "FEATURE_FLAG": "on" } }'
 ```
 
-Redeploy, restart, or delete:
+Redeploy or delete:
 
 ```bash
 curl -X POST https://varity.app/api/deployments/$DEPLOYMENT_ID/redeploy \
   -H "Authorization: Bearer $VARITY_API_KEY"
 
-curl -X POST https://varity.app/api/deployments/$DEPLOYMENT_ID/restart \
-  -H "Authorization: Bearer $VARITY_API_KEY"
-
 curl -X DELETE https://varity.app/api/deployments/$DEPLOYMENT_ID \
   -H "Authorization: Bearer $VARITY_API_KEY"
 ```
+
+A verified restart operation is not currently available. `POST
+/api/deployments/{deployment_id}/restart` fails closed with HTTP `501` and
+`code: restart_unavailable`; Varity does not present a potentially no-op
+configuration redeploy as a restart.
 
 ## Templates, Pricing, And Credits
 
@@ -190,6 +192,8 @@ The response includes `signing_secret` once. Store it to verify webhook deliveri
 
 The signature is `v1=` plus an HMAC-SHA256 over `timestamp.body` using the webhook signing secret. Webhook endpoint URLs must be public HTTPS URLs; local and private hosts are rejected.
 
+`deployment.restart_requested` remains an accepted subscription value only for backward compatibility. Varity does not emit that event while verified restart is unavailable.
+
 Webhook handlers should be idempotent. Delivery-time DNS/IP revalidation, durable delivery queue hardening, and additional signing-secret custody hardening remain non-blocking v1 follow-ups.
 
 List webhooks and delivery status:
@@ -219,7 +223,7 @@ The OpenAPI document contains these 18 public paths:
 | `GET` | `/api/deployments/{deployment_id}/events` | Read deployment events |
 | `GET`, `PATCH` | `/api/deployments/{deployment_id}/env` | List environment variable keys or update values |
 | `POST` | `/api/deployments/{deployment_id}/redeploy` | Redeploy in place |
-| `POST` | `/api/deployments/{deployment_id}/restart` | Restart in place |
+| `POST` | `/api/deployments/{deployment_id}/restart` | Returns `501 restart_unavailable` until verified restart ships |
 | `GET` | `/api/templates` | List templates |
 | `GET` | `/api/templates/{template_id}` | Read a template |
 | `POST` | `/api/templates/{template_id}/deploy` | Deploy a template |

--- a/src/content/docs/ai-tools/mcp-server-spec.mdx
+++ b/src/content/docs/ai-tools/mcp-server-spec.mdx
@@ -284,15 +284,15 @@ Set or update environment variables (config + secrets) on an app that is **alrea
 
 ### `varity_redeploy`: Redeploy an app in place
 
-Redeploy or restart an app that is **already deployed**, in place. This re-pulls the image (or rebuilds from source) and restarts the container on the **same** deployment with the same URL and same reserved hardware. Takes no body and keeps the current environment variables; use `varity_set_env` to change config at the same time.
+Reapply the saved configuration for an app that is **already deployed**. The app keeps the same URL and reserved hardware. An unchanged configuration may be a no-op, so this tool is not a verified restart for a stuck app. Use `varity_set_env` to change environment variables at the same time.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `name` | string | Yes | none | The app name or subdomain. The `<name>` in `https://varity.app/<name>/` |
 
-**Annotations:** `destructiveHint: true` (restarts live infrastructure)
+**Annotations:** `destructiveHint: true` (re-applies live deployment configuration)
 
-**Example prompt:** "Redeploy my-api" or "My app is stuck. Restart worker-bot"
+**Example prompt:** "Reapply the saved deployment configuration for my-api"
 
 ---
 


### PR DESCRIPTION
Corrects the public API and MCP documentation to distinguish saved-configuration replay from verified restart. Documents the fail-closed restart candidate and preserves the deprecated webhook subscription value as backward-compatible but non-emitting. No documentation deployment is performed by this PR.

Architecture impact: none
Reason: Align public contract documentation with source-proven restart behavior without changing runtime architecture.
Affected runtime services/modules: none; documentation API reference, OpenAPI artifact, and MCP schema artifact only
Interfaces/data/security/topology changed: yes; documented restart response and webhook compatibility semantics only
Architecture/ADR files: none