### PR TITLE
docs: pricing reference converges on PRICING-CARD-CANONICAL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,9 @@ Authority rules:
 - The workspace manifest and live code own shipped capability and public
   interface reality. Documentation projects that truth; it does not create it.
 - The root positioning and pricing authorities own public language and claim
-  structure. Never hardcode live pricing numbers.
+  structure. Pricing numbers must come verbatim from the ratified
+  `PRICING-CARD-CANONICAL.md`; never invent, remember, or derive a price from
+  any other source.
 - `src/content/docs/` owns human-facing pages.
 - `public/openapi.yaml`, `public/mcp-schema.json`, `public/llms.txt`, and
   `public/llms-full.txt` are checked-in public contract projections. Update and

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1549,7 +1549,7 @@ varitykit app deploy
 ```
 
 - **Best for**: Marketing sites, documentation, SPAs
-- **Cost**: One flat monthly cost per app. Your bill on day 1 equals your bill on day 1000. See the [pricing calculator](https://developer.store.varity.so/dashboard/pricing).
+- **Cost**: Free for verified accounts, up to 3 active static sites and 1 GB of pinned assets. See [Pricing and Costs](/resources/pricing/).
 - **Speed**: Global CDN distribution
 
 ### Dynamic Apps
@@ -4314,10 +4314,10 @@ Usage metered hosting charges more as more people use your app. Varity charges a
 
 | Question | Usage metered hosting | Varity |
 |----------|-----------------------|--------|
-| What drives the bill? | Requests, bandwidth, invocations, storage, add ons, and build activity | Reserved hardware profile |
-| What happens during traffic spikes? | The bill can grow with usage | The app keeps the same monthly profile |
-| How do services affect cost? | Services are often separate products or meters | Supported services are attached as part of the deployment profile |
-| What should the builder think about? | Usage limits, surprise overages, and add on pricing | The workload profile and whether it fits the app |
+| What drives the bill? | Usage meters such as requests, bandwidth, invocations, storage, and build activity | The reserved resource profile, up to a monthly maximum prorated by running time |
+| What happens during traffic spikes? | Billing follows the usage meters | An unchanged profile keeps the same monthly maximum |
+| How do services affect cost? | Services are often separate products or meters | Attached services select their own preset and bill as separate reserved deployments |
+| What should the builder think about? | Usage limits and add-on pricing | The workload profile and whether it fits the app |
 
 Use [Pricing and Costs](/resources/pricing/) for the current pricing workflow and cost calculator.
 
@@ -4682,7 +4682,7 @@ Deploy a production Next.js app with a database and a live URL. No server config
     Varity detects your framework, wires your database, and deploys from your editor or terminal.
 
 
-    One flat monthly cost per app. Your bill on day 1 equals your bill on day 1000. No DevOps overhead.
+    Up to a fixed monthly maximum per app, prorated by running time. An unchanged profile keeps the same price as traffic grows. No DevOps overhead.
 
 
 ## Two ways to deploy
@@ -4964,17 +4964,17 @@ Description: Predictable cloud hosting for Node, Python, Go, static apps, AI age
 ## Billing and Pricing on Varity
 
 URL: https://docs.varity.so/resources/billing/
-Description: How Varity billing works, with a card on file before your first deploy and a flat monthly price per app that doesn't change with traffic.
+Description: How Varity billing works: a payment method for paid products, free static hosting with a verified account, and a monthly maximum per app that doesn't grow with traffic.
 
-Varity billing is built to be predictable: a flat monthly price per app for the hardware it reserves, and a bill that doesn't move with your traffic. This page covers the practical side: adding a card, what you're charged for, and where to see your costs.
+Varity billing is built to be predictable: each paid app bills up to a fixed monthly maximum for the resources it reserves, prorated by running time, and the bill doesn't grow with your traffic. Static sites are free for verified accounts. This page covers the practical side: adding a card, what you're charged for, and where to see your costs.
 
 ## A Card on File
 
-Varity asks for a payment method **before your first deploy**, so your app can go live and keep running. You add it once in the dashboard; you're only charged for apps you actually deploy.
+Varity asks for a payment method **before your first paid deploy**, so your app can go live and keep running. You add it once in the dashboard; you're only charged for apps you actually deploy. Free static sites don't need a card — a verified account is enough.
 
 ## What You're Charged For
 
-You pay a **flat monthly price per app**, based on the hardware that app reserves. That's it.
+Each paid app bills **up to a fixed monthly maximum**, based on the resources that app reserves, prorated by the time it runs. That's it.
 
 Your bill does **not** change with:
 
@@ -4982,13 +4982,13 @@ Your bill does **not** change with:
 - Requests or invocations
 - Build minutes
 
-This is the core difference from usage-metered hosting, where the bill grows as your app gets more traffic. With Varity, your bill on day 1 is your bill on day 1000. For the full model, see [How Pricing Works](/resources/pricing/).
+This is the core difference from usage-metered hosting, where billing follows usage meters. With Varity, an unchanged profile keeps the same monthly maximum no matter how much traffic it serves. For the full model, see [How Pricing Works](/resources/pricing/).
 
-Static sites and dynamic apps are priced differently because they reserve different resources. Use the cost calculator in the dashboard (or the `varity_cost_calculator` tool in your AI editor) for a current estimate before you deploy.
+Static sites are free for verified accounts (up to 3 active sites and 1 GB of pinned assets). Dynamic apps select a Managed Cloud preset. Use the cost calculator in the dashboard (or the `varity_cost_calculator` tool in your AI editor) for a current estimate before you deploy.
 
 ## Seeing Your Costs
 
-Your dashboard shows the monthly cost for each app and your overall bill. Because the price is fixed per app, the number you see is the number you pay. There is no end-of-month surprise from a traffic spike.
+Your dashboard shows the monthly maximum for each app and your overall bill. Because pricing is tied to the reserved profile, there is no end-of-month surprise from a traffic spike.
 
 ## Deleting an App
 
@@ -5018,7 +5018,7 @@ Varity is a predictable cloud platform focused on deployment. The two core packa
 
 | Feature | Usage-metered hosting | Varity |
 |---------|-----------------------|--------|
-| Pricing | Usage-metered, grows with traffic | One flat monthly cost per app |
+| Pricing | Billed by usage meters (requests, bandwidth, invocations) | Up to a fixed monthly maximum per app, prorated by running time |
 | Backend services | Separate add-ons, separate bills | Auto-wired in the same deploy |
 | Auth | Configure separately | Configured automatically |
 | Setup | Build config and env wiring | Zero config, one command |
@@ -5086,13 +5086,13 @@ No. Your existing auth works as-is. Set any secrets your provider needs as envir
 
 ### How much does Varity cost?
 
-Varity pricing is profile-based and fixed per selected deployment profile. Usage-metered hosting bills primarily by request volume, bandwidth, invocations, and execution time.
+Static sites are free for verified accounts (up to 3 active sites, 1 GB of pinned assets). Dynamic apps select a fixed Managed Cloud preset that bills up to a monthly maximum, prorated by running time.
 
 For current numbers, use [Pricing and Costs](/resources/pricing) or run `varity_cost_calculator`.
 
-### Why does my bill stay flat on Varity?
+### Why doesn't my bill grow with traffic?
 
-Varity charges one flat monthly cost per app, based on the hardware you reserve. Your bill does not change with traffic, bandwidth, or invocations. Usage-metered platforms scale billing with each of those, so your bill grows as your app succeeds.
+Varity prices each app by the resources it reserves, up to a fixed monthly maximum prorated by running time. For an unchanged profile, traffic, bandwidth, and invocations don't change the price. Changing the profile — more resources, services, replicas, or accelerators — can.
 
 ### Is there a contract or commitment?
 
@@ -5264,36 +5264,58 @@ Not sure which hosting type your app needs? Just run `varitykit app deploy`. Var
 ## Pricing and Costs on Varity
 
 URL: https://docs.varity.so/resources/pricing/
-Description: Pricing model overview for Varity. Compare Varity's fixed reserved-hardware pricing with usage-metered cloud billing.
+Description: The Varity price reference: free static hosting, Managed Cloud presets, the VM billing model, live GPU quotes, and AI Gateway fees.
 
-Varity pricing is based on reserved hardware capacity, not usage metering. Your monthly bill does not change with request volume, bandwidth spikes, or invocation count.
+Varity pricing is based on the resources a deployment reserves, not usage metering. For an unchanged deployment profile, your bill does not grow with request volume, bandwidth, or invocation count; changing the profile (resources, services, replicas, accelerators, or app count) can change the price.
 
-## Structural Pricing Difference
+## Static Sites: Free
 
-- **Varity:** fixed monthly hardware cost per deployment profile
-- **Usage-metered hosting:** billing scales with requests, bandwidth, invocations, and execution
+Static sites are **free** for verified accounts, with a limit of **3 active static sites** and **1 GB of total pinned assets** per account. No payment method is required for free static hosting — only a verified account. Larger or dynamic apps use Managed Cloud.
 
-Varity's bill stays flat as traffic rises; usage-metered bills move with every spike.
+## Managed Cloud Presets
 
-## How to Get an Estimate
+Dynamic apps select one of four fixed presets. Each price is a **monthly maximum**: billing is prorated by running time (per minute, against a 730-hour month), so a deployment that runs part of the month bills less than its maximum.
 
-Use the live pricing endpoint backing the portal and MCP calculator:
+| Preset | vCPU | RAM | Ephemeral storage | Price |
+|--------|-----:|----:|------------------:|-------|
+| Starter | 0.5 | 1 GB | 2 GB | Up to $7/mo, prorated |
+| Growth | 1 | 2 GB | 5 GB | Up to $14/mo, prorated |
+| Scale | 2 | 4 GB | 25 GB | Up to $28/mo, prorated |
+| Pro | 4 | 8 GB | 50 GB | Up to $56/mo, prorated |
 
-```bash
-curl "https://varity.app/api/pricing?profile=web-app&has_db=true"
-```
+- Attached services (Postgres, Redis, MongoDB, MySQL, object storage) select their own preset and bill as separate reserved deployments.
+- Persistent storage is an add-on at **$0.16/GB-month**, prorated on the same period. It bills while allocated, until the volume is deleted.
+- Each replica reserves its own resources: 2 replicas of a preset bill up to 2x that preset's maximum.
 
-You can also use:
+## CPU VMs
 
-- Developer Portal: [developer.store.varity.so](https://developer.store.varity.so)
-- MCP tool: `varity_cost_calculator`
+CPU VMs bill **hourly against a hard monthly cap**: the hourly rate is derived from the VM's monthly maximum divided by 730 hours, and the month's compute charge never exceeds that cap. Every VM includes a **20 GB NVMe boot disk** and **one public IPv4**, with no separate ingress or egress charge. Additional NVMe storage is **$0.09/GB-month**, prorated hourly. Billing continues while the VM's resources remain reserved; stopping the guest OS does not by itself release them — delete the VM to stop billing. VM sizes and regions are published in the Developer Portal as they pass Varity's end-to-end release verification.
 
-For launch-critical pricing claims, always validate examples against the live `/api/pricing` response first.
+## GPU
+
+GPU pricing is a **live quote**: the exact hourly rate is computed server-side from currently available capacity and shown before you commit. Any continuous-use monthly figure is an estimate for planning, never a cap. GPU workloads are paid-only and are excluded from the launch credit.
+
+## AI Gateway
+
+The AI Gateway bills the provider's actual cost for your requests **plus a 5% Varity fee**, drawn from a prepaid balance. The minimum refill is **$20** (a $21 charge before tax, including the fee). AI Gateway balances are separate from other Varity products and cannot be spent on Cloud, VM, GPU, or static hosting.
+
+## Launch Credit
+
+New accounts with a valid payment method receive a **$5 Managed Cloud credit, valid for 14 days**. It applies to Managed Cloud CPU deployments only — not VMs, GPU, the AI Gateway, or static sites (which are already free).
+
+## How to Get an Exact Number
+
+Every price is computed by Varity's server-side pricing authority, so all surfaces show identical numbers:
+
+- Developer Portal: [developer.store.varity.so](https://developer.store.varity.so) shows the exact price before you confirm a deployment.
+- MCP tool: `varity_cost_calculator` in your AI editor.
+
+The price you confirm at deploy time is authoritative for that deployment. Cost comparisons with other platforms live on [varity.so](https://www.varity.so), not in these docs.
 
 ## Related Guides
 
+- [Billing and Pricing](/resources/billing)
 - [Deploy Your App](/deploy/deploy-your-app)
-- [Managed Credentials](/deploy/managed-credentials)
 - [FAQ](/resources/faq)
 
 ---
@@ -5761,7 +5783,7 @@ Here is what you accomplished, without writing any code yourself:
 4. **Verified deployment status**: URL, framework, and runtime are visible in status output
 
 **Total time:** 10-15 minutes
-**Total cost:** One flat monthly bill, predictable on day 1 and day 1000
+**Total cost:** Up to a fixed monthly maximum for the app's reserved profile; an unchanged profile keeps the same price as traffic grows
 **Code written:** 0 lines
 
 ## Next Steps

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -889,8 +889,8 @@ costs per month.
 ## Estimate cost before deploying
 
 ```text
