### PR TITLE
docs: sync mcp-schema cost_calculator projection to merged MCP main (2.3.9)

### DIFF
--- a/public/mcp-schema.json
+++ b/public/mcp-schema.json
@@ -61,7 +61,7 @@
     {
       "name": "varity_cost_calculator",
       "title": "Cost Calculator",
-      "description": "Compare a deployment's flat monthly Varity cost against usage-metered hosting (bandwidth + invocations). Varity charges a FLAT hardware-only price that doesn't spike with traffic; usage-metered hosting bills grow as the app scales. Varity's price is fixed and doesn't move as the app grows. Use whenever a developer asks about pricing, cost, hosting bills, traffic costs, or platform comparison. Pass `subdomain` for a specific live deployment's REAL cost, or `app_profile` for a pre-deploy estimate.",
+      "description": "Estimate the fixed monthly price for a deployment profile. Pricing is computed by the Varity pricing service, so this tool, the CLI, and the portal render identical numbers. Use whenever a developer asks what a Varity deployment costs. Pass `subdomain` for a specific live deployment's REAL cost, or `app_profile` for a pre-deploy estimate.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -83,7 +83,7 @@
           },
           "has_database": {
             "type": "boolean",
-            "description": "Whether the app uses a database (affects competitor base cost)"
+            "description": "Whether the app uses a database (selects the database-inclusive estimate)"
           }
         },
         "additionalProperties": false,


### PR DESCRIPTION
## What changed

public/mcp-schema.json still projected the retired usage-metered-comparison framing for varity_cost_calculator. The source tool was already converged in varity-mcp-standalone main (merged 2026-07-31): the description now reads 'Estimate the fixed monthly price for a deployment profile…' computed by the Varity pricing service. This hand-syncs the projection (description + has_database param) to that merged description.

Note: this projects merged-main 2.3.9; npm publish of 2.3.9 is pending, so the projection leads the published package by design of the merge-first flow.

## Why

PRICING-CARD-CANONICAL §8: one governed server-side comparison engine; clients and their public contract projections must not carry competitor-comparison framing.

## Related issues

None.

## Architecture impact

Architecture impact: none
Reason: contract-projection copy sync behind unchanged tool names, schemas, and interfaces.
Affected runtime services/modules: none
Interfaces/data/security/topology changed: no
Architecture/ADR files: none

## Checklist

- [x] Code examples are tested and working
- [x] No forbidden vocabulary in prose
- [x] No em-dashes in prose
- [x] Build passes (npm run build)
- [x] Repository check passes (npm run check)
- [x] Links are valid
- [x] Spelling and grammar reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)