### PR TITLE
docs(api): mirror live health-history endpoint (AK-021 docs projection)

### DIFF
--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -303,6 +303,43 @@
         }
       }
     },
+    "/deployments/{deployment_id}/health-history": {
+      "get": {
+        "operationId": "readDeploymentHealthHistory",
+        "summary": "Read durable runtime and route health history",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/DeploymentId"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500,
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Durable health history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthHistory"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
     "/deployments/{deployment_id}/env": {
       "get": {
         "operationId": "listDeploymentEnv",
@@ -1223,6 +1260,148 @@
                 },
                 "created_at": {
                   "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "HealthHistory": {
+        "type": "object",
+        "required": [
+          "summary",
+          "observations"
+        ],
+        "properties": {
+          "summary": {
+            "type": "object",
+            "required": [
+              "runtime_state",
+              "runtime_reason",
+              "route_state",
+              "route_reason",
+              "consecutive_runtime_failures",
+              "consecutive_route_failures",
+              "freshness_at",
+              "services"
+            ],
+            "properties": {
+              "runtime_state": {
+                "type": ["string", "null"],
+                "enum": ["healthy", "unhealthy", "unknown", null]
+              },
+              "runtime_reason": {
+                "type": ["string", "null"]
+              },
+              "route_state": {
+                "type": ["string", "null"],
+                "enum": ["healthy", "unhealthy", "unknown", null]
+              },
+              "route_reason": {
+                "type": ["string", "null"]
+              },
+              "consecutive_runtime_failures": {
+                "type": "integer"
+              },
+              "consecutive_route_failures": {
+                "type": "integer"
+              },
+              "freshness_at": {
+                "type": ["string", "null"],
+                "format": "date-time"
+              },
+              "services": {
+                "type": "array",
+                "description": "Latest observation's bounded per-service facts; empty when no per-service status was observable.",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "state",
+                    "replicas",
+                    "updated_replicas",
+                    "ready_replicas",
+                    "available_replicas",
+                    "public_endpoint_count",
+                    "forwarded_port_count",
+                    "dedicated_ip_count",
+                    "restart_count",
+                    "restart_count_supported"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "type": "string",
+                      "enum": ["healthy", "degraded"]
+                    },
+                    "replicas": {
+                      "type": "integer"
+                    },
+                    "updated_replicas": {
+                      "type": "integer"
+                    },
+                    "ready_replicas": {
+                      "type": "integer"
+                    },
+                    "available_replicas": {
+                      "type": "integer"
+                    },
+                    "public_endpoint_count": {
+                      "type": "integer"
+                    },
+                    "forwarded_port_count": {
+                      "type": "integer"
+                    },
+                    "dedicated_ip_count": {
+                      "type": "integer"
+                    },
+                    "restart_count": {
+                      "type": "null",
+                      "description": "Restart counting is not supported by the current runtime substrate."
+                    },
+                    "restart_count_supported": {
+                      "const": false
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "observations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "runtime_state",
+                "runtime_reason",
+                "route_state",
+                "route_reason",
+                "route_status",
+                "observed_at"
+              ],
+              "properties": {
+                "runtime_state": {
+                  "type": "string",
+                  "enum": ["healthy", "unhealthy", "unknown"]
+                },
+                "runtime_reason": {
+                  "type": "string"
+                },
+                "route_state": {
+                  "type": "string",
+                  "enum": ["healthy", "unhealthy", "unknown"]
+                },
+                "route_reason": {
+                  "type": "string"
+                },
+                "route_status": {
+                  "type": ["integer", "null"]
+                },
+                "observed_at": {
+                  "type": ["string", "null"],
+                  "format": "date-time"
                 }
               }
             }

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -314,7 +314,6 @@
           {
             "name": "limit",
             "in": "query",
-            "required": false,
             "schema": {
               "type": "integer",
               "minimum": 1,

--- a/src/content/docs/ai-tools/api-reference.mdx
+++ b/src/content/docs/ai-tools/api-reference.mdx
@@ -136,9 +136,9 @@ curl "https://varity.app/api/deployments/$DEPLOYMENT_ID/health-history?limit=100
   -H "Authorization: Bearer $VARITY_API_KEY"
 ```
 
-The response contains a `summary` — the latest runtime and route health state
-with reasons, consecutive failure counts, a `freshness_at` timestamp, and
-bounded per-service facts (replica, endpoint, and port counts) — plus an
+The response contains a `summary` with the latest runtime and route health
+state and reasons, consecutive failure counts, a `freshness_at` timestamp, and
+bounded per-service facts (replica, endpoint, and port counts), plus an
 `observations` array of recent health checks, bounded by `limit` (default 100,
 maximum 500). Per-service entries report
 `restart_count_supported: false` and a `null` `restart_count`; restart counting

--- a/src/content/docs/ai-tools/api-reference.mdx
+++ b/src/content/docs/ai-tools/api-reference.mdx
@@ -129,6 +129,21 @@ Both responses include a `complete` flag and an `observed_at` timestamp. When
 live runtime source was momentarily unavailable) and a `warning_code` is set.
 The read is safe to retry for a complete window.
 
+Read durable runtime and route health history:
+
+```bash
+curl "https://varity.app/api/deployments/$DEPLOYMENT_ID/health-history?limit=100" \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+The response contains a `summary` — the latest runtime and route health state
+with reasons, consecutive failure counts, a `freshness_at` timestamp, and
+bounded per-service facts (replica, endpoint, and port counts) — plus an
+`observations` array of recent health checks, bounded by `limit` (default 100,
+maximum 500). Per-service entries report
+`restart_count_supported: false` and a `null` `restart_count`; restart counting
+is not supported by the current runtime substrate.
+
 List environment variable keys. Values are write-only and are not returned:
 
 ```bash


### PR DESCRIPTION
## What changed

The live public API serves `GET /api/deployments/{deployment_id}/health-history` (present in the live `https://varity.app/api/openapi.json` on gateway `1.12.88`), but the published docs mirror had no trace of it. APIDOCS canon requires `docs.varity.so/openapi.yaml` to match the live contract.

Changes:
- `public/openapi.yaml`: add the health-history path object and the `HealthHistory` schema (summary + observations; per-service facts including `restart_count_supported: false` and always-`null` `restart_count`), placed to match live contract ordering (path after events, before env; schema between `EventList` and `EnvKeyList`).
- `src/content/docs/ai-tools/api-reference.mdx`: document the endpoint in the Operate section, following the merged AK-022 pattern (#94).

## Why

AK-021 docs projection: the docs mirror must match the live gateway-owned contract. The added path object and `HealthHistory` schema were extracted from the live `GET https://varity.app/api/openapi.json` response and verified parse-equal (JSON compare) after the edit, and cross-checked against gateway source `services/varity-gateway/src/services/public-api-openapi.ts` on `varity-sdk-private` `origin/main` (identical shape, no mismatch). Provider-neutral vocabulary only (deployment, service, health history); no pricing numbers.

## Architecture impact

Architecture impact: none
Reason: Documentation-only change that mirrors an endpoint and schema the gateway already serves in its live OpenAPI contract; no interface, endpoint, or behavior changes.
Affected runtime services/modules: none
Interfaces/data/security/topology changed: no
Architecture/ADR files: none

## Checklist

- [x] No forbidden vocabulary in prose
- [x] No em-dashes in prose
- [x] Repository check passes (test:architecture, test:contracts, test:positioning green locally)

DO NOT auto-merge: lead review required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