-Using Varity's cost calculator, what will this app cost per month on Varity
-versus usage-metered hosting as traffic grows?
+Using Varity's cost calculator, what will this app cost per month on Varity,
+and what is included in that price?
 ```
 
 ## Tips for the best results

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -898,7 +898,7 @@ versus usage-metered hosting as traffic grows?
 - Tell your AI tool the full path to your project so it deploys the right folder.
 - Varity deploys Node apps (Next.js, React, Vue, Astro, Qwik, Vite, Express, Fastify, NestJS, Koa, Hono) and Python apps (FastAPI, Django, Flask), plus static sites.
 - A database is configured automatically when your app needs it. You do not install anything extra.
-- Your bill is one flat monthly cost per app and does not change with traffic.
+- Your bill is at most a fixed monthly maximum per app, prorated by running time, and an unchanged profile does not cost more as traffic grows.
 
 ---
 
@@ -1107,7 +1107,7 @@ varitykit app deploy
 - Global CDN distribution
 - Permanent deployment URLs
 - Automatic SSL
-- One flat monthly cost per app, your bill does not change with traffic
+- Free for verified accounts, up to 3 active static sites and 1 GB of pinned assets
 
 ### Dynamic Apps
 
@@ -1126,7 +1126,7 @@ varitykit app deploy --hosting dynamic
 **Features:**
 - Container hosting
 - Persistent storage
-- One flat monthly cost per app. Your bill does not change with traffic
+- Up to a fixed monthly maximum per app, prorated by running time. An unchanged profile does not cost more as traffic grows
 
 Dynamic hosting is powered by cloud compute. Use `--hosting dynamic` for server-side frameworks (Next.js API routes, Express, etc.). Static hosting remains the default.
 
@@ -1561,7 +1561,7 @@ varitykit app deploy --hosting dynamic
 ```
 
 - **Best for**: APIs, databases, server-side rendering, AI agents, LLMs
