### PR TITLE
docs: pricing audit fixes: attached database billing + cost-estimate framing

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -378,7 +378,7 @@ Search Varity docs for guides, API references, and tutorials.
 
 ### `varity_cost_calculator`: Estimate costs
 
-Compare Varity's flat hosting cost against usage-metered hosting as your traffic grows.
+Estimate the monthly price for your deployment profile.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
@@ -3484,7 +3484,7 @@ varitykit migrate rollback ./my-app
 
 ## After migration
 
-- Your app runs on Varity infrastructure with database and hosting included
+- Your app runs on Varity infrastructure; an attached database runs as its own reserved Managed Cloud deployment with its own preset price
 - Environment variables are managed automatically. No manual configuration needed
 - Review any warnings from the migration output and fix manually if needed
 - Set a custom subdomain or check the cost of your new deployment
@@ -5755,22 +5755,21 @@ That's it. No complex infrastructure setup.
      Created: 2 minutes ago
    ```
 
-9. **Compare costs**
+9. **Estimate costs**
 
     Prompt:
 
-    > "How much would this cost to host for 500 users on Varity versus usage-metered hosting?"
+    > "How much will this deployment profile cost per month on Varity?"
 
-    **What happens:** The AI runs `varity_cost_calculator` to show cost breakdown.
+    **What happens:** The AI runs `varity_cost_calculator` to estimate the monthly price for your deployment profile.
 
     **Expected output:**
     ```
-    Hosting costs for 500 users:
+    Estimated monthly price:
 
     Varity:
       - Profile-based monthly cost (fixed by selected deployment profile)
-    Usage-metered hosting:
-      - Usage-based cost that grows with traffic and invocations
+      - An unchanged profile keeps the same price as traffic grows
     ```
 
 ## What Just Happened?
@@ -5821,7 +5820,7 @@ When you prompt your AI editor, here's what happens:
 | "Build for production" | `varity_build` compiles the app, optimizes the bundle |
 | "Deploy" | `varity_deploy` deploys the app and injects credentials |
 | "Show status" | `varity_deploy_status` fetches deployment info |
-| "Compare costs" | `varity_cost_calculator` compares Varity's flat cost against usage-metered hosting as traffic grows |
+| "Estimate costs" | `varity_cost_calculator` estimates the monthly price for your deployment profile |
 
 Every tool runs locally or via Varity's infrastructure. No manual configuration needed.
 

--- a/src/content/docs/ai-tools/mcp-server-spec.mdx
+++ b/src/content/docs/ai-tools/mcp-server-spec.mdx
@@ -132,7 +132,7 @@ Search Varity docs for guides, API references, and tutorials.
 
 ### `varity_cost_calculator`: Estimate costs
 
-Compare Varity's flat hosting cost against usage-metered hosting as your traffic grows.
+Estimate the monthly price for your deployment profile.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|

--- a/src/content/docs/deploy/vercel-migration.mdx
+++ b/src/content/docs/deploy/vercel-migration.mdx
@@ -99,7 +99,7 @@ varitykit migrate rollback ./my-app
 
 ## After migration
 
-- Your app runs on Varity infrastructure with database and hosting included
+- Your app runs on Varity infrastructure; an attached database runs as its own reserved Managed Cloud deployment with its own preset price
 - Environment variables are managed automatically. No manual configuration needed
 - Review any warnings from the migration output and fix manually if needed
 - Set a custom subdomain or check the cost of your new deployment

--- a/src/content/docs/tutorials/build-with-ai.mdx
+++ b/src/content/docs/tutorials/build-with-ai.mdx
@@ -189,22 +189,21 @@ That's it. No complex infrastructure setup.
      Created: 2 minutes ago
    ```
 
-9. **Compare costs**
+9. **Estimate costs**
 
     Prompt:
 
-    > "How much would this cost to host for 500 users on Varity versus usage-metered hosting?"
+    > "How much will this deployment profile cost per month on Varity?"
 
-    **What happens:** The AI runs `varity_cost_calculator` to show cost breakdown.
+    **What happens:** The AI runs `varity_cost_calculator` to estimate the monthly price for your deployment profile.
 
     **Expected output:**
     ```
-    Hosting costs for 500 users:
+    Estimated monthly price:
 
     Varity:
       - Profile-based monthly cost (fixed by selected deployment profile)
-    Usage-metered hosting:
-      - Usage-based cost that grows with traffic and invocations
+      - An unchanged profile keeps the same price as traffic grows
     ```
 
 </Steps>
@@ -257,7 +256,7 @@ When you prompt your AI editor, here's what happens:
 | "Build for production" | `varity_build` compiles the app, optimizes the bundle |
 | "Deploy" | `varity_deploy` deploys the app and injects credentials |
 | "Show status" | `varity_deploy_status` fetches deployment info |
-| "Compare costs" | `varity_cost_calculator` compares Varity's flat cost against usage-metered hosting as traffic grows |
+| "Estimate costs" | `varity_cost_calculator` estimates the monthly price for your deployment profile |
 
 Every tool runs locally or via Varity's infrastructure. No manual configuration needed.
 


### PR DESCRIPTION
## What changed

Founder-authorized fix pass for the 2026-07-31 adversarial pricing audit:

- /deploy/vercel-migration: 'database and hosting included' corrected: an attached database runs as its own reserved Managed Cloud deployment with its own preset price (PRICING-CARD-CANONICAL §2).
- /tutorials/build-with-ai and /ai-tools/mcp-server-spec: client-side cost-comparison framing removed; varity_cost_calculator described as estimating the monthly price for your deployment profile (card §8: one governed server-side comparison engine; clients must not maintain competitor calculations).
- public/llms-full.txt re-synced with exact-match replacements (public/llms.txt contained no affected strings; verified by grep).

Note: public/mcp-schema.json still describes varity_cost_calculator as a usage-metered-hosting comparison. That projection mirrors the shipped MCP tool; correcting it requires a product change in varity-mcp-standalone, flagged separately.

## Why

The docs claimed the database is included in the app price and advertised an ungoverned client-side cost comparison, both contradicting the ratified pricing card.

## Related issues

None.

## Architecture impact

Architecture impact: none
Reason: docs-only copy correction behind unchanged interfaces; no runtime, contract, or topology change.
Affected runtime services/modules: none
Interfaces/data/security/topology changed: no
Architecture/ADR files: none

## Checklist

- [x] Code examples are tested and working
- [x] No forbidden vocabulary in prose (no blockchain/crypto/DePIN/wallet/Akash/IPFS terms)
- [x] No em-dashes in prose
- [x] Build passes (npm run build)
- [x] Repository check passes (npm run check)
- [x] Links are valid
- [x] Spelling and grammar reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)