### PR TITLE
docs(api): document logs/events completeness + freshness fields (AK-022)

### DIFF
--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -1147,7 +1147,8 @@
         "type": "object",
         "required": [
           "lines",
-          "count"
+          "count",
+          "complete"
         ],
         "properties": {
           "lines": {
@@ -1158,15 +1159,48 @@
           },
           "count": {
             "type": "integer"
+          },
+          "complete": {
+            "type": "boolean",
+            "description": "False when the returned window may be partial, for example when the live runtime source was momentarily unavailable. When false, warning_code is set and the request is safe to retry for a complete window."
+          },
+          "observed_at": {
+            "type": ["string", "null"],
+            "description": "ISO 8601 timestamp of the live runtime read behind this window, or null when no live read was captured."
+          },
+          "warning_code": {
+            "type": "string",
+            "description": "Present only when `complete` is false (e.g. `logs_incomplete`)."
+          },
+          "retryable": {
+            "type": "boolean",
+            "description": "Present only when `complete` is false; the read is safe to retry."
           }
         }
       },
       "EventList": {
         "type": "object",
         "required": [
-          "events"
+          "events",
+          "complete"
         ],
         "properties": {
+          "complete": {
+            "type": "boolean",
+            "description": "False when the returned events may be partial, for example when the live runtime source was momentarily unavailable. When false, warning_code is set and the request is safe to retry."
+          },
+          "observed_at": {
+            "type": ["string", "null"],
+            "description": "ISO 8601 timestamp of the live runtime read behind these events, or null when no live read was captured."
+          },
+          "warning_code": {
+            "type": "string",
+            "description": "Present only when `complete` is false (e.g. `events_incomplete`)."
+          },
+          "retryable": {
+            "type": "boolean",
+            "description": "Present only when `complete` is false; the read is safe to retry."
+          },
           "events": {
             "type": "array",
             "items": {

--- a/src/content/docs/ai-tools/api-reference.mdx
+++ b/src/content/docs/ai-tools/api-reference.mdx
@@ -124,6 +124,11 @@ curl https://varity.app/api/deployments/$DEPLOYMENT_ID/events \
   -H "Authorization: Bearer $VARITY_API_KEY"
 ```
 
+Both responses include a `complete` flag and an `observed_at` timestamp. When
+`complete` is `false`, the returned window may be partial (for example when the
+live runtime source was momentarily unavailable) and a `warning_code` is set.
+The read is safe to retry for a complete window.
+
 List environment variable keys. Values are write-only and are not returned:
 
 ```bash


### PR DESCRIPTION
## What changed

The public `/api/deployments/{id}/logs` and `/events` responses already carry `complete`, `observed_at`, and (when incomplete) `warning_code` plus `retryable`, so a caller can tell a partial or stale window from a whole one. The published OpenAPI `LogList`/`EventList` schemas omitted these fields, and the API reference did not mention them.

Changes:
- `public/openapi.yaml`: add `complete` (required), `observed_at`, `warning_code`, `retryable` to `LogList` and `EventList` with descriptions matching gateway behavior.
- `src/content/docs/ai-tools/api-reference.mdx`: one prose note explaining the partial-window semantics and that the read is safe to retry.

## Why

AK-022 cross-surface honesty: consumers reading the API reference could not know these completeness and freshness fields exist. This documents the existing contract accurately. Provider-neutral vocabulary only (app, logs, events).

## Architecture impact

Architecture impact: none
Reason: Documentation-only change that describes response fields the gateway already emits; no interface, endpoint, or behavior changes.
Affected runtime services/modules: none
Interfaces/data/security/topology changed: no
Architecture/ADR files: none

## Checklist

- [x] No forbidden vocabulary in prose
- [x] No em-dashes in prose
- [x] Repository check passes (test:architecture, test:contracts, test:positioning green locally)