-- **Cost**: One flat monthly cost per app, based on the hardware you reserve. See the [pricing calculator](https://developer.store.varity.so/dashboard/pricing).
+- **Cost**: Up to a fixed monthly maximum per app, prorated by running time, based on the resources you reserve. See [Pricing and Costs](/resources/pricing/).
 - **Features**: Containers, scaling, persistence
 
 Varity auto-detects when your app needs dynamic hosting (Express, Fastify, Next.js SSR, FastAPI, Django, Flask, etc.) and selects it automatically. Use `--hosting dynamic` only to force the mode explicitly.
@@ -2029,7 +2029,7 @@ Private images are supported in all three deploy paths:
 1. Varity pulls your image and starts it on dynamic compute hosting
 2. The deployment gets a name derived from the image (override with `--name`)
 3. Image deploys run as dynamic apps, so your app is reachable at `https://<name>.varity.app/` (`https://varity.app/<name>` redirects there)
-4. Billing starts as one flat monthly cost for the reserved hardware. It does not change with traffic
+4. Billing starts at deploy: up to a fixed monthly maximum for the reserved hardware, prorated by running time. It does not grow with traffic for an unchanged profile
 
 Make sure your container listens on `0.0.0.0`, not `localhost`. If the app serves on a non-default port, pass `--port`.
 
@@ -2064,7 +2064,7 @@ This is the path most people use. If you prefer the terminal, see [Deploy Your A
 ## Before You Start
 
 - A Varity account. Sign in at [developer.store.varity.so](https://developer.store.varity.so).
-- A payment method on file. Varity asks for a card before your first deploy so your app can go live and stay live; you are billed a flat monthly price for the hardware your app reserves, not for traffic. See [Billing](/resources/billing/).
+- A payment method on file for paid products. Varity asks for a card before your first paid deploy so your app can go live and stay live; you are billed up to a fixed monthly maximum for the hardware your app reserves, prorated by running time, not for traffic. Free static sites need a verified account only. See [Billing](/resources/billing/).
 - Your app's source: a public GitHub repo, a connected GitHub account, or a public Docker image.
 
 ## Deploy in a Few Steps
@@ -2110,7 +2110,7 @@ Everything after deploy lives in the dashboard:
     View your app's output to diagnose issues.
 
 
-    See your flat monthly cost per app. It doesn't move with traffic.
+    See the monthly maximum for each app, prorated by running time. It doesn't move with traffic.
 
 
     Remove an app from the dashboard. Deleting stops its billing immediately.
@@ -2226,7 +2226,7 @@ Choose the right hosting for your application type:
     - Container-based compute
     - Managed container hosting
     - Auto-wired database support
-    - Flat monthly pricing
+    - Priced up to a fixed monthly maximum, prorated by running time
 
     ```bash
     varitykit app deploy --hosting dynamic
@@ -4673,7 +4673,7 @@ See [MCP Server Spec](/ai-tools/mcp-server-spec) for the full troubleshooting se
 ## Deploy a Next.js App on Varity
 
 URL: https://docs.varity.so/guides/deploy-nextjs/
-Description: Predictable cloud hosting for a Next.js app with a database, automatic service wiring, and a flat monthly bill that does not grow with traffic.
+Description: Predictable cloud hosting for a Next.js app with a database, automatic service wiring, and a monthly maximum that does not grow with traffic.
 
 Deploy a production Next.js app with a database and a live URL. No server configuration, no environment variable setup, no infrastructure decisions.
 
@@ -4970,7 +4970,7 @@ Varity billing is built to be predictable: each paid app bills up to a fixed mon
 
 ## A Card on File
 
-Varity asks for a payment method **before your first paid deploy**, so your app can go live and keep running. You add it once in the dashboard; you're only charged for apps you actually deploy. Free static sites don't need a card — a verified account is enough.
+Varity asks for a payment method **before your first paid deploy**, so your app can go live and keep running. You add it once in the dashboard; you're only charged for apps you actually deploy. Free static sites don't need a card; a verified account is enough.
 
 ## What You're Charged For
 
@@ -5092,7 +5092,7 @@ For current numbers, use [Pricing and Costs](/resources/pricing) or run `varity_
 
 ### Why doesn't my bill grow with traffic?
 
-Varity prices each app by the resources it reserves, up to a fixed monthly maximum prorated by running time. For an unchanged profile, traffic, bandwidth, and invocations don't change the price. Changing the profile — more resources, services, replicas, or accelerators — can.
+Varity prices each app by the resources it reserves, up to a fixed monthly maximum prorated by running time. For an unchanged profile, traffic, bandwidth, and invocations don't change the price. Changing the profile (more resources, services, replicas, or accelerators) can.
 
 ### Is there a contract or commitment?
 
@@ -5270,7 +5270,7 @@ Varity pricing is based on the resources a deployment reserves, not usage meteri
 
 ## Static Sites: Free
 
-Static sites are **free** for verified accounts, with a limit of **3 active static sites** and **1 GB of total pinned assets** per account. No payment method is required for free static hosting — only a verified account. Larger or dynamic apps use Managed Cloud.
+Static sites are **free** for verified accounts, with a limit of **3 active static sites** and **1 GB of total pinned assets** per account. No payment method is required for free static hosting, only a verified account. Larger or dynamic apps use Managed Cloud.
 
 ## Managed Cloud Presets
 
@@ -5289,7 +5289,7 @@ Dynamic apps select one of four fixed presets. Each price is a **monthly maximum
 
 ## CPU VMs
 
-CPU VMs bill **hourly against a hard monthly cap**: the hourly rate is derived from the VM's monthly maximum divided by 730 hours, and the month's compute charge never exceeds that cap. Every VM includes a **20 GB NVMe boot disk** and **one public IPv4**, with no separate ingress or egress charge. Additional NVMe storage is **$0.09/GB-month**, prorated hourly. Billing continues while the VM's resources remain reserved; stopping the guest OS does not by itself release them — delete the VM to stop billing. VM sizes and regions are published in the Developer Portal as they pass Varity's end-to-end release verification.
+CPU VMs bill **hourly against a hard monthly cap**: the hourly rate is derived from the VM's monthly maximum divided by 730 hours, and the month's compute charge never exceeds that cap. Every VM includes a **20 GB NVMe boot disk** and **one public IPv4**, with no separate ingress or egress charge. Additional NVMe storage is **$0.09/GB-month**, prorated hourly. Billing continues while the VM's resources remain reserved; stopping the guest OS does not by itself release them; delete the VM to stop billing. VM sizes and regions are published in the Developer Portal as they pass Varity's end-to-end release verification.
 
 ## GPU
 
@@ -5301,7 +5301,7 @@ The AI Gateway bills the provider's actual cost for your requests **plus a 5% Va
 
 ## Launch Credit
 
-New accounts with a valid payment method receive a **$5 Managed Cloud credit, valid for 14 days**. It applies to Managed Cloud CPU deployments only — not VMs, GPU, the AI Gateway, or static sites (which are already free).
+New accounts with a valid payment method receive a **$5 Managed Cloud credit, valid for 14 days**. It applies to Managed Cloud CPU deployments only, not to VMs, GPU, the AI Gateway, or static sites (which are already free).
 
 ## How to Get an Exact Number
 
@@ -5871,16 +5871,16 @@ Result: You can build production apps in minutes instead of weeks.
 
 ## Cost Breakdown
 
-Varity charges one flat monthly cost per app, based on the hardware you reserve. Usage-metered hosting bills on usage, so the same app costs more as traffic grows and you add separate database and auth add-ons.
+Varity prices each app by the resources it reserves, up to a fixed monthly maximum prorated by running time. Usage-metered hosting bills on usage dimensions such as bandwidth and invocations, with databases and auth often sold as separate add-ons.
 
-For a small production app with a database, a typical comparison looks like:
+For a small production app with a database, the structural difference:
 
-| Provider | At launch | At traction |
-|----------|-----------|-------------|
-| **Varity** | One flat monthly cost (fixed) | Same flat cost, your bill does not change with traffic |
-| Usage-metered hosting | Higher base, plus add-ons | Grows with bandwidth, invocations, and usage |
+| Provider | Billing basis | As traffic grows |
+|----------|---------------|------------------|
+| **Varity** | Reserved resource profile, up to a monthly maximum (prorated) | An unchanged profile keeps the same monthly maximum |
+| Usage-metered hosting | Usage meters plus add-ons | Billing follows the usage meters |
 
-Overall, Varity keeps your bill flat as your app scales while usage-metered platforms ramp with traffic, and Varity handles all configuration. No DevOps engineer needed.
+Varity also handles all configuration. No DevOps engineer needed.
 
 For exact numbers, ask your AI editor to run `varity_cost_calculator`, or see [Pricing and Costs](/resources/pricing).
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -69,10 +69,10 @@ claude mcp add varity -- npx -y @varity-labs/mcp
 - [Deploy from Claude Code, Cursor, or Windsurf](https://docs.varity.so/guides/deploy-from-ai-ide/): Deploy supported apps and runnable Docker services from your AI editor with the Varity MCP server.
 - [Deploy a Next.js App on Varity](https://docs.varity.so/guides/deploy-nextjs/): Predictable cloud hosting for a Next.js app with a database, automatic service wiring, and a flat monthly bill that does not grow with traffic.
 - [Varity Documentation Home](https://docs.varity.so/): Predictable cloud hosting for Node, Python, Go, static apps, AI agents, and runnable Docker services.
-- [Billing and Pricing on Varity](https://docs.varity.so/resources/billing/): How Varity billing works, with a card on file before your first deploy and a flat monthly price per app that doesn't change with traffic.
+- [Billing and Pricing on Varity](https://docs.varity.so/resources/billing/): How Varity billing works: a payment method for paid products, free static hosting with a verified account, and a monthly maximum per app that doesn't grow with traffic.
 - [Varity Deployment FAQ Guide](https://docs.varity.so/resources/faq/): Frequently asked questions about Varity: deployment workflow, supported frameworks, and pricing model.
 - [Varity Docs Glossary Guide](https://docs.varity.so/resources/glossary/): Definitions of key Varity terms: deploy keys, managed credentials, deployment IDs, static hosting, dynamic hosting, and MCP tools.
-- [Pricing and Costs on Varity](https://docs.varity.so/resources/pricing/): Pricing model overview for Varity. Compare Varity's fixed reserved-hardware pricing with usage-metered cloud billing.
+- [Pricing and Costs on Varity](https://docs.varity.so/resources/pricing/): The Varity price reference: free static hosting, Managed Cloud presets, the VM billing model, live GPU quotes, and AI Gateway fees.
 - [Security and shared responsibility](https://docs.varity.so/resources/security/): How Varity secures your deployments, what you are responsible for, and how to report a security vulnerability.
 - [Troubleshooting Varity Deploys](https://docs.varity.so/resources/troubleshooting/): Fix common Varity issues: CLI not found, build errors, authentication failures, deployment problems, and database connection troubleshooting.
 - [Build an App Using Only AI (No Code Required)](https://docs.varity.so/tutorials/build-with-ai/): Build and deploy an app with your AI editor. Varity MCP handles setup checks, the deploy workflow, and cost estimation.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -67,7 +67,7 @@ claude mcp add varity -- npx -y @varity-labs/mcp
 - [Quick Start with Varity Docs](https://docs.varity.so/getting-started/quickstart/): Get started with Varity in minutes. Migrate an existing app, deploy from your repo, or deploy with AI tools.
 - [Why Developers Choose Varity](https://docs.varity.so/getting-started/why-varity/): Why Varity uses predictable hardware based billing instead of usage metering.
 - [Deploy from Claude Code, Cursor, or Windsurf](https://docs.varity.so/guides/deploy-from-ai-ide/): Deploy supported apps and runnable Docker services from your AI editor with the Varity MCP server.
-- [Deploy a Next.js App on Varity](https://docs.varity.so/guides/deploy-nextjs/): Predictable cloud hosting for a Next.js app with a database, automatic service wiring, and a flat monthly bill that does not grow with traffic.
+- [Deploy a Next.js App on Varity](https://docs.varity.so/guides/deploy-nextjs/): Predictable cloud hosting for a Next.js app with a database, automatic service wiring, and a monthly maximum that does not grow with traffic.
 - [Varity Documentation Home](https://docs.varity.so/): Predictable cloud hosting for Node, Python, Go, static apps, AI agents, and runnable Docker services.
 - [Billing and Pricing on Varity](https://docs.varity.so/resources/billing/): How Varity billing works: a payment method for paid products, free static hosting with a verified account, and a monthly maximum per app that doesn't grow with traffic.
 - [Varity Deployment FAQ Guide](https://docs.varity.so/resources/faq/): Frequently asked questions about Varity: deployment workflow, supported frameworks, and pricing model.

--- a/src/content/docs/ai-tools/prompts.mdx
+++ b/src/content/docs/ai-tools/prompts.mdx
@@ -69,4 +69,4 @@ versus usage-metered hosting as traffic grows?
 - Tell your AI tool the full path to your project so it deploys the right folder.
 - Varity deploys Node apps (Next.js, React, Vue, Astro, Qwik, Vite, Express, Fastify, NestJS, Koa, Hono) and Python apps (FastAPI, Django, Flask), plus static sites.
 - A database is configured automatically when your app needs it. You do not install anything extra.
-- Your bill is one flat monthly cost per app and does not change with traffic.
+- Your bill is at most a fixed monthly maximum per app, prorated by running time, and an unchanged profile does not cost more as traffic grows.

--- a/src/content/docs/ai-tools/prompts.mdx
+++ b/src/content/docs/ai-tools/prompts.mdx
@@ -60,8 +60,8 @@ costs per month.
 ## Estimate cost before deploying
 
 ```text
-Using Varity's cost calculator, what will this app cost per month on Varity
-versus usage-metered hosting as traffic grows?
+Using Varity's cost calculator, what will this app cost per month on Varity,
+and what is included in that price?
 ```
 
 ## Tips for the best results

--- a/src/content/docs/cli/commands/deploy.mdx
+++ b/src/content/docs/cli/commands/deploy.mdx
@@ -42,7 +42,7 @@ varitykit app deploy
 - Global CDN distribution
 - Permanent deployment URLs
 - Automatic SSL
-- One flat monthly cost per app, your bill does not change with traffic
+- Free for verified accounts, up to 3 active static sites and 1 GB of pinned assets
 
 ### Dynamic Apps
 
@@ -61,7 +61,7 @@ varitykit app deploy --hosting dynamic
 **Features:**
 - Container hosting
 - Persistent storage
-- One flat monthly cost per app. Your bill does not change with traffic
+- Up to a fixed monthly maximum per app, prorated by running time. An unchanged profile does not cost more as traffic grows
 
 <Aside type="tip">
 Dynamic hosting is powered by cloud compute. Use `--hosting dynamic` for server-side frameworks (Next.js API routes, Express, etc.). Static hosting remains the default.

--- a/src/content/docs/cli/overview.mdx
+++ b/src/content/docs/cli/overview.mdx
@@ -132,7 +132,7 @@ varitykit app deploy
 ```
 
 - **Best for**: Marketing sites, documentation, SPAs
-- **Cost**: One flat monthly cost per app. Your bill on day 1 equals your bill on day 1000. See the [pricing calculator](https://developer.store.varity.so/dashboard/pricing).
+- **Cost**: Free for verified accounts, up to 3 active static sites and 1 GB of pinned assets. See [Pricing and Costs](/resources/pricing/).
 - **Speed**: Global CDN distribution
 
 ### Dynamic Apps

--- a/src/content/docs/cli/overview.mdx
+++ b/src/content/docs/cli/overview.mdx
@@ -144,7 +144,7 @@ varitykit app deploy --hosting dynamic
 ```
 
 - **Best for**: APIs, databases, server-side rendering, AI agents, LLMs
-- **Cost**: One flat monthly cost per app, based on the hardware you reserve. See the [pricing calculator](https://developer.store.varity.so/dashboard/pricing).
+- **Cost**: Up to a fixed monthly maximum per app, prorated by running time, based on the resources you reserve. See [Pricing and Costs](/resources/pricing/).
 - **Features**: Containers, scaling, persistence
 
 Varity auto-detects when your app needs dynamic hosting (Express, Fastify, Next.js SSR, FastAPI, Django, Flask, etc.) and selects it automatically. Use `--hosting dynamic` only to force the mode explicitly.

--- a/src/content/docs/deploy/deploy-docker-image.mdx
+++ b/src/content/docs/deploy/deploy-docker-image.mdx
@@ -88,7 +88,7 @@ Private images are supported in all three deploy paths:
 1. Varity pulls your image and starts it on dynamic compute hosting
 2. The deployment gets a name derived from the image (override with `--name`)
 3. Image deploys run as dynamic apps, so your app is reachable at `https://<name>.varity.app/` (`https://varity.app/<name>` redirects there)
-4. Billing starts as one flat monthly cost for the reserved hardware. It does not change with traffic
+4. Billing starts at deploy: up to a fixed monthly maximum for the reserved hardware, prorated by running time. It does not grow with traffic for an unchanged profile
 
 <Aside type="tip">
 Make sure your container listens on `0.0.0.0`, not `localhost`. If the app serves on a non-default port, pass `--port`.

--- a/src/content/docs/deploy/deploy-from-dashboard.mdx
+++ b/src/content/docs/deploy/deploy-from-dashboard.mdx
@@ -20,7 +20,7 @@ This is the path most people use. If you prefer the terminal, see [Deploy Your A
 ## Before You Start
 
 - A Varity account. Sign in at [developer.store.varity.so](https://developer.store.varity.so).
-- A payment method on file. Varity asks for a card before your first deploy so your app can go live and stay live; you are billed a flat monthly price for the hardware your app reserves, not for traffic. See [Billing](/resources/billing/).
+- A payment method on file for paid products. Varity asks for a card before your first paid deploy so your app can go live and stay live; you are billed up to a fixed monthly maximum for the hardware your app reserves, prorated by running time, not for traffic. Free static sites need a verified account only. See [Billing](/resources/billing/).
 - Your app's source: a public GitHub repo, a connected GitHub account, or a public Docker image.
 
 ## Deploy in a Few Steps
@@ -70,7 +70,7 @@ Everything after deploy lives in the dashboard:
     View your app's output to diagnose issues.
   </Card>
   <Card title="Cost" icon="seti:db">
-    See your flat monthly cost per app. It doesn't move with traffic.
+    See the monthly maximum for each app, prorated by running time. It doesn't move with traffic.
   </Card>
   <Card title="Delete" icon="trash">
     Remove an app from the dashboard. Deleting stops its billing immediately.

--- a/src/content/docs/deploy/deploy-your-app.mdx
+++ b/src/content/docs/deploy/deploy-your-app.mdx
@@ -106,7 +106,7 @@ Choose the right hosting for your application type:
     - Container-based compute
     - Managed container hosting
     - Auto-wired database support
-    - Flat monthly pricing
+    - Priced up to a fixed monthly maximum, prorated by running time
 
     ```bash
     varitykit app deploy --hosting dynamic

--- a/src/content/docs/getting-started/why-varity.mdx
+++ b/src/content/docs/getting-started/why-varity.mdx
@@ -21,10 +21,10 @@ Usage metered hosting charges more as more people use your app. Varity charges a
 
 | Question | Usage metered hosting | Varity |
 |----------|-----------------------|--------|
-| What drives the bill? | Requests, bandwidth, invocations, storage, add ons, and build activity | Reserved hardware profile |
-| What happens during traffic spikes? | The bill can grow with usage | The app keeps the same monthly profile |
-| How do services affect cost? | Services are often separate products or meters | Supported services are attached as part of the deployment profile |
-| What should the builder think about? | Usage limits, surprise overages, and add on pricing | The workload profile and whether it fits the app |
+| What drives the bill? | Usage meters such as requests, bandwidth, invocations, storage, and build activity | The reserved resource profile, up to a monthly maximum prorated by running time |
+| What happens during traffic spikes? | Billing follows the usage meters | An unchanged profile keeps the same monthly maximum |
+| How do services affect cost? | Services are often separate products or meters | Attached services select their own preset and bill as separate reserved deployments |
+| What should the builder think about? | Usage limits and add-on pricing | The workload profile and whether it fits the app |
 
 Use [Pricing and Costs](/resources/pricing/) for the current pricing workflow and cost calculator.
 

--- a/src/content/docs/guides/deploy-nextjs.mdx
+++ b/src/content/docs/guides/deploy-nextjs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy a Next.js App on Varity
-description: Predictable cloud hosting for a Next.js app with a database, automatic service wiring, and a flat monthly bill that does not grow with traffic.
+description: Predictable cloud hosting for a Next.js app with a database, automatic service wiring, and a monthly maximum that does not grow with traffic.
 ---
 
 import { Steps, Tabs, TabItem, Aside, Card, CardGrid } from '@astrojs/starlight/components';

--- a/src/content/docs/guides/deploy-nextjs.mdx
+++ b/src/content/docs/guides/deploy-nextjs.mdx
@@ -20,7 +20,7 @@ Deploy a production Next.js app with a database and a live URL. No server config
     Varity detects your framework, wires your database, and deploys from your editor or terminal.
   </Card>
   <Card title="Predictable pricing instead of usage-metered cloud bills" icon="seti:money">
-    One flat monthly cost per app. Your bill on day 1 equals your bill on day 1000. No DevOps overhead.
+    Up to a fixed monthly maximum per app, prorated by running time. An unchanged profile keeps the same price as traffic grows. No DevOps overhead.
   </Card>
 </CardGrid>
 

--- a/src/content/docs/resources/billing.mdx
+++ b/src/content/docs/resources/billing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Billing and Pricing on Varity
-description: How Varity billing works, with a card on file before your first deploy and a flat monthly price per app that doesn't change with traffic.
+description: "How Varity billing works: a payment method for paid products, free static hosting with a verified account, and a monthly maximum per app that doesn't grow with traffic."
 ---
 
 import { Aside } from '@astrojs/starlight/components';
@@ -13,15 +13,15 @@ import PageMeta from '../../../components/PageMeta.astro';
   stability="stable"
 />
 
-Varity billing is built to be predictable: a flat monthly price per app for the hardware it reserves, and a bill that doesn't move with your traffic. This page covers the practical side: adding a card, what you're charged for, and where to see your costs.
+Varity billing is built to be predictable: each paid app bills up to a fixed monthly maximum for the resources it reserves, prorated by running time, and the bill doesn't grow with your traffic. Static sites are free for verified accounts. This page covers the practical side: adding a card, what you're charged for, and where to see your costs.
 
 ## A Card on File
 
-Varity asks for a payment method **before your first deploy**, so your app can go live and keep running. You add it once in the dashboard; you're only charged for apps you actually deploy.
+Varity asks for a payment method **before your first paid deploy**, so your app can go live and keep running. You add it once in the dashboard; you're only charged for apps you actually deploy. Free static sites don't need a card — a verified account is enough.
 
 ## What You're Charged For
 
-You pay a **flat monthly price per app**, based on the hardware that app reserves. That's it.
+Each paid app bills **up to a fixed monthly maximum**, based on the resources that app reserves, prorated by the time it runs. That's it.
 
 Your bill does **not** change with:
 
@@ -29,15 +29,15 @@ Your bill does **not** change with:
 - Requests or invocations
 - Build minutes
 
-This is the core difference from usage-metered hosting, where the bill grows as your app gets more traffic. With Varity, your bill on day 1 is your bill on day 1000. For the full model, see [How Pricing Works](/resources/pricing/).
+This is the core difference from usage-metered hosting, where billing follows usage meters. With Varity, an unchanged profile keeps the same monthly maximum no matter how much traffic it serves. For the full model, see [How Pricing Works](/resources/pricing/).
 
 <Aside type="note">
-Static sites and dynamic apps are priced differently because they reserve different resources. Use the cost calculator in the dashboard (or the `varity_cost_calculator` tool in your AI editor) for a current estimate before you deploy.
+Static sites are free for verified accounts (up to 3 active sites and 1 GB of pinned assets). Dynamic apps select a Managed Cloud preset. Use the cost calculator in the dashboard (or the `varity_cost_calculator` tool in your AI editor) for a current estimate before you deploy.
 </Aside>
 
 ## Seeing Your Costs
 
-Your dashboard shows the monthly cost for each app and your overall bill. Because the price is fixed per app, the number you see is the number you pay. There is no end-of-month surprise from a traffic spike.
+Your dashboard shows the monthly maximum for each app and your overall bill. Because pricing is tied to the reserved profile, there is no end-of-month surprise from a traffic spike.
 
 ## Deleting an App
 

--- a/src/content/docs/resources/billing.mdx
+++ b/src/content/docs/resources/billing.mdx
@@ -17,7 +17,7 @@ Varity billing is built to be predictable: each paid app bills up to a fixed mon
 
 ## A Card on File
 
-Varity asks for a payment method **before your first paid deploy**, so your app can go live and keep running. You add it once in the dashboard; you're only charged for apps you actually deploy. Free static sites don't need a card — a verified account is enough.
+Varity asks for a payment method **before your first paid deploy**, so your app can go live and keep running. You add it once in the dashboard; you're only charged for apps you actually deploy. Free static sites don't need a card; a verified account is enough.
 
 ## What You're Charged For
 

--- a/src/content/docs/resources/faq.mdx
+++ b/src/content/docs/resources/faq.mdx
@@ -98,7 +98,7 @@ For current numbers, use [Pricing and Costs](/resources/pricing) or run `varity_
 
 ### Why doesn't my bill grow with traffic?
 
-Varity prices each app by the resources it reserves, up to a fixed monthly maximum prorated by running time. For an unchanged profile, traffic, bandwidth, and invocations don't change the price. Changing the profile — more resources, services, replicas, or accelerators — can.
+Varity prices each app by the resources it reserves, up to a fixed monthly maximum prorated by running time. For an unchanged profile, traffic, bandwidth, and invocations don't change the price. Changing the profile (more resources, services, replicas, or accelerators) can.
 
 ### Is there a contract or commitment?
 

--- a/src/content/docs/resources/faq.mdx
+++ b/src/content/docs/resources/faq.mdx
@@ -24,7 +24,7 @@ Varity is a predictable cloud platform focused on deployment. The two core packa
 
 | Feature | Usage-metered hosting | Varity |
 |---------|-----------------------|--------|
-| Pricing | Usage-metered, grows with traffic | One flat monthly cost per app |
+| Pricing | Billed by usage meters (requests, bandwidth, invocations) | Up to a fixed monthly maximum per app, prorated by running time |
 | Backend services | Separate add-ons, separate bills | Auto-wired in the same deploy |
 | Auth | Configure separately | Configured automatically |
 | Setup | Build config and env wiring | Zero config, one command |
@@ -92,13 +92,13 @@ No. Your existing auth works as-is. Set any secrets your provider needs as envir
 
 ### How much does Varity cost?
 
-Varity pricing is profile-based and fixed per selected deployment profile. Usage-metered hosting bills primarily by request volume, bandwidth, invocations, and execution time.
+Static sites are free for verified accounts (up to 3 active sites, 1 GB of pinned assets). Dynamic apps select a fixed Managed Cloud preset that bills up to a monthly maximum, prorated by running time.
 
 For current numbers, use [Pricing and Costs](/resources/pricing) or run `varity_cost_calculator`.
 
-### Why does my bill stay flat on Varity?
+### Why doesn't my bill grow with traffic?
 
-Varity charges one flat monthly cost per app, based on the hardware you reserve. Your bill does not change with traffic, bandwidth, or invocations. Usage-metered platforms scale billing with each of those, so your bill grows as your app succeeds.
+Varity prices each app by the resources it reserves, up to a fixed monthly maximum prorated by running time. For an unchanged profile, traffic, bandwidth, and invocations don't change the price. Changing the profile — more resources, services, replicas, or accelerators — can.
 
 ### Is there a contract or commitment?
 

--- a/src/content/docs/resources/pricing.mdx
+++ b/src/content/docs/resources/pricing.mdx
@@ -17,7 +17,7 @@ Varity pricing is based on the resources a deployment reserves, not usage meteri
 
 ## Static Sites: Free
 
-Static sites are **free** for verified accounts, with a limit of **3 active static sites** and **1 GB of total pinned assets** per account. No payment method is required for free static hosting — only a verified account. Larger or dynamic apps use Managed Cloud.
+Static sites are **free** for verified accounts, with a limit of **3 active static sites** and **1 GB of total pinned assets** per account. No payment method is required for free static hosting, only a verified account. Larger or dynamic apps use Managed Cloud.
 
 ## Managed Cloud Presets
 
@@ -36,7 +36,7 @@ Dynamic apps select one of four fixed presets. Each price is a **monthly maximum
 
 ## CPU VMs
 
-CPU VMs bill **hourly against a hard monthly cap**: the hourly rate is derived from the VM's monthly maximum divided by 730 hours, and the month's compute charge never exceeds that cap. Every VM includes a **20 GB NVMe boot disk** and **one public IPv4**, with no separate ingress or egress charge. Additional NVMe storage is **$0.09/GB-month**, prorated hourly. Billing continues while the VM's resources remain reserved; stopping the guest OS does not by itself release them — delete the VM to stop billing. VM sizes and regions are published in the Developer Portal as they pass Varity's end-to-end release verification.
+CPU VMs bill **hourly against a hard monthly cap**: the hourly rate is derived from the VM's monthly maximum divided by 730 hours, and the month's compute charge never exceeds that cap. Every VM includes a **20 GB NVMe boot disk** and **one public IPv4**, with no separate ingress or egress charge. Additional NVMe storage is **$0.09/GB-month**, prorated hourly. Billing continues while the VM's resources remain reserved; stopping the guest OS does not by itself release them; delete the VM to stop billing. VM sizes and regions are published in the Developer Portal as they pass Varity's end-to-end release verification.
 
 ## GPU
 
@@ -48,7 +48,7 @@ The AI Gateway bills the provider's actual cost for your requests **plus a 5% Va
 
 ## Launch Credit
 
-New accounts with a valid payment method receive a **$5 Managed Cloud credit, valid for 14 days**. It applies to Managed Cloud CPU deployments only — not VMs, GPU, the AI Gateway, or static sites (which are already free).
+New accounts with a valid payment method receive a **$5 Managed Cloud credit, valid for 14 days**. It applies to Managed Cloud CPU deployments only, not to VMs, GPU, the AI Gateway, or static sites (which are already free).
 
 ## How to Get an Exact Number
 

--- a/src/content/docs/resources/pricing.mdx
+++ b/src/content/docs/resources/pricing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pricing and Costs on Varity
-description: Pricing model overview for Varity. Compare Varity's fixed reserved-hardware pricing with usage-metered cloud billing.
+description: "The Varity price reference: free static hosting, Managed Cloud presets, the VM billing model, live GPU quotes, and AI Gateway fees."
 ---
 
 import { Aside } from '@astrojs/starlight/components';
@@ -9,38 +9,60 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="June 2026"
+  lastUpdated="July 2026"
   stability="stable"
 />
 
-Varity pricing is based on reserved hardware capacity, not usage metering. Your monthly bill does not change with request volume, bandwidth spikes, or invocation count.
+Varity pricing is based on the resources a deployment reserves, not usage metering. For an unchanged deployment profile, your bill does not grow with request volume, bandwidth, or invocation count; changing the profile (resources, services, replicas, accelerators, or app count) can change the price.
 
-## Structural Pricing Difference
+## Static Sites: Free
 
-- **Varity:** fixed monthly hardware cost per deployment profile
-- **Usage-metered hosting:** billing scales with requests, bandwidth, invocations, and execution
+Static sites are **free** for verified accounts, with a limit of **3 active static sites** and **1 GB of total pinned assets** per account. No payment method is required for free static hosting — only a verified account. Larger or dynamic apps use Managed Cloud.
 
-Varity's bill stays flat as traffic rises; usage-metered bills move with every spike.
+## Managed Cloud Presets
 
-## How to Get an Estimate
+Dynamic apps select one of four fixed presets. Each price is a **monthly maximum**: billing is prorated by running time (per minute, against a 730-hour month), so a deployment that runs part of the month bills less than its maximum.
 
-Use the live pricing endpoint backing the portal and MCP calculator:
+| Preset | vCPU | RAM | Ephemeral storage | Price |
+|--------|-----:|----:|------------------:|-------|
+| Starter | 0.5 | 1 GB | 2 GB | Up to $7/mo, prorated |
+| Growth | 1 | 2 GB | 5 GB | Up to $14/mo, prorated |
+| Scale | 2 | 4 GB | 25 GB | Up to $28/mo, prorated |
+| Pro | 4 | 8 GB | 50 GB | Up to $56/mo, prorated |
 
-```bash
-curl "https://varity.app/api/pricing?profile=web-app&has_db=true"
-```
+- Attached services (Postgres, Redis, MongoDB, MySQL, object storage) select their own preset and bill as separate reserved deployments.
+- Persistent storage is an add-on at **$0.16/GB-month**, prorated on the same period. It bills while allocated, until the volume is deleted.
+- Each replica reserves its own resources: 2 replicas of a preset bill up to 2x that preset's maximum.
 
-You can also use:
+## CPU VMs
 
-- Developer Portal: [developer.store.varity.so](https://developer.store.varity.so)
-- MCP tool: `varity_cost_calculator`
+CPU VMs bill **hourly against a hard monthly cap**: the hourly rate is derived from the VM's monthly maximum divided by 730 hours, and the month's compute charge never exceeds that cap. Every VM includes a **20 GB NVMe boot disk** and **one public IPv4**, with no separate ingress or egress charge. Additional NVMe storage is **$0.09/GB-month**, prorated hourly. Billing continues while the VM's resources remain reserved; stopping the guest OS does not by itself release them — delete the VM to stop billing. VM sizes and regions are published in the Developer Portal as they pass Varity's end-to-end release verification.
 
-<Aside type="tip">
-For launch-critical pricing claims, always validate examples against the live `/api/pricing` response first.
+## GPU
+
+GPU pricing is a **live quote**: the exact hourly rate is computed server-side from currently available capacity and shown before you commit. Any continuous-use monthly figure is an estimate for planning, never a cap. GPU workloads are paid-only and are excluded from the launch credit.
+
+## AI Gateway
+
+The AI Gateway bills the provider's actual cost for your requests **plus a 5% Varity fee**, drawn from a prepaid balance. The minimum refill is **$20** (a $21 charge before tax, including the fee). AI Gateway balances are separate from other Varity products and cannot be spent on Cloud, VM, GPU, or static hosting.
+
+## Launch Credit
+
+New accounts with a valid payment method receive a **$5 Managed Cloud credit, valid for 14 days**. It applies to Managed Cloud CPU deployments only — not VMs, GPU, the AI Gateway, or static sites (which are already free).
+
+## How to Get an Exact Number
+
+Every price is computed by Varity's server-side pricing authority, so all surfaces show identical numbers:
+
+- Developer Portal: [developer.store.varity.so](https://developer.store.varity.so) shows the exact price before you confirm a deployment.
+- MCP tool: `varity_cost_calculator` in your AI editor.
+
+<Aside type="note">
+The price you confirm at deploy time is authoritative for that deployment. Cost comparisons with other platforms live on [varity.so](https://www.varity.so), not in these docs.
 </Aside>
 
 ## Related Guides
 
+- [Billing and Pricing](/resources/billing)
 - [Deploy Your App](/deploy/deploy-your-app)
-- [Managed Credentials](/deploy/managed-credentials)
 - [FAQ](/resources/faq)

--- a/src/content/docs/tutorials/build-with-ai.mdx
+++ b/src/content/docs/tutorials/build-with-ai.mdx
@@ -219,7 +219,7 @@ Here is what you accomplished, without writing any code yourself:
 4. **Verified deployment status**: URL, framework, and runtime are visible in status output
 
 **Total time:** 10-15 minutes  
-**Total cost:** One flat monthly bill, predictable on day 1 and day 1000  
+**Total cost:** Up to a fixed monthly maximum for the app's reserved profile; an unchanged profile keeps the same price as traffic grows  
 **Code written:** 0 lines
 
 ## Next Steps

--- a/src/content/docs/tutorials/build-with-ai.mdx
+++ b/src/content/docs/tutorials/build-with-ai.mdx
@@ -307,16 +307,16 @@ Result: You can build production apps in minutes instead of weeks.
 
 ## Cost Breakdown
 
-Varity charges one flat monthly cost per app, based on the hardware you reserve. Usage-metered hosting bills on usage, so the same app costs more as traffic grows and you add separate database and auth add-ons.
+Varity prices each app by the resources it reserves, up to a fixed monthly maximum prorated by running time. Usage-metered hosting bills on usage dimensions such as bandwidth and invocations, with databases and auth often sold as separate add-ons.
 
-For a small production app with a database, a typical comparison looks like:
+For a small production app with a database, the structural difference:
 
-| Provider | At launch | At traction |
-|----------|-----------|-------------|
-| **Varity** | One flat monthly cost (fixed) | Same flat cost, your bill does not change with traffic |
-| Usage-metered hosting | Higher base, plus add-ons | Grows with bandwidth, invocations, and usage |
+| Provider | Billing basis | As traffic grows |
+|----------|---------------|------------------|
+| **Varity** | Reserved resource profile, up to a monthly maximum (prorated) | An unchanged profile keeps the same monthly maximum |
+| Usage-metered hosting | Usage meters plus add-ons | Billing follows the usage meters |
 
-Overall, Varity keeps your bill flat as your app scales while usage-metered platforms ramp with traffic, and Varity handles all configuration. No DevOps engineer needed.
+Varity also handles all configuration. No DevOps engineer needed.
 
 For exact numbers, ask your AI editor to run `varity_cost_calculator`, or see [Pricing and Costs](/resources/pricing).
 


### PR DESCRIPTION
Founder-authorized pricing convergence (2026-07-31 pricing-convergence lane).

- Converges /resources/pricing, /resources/billing, FAQ, and all pricing-adjacent docs pages on the ratified PRICING-CARD-CANONICAL numbers ($7 base, $14, static = Free).
- Removes non-conformant "day 1000" / "flat monthly" phrasing; no CPU-VM GA claim.
- Syncs public/llms.txt and public/llms-full.txt with page content.
- Adds card-verbatim pricing rule to repo CLAUDE.md; neutralizes comparison sample prompt.

Verification: full `npm run check` green locally (governance/contract/positioning tests, astro check, astro build, VERIFY_DIST dist parity).

Note: an accidentally tracked node_modules symlink was amended out of the tip commit before push.

Architecture impact: none
Reason: documentation-only pricing copy convergence on PRICING-CARD-CANONICAL; no runtime code, endpoints, or infrastructure touched.
Affected runtime services/modules: none
Interfaces/data/security/topology changed: none
Architecture/ADR files: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)