### PR TITLE
docs(architecture): route documentation truth through Workspace V2

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,12 +1,9 @@
 # Varity Documentation Architecture
 
-Status: current repository architecture
-Last code-grounded audit: 2026-07-18
-
 This document is the repository-level architecture layer for
-`varity-docs`. The workspace-level system map owns cross-repository runtime
-relationships. This file owns how public documentation and machine-readable
-artifacts are authored, verified, and published.
+`varity-docs`. `varity-engineering:ARCHITECTURE.md` owns cross-repository
+runtime relationships. This file owns how public documentation and
+machine-readable artifacts are authored, verified, and published.
 
 ## Context and responsibility
 
@@ -30,9 +27,9 @@ implementation.
 
 ```mermaid
 flowchart LR
-  A[Root product and positioning authorities]
-  B[Gateway public interface source]
-  C[MCP implementation source]
+  A[varity-engineering claim authorities]
+  B[varity-platform gateway contract]
+  C[varity-mcp interface]
   H[Human maintainers]
   D[Checked-in docs and contract projections]
   V[Repository-local verification]
@@ -101,9 +98,9 @@ checks should be ported or deleted.
 
 | Published surface | Checked-in owner | Narrower authority to reconcile | Required verification |
 |---|---|---|---|
-| Human pages | `src/content/docs/` | Workspace manifest, positioning, pricing, security, and current public behavior | `npm run check` plus browser review when visual/navigation behavior changes |
-| OpenAPI | `public/openapi.yaml` | Gateway-owned public platform interface and its current implementation tests | JSON/OpenAPI structure, internal references, unique operation IDs, API-reference link, build copy |
-| MCP catalog | `public/mcp-schema.json` | Canonical `@varity-labs/mcp` implementation and published package contract | JSON/schema structure, tool-count/name uniqueness, reference-page links, build copy |
+| Human pages | `src/content/docs/` | `varity-engineering:CURRENT-STATE.md`, `POSITIONING.md`, `PRICING.md`, plus verified public behavior | `npm run check` plus browser review when visual/navigation behavior changes |
+| OpenAPI | `public/openapi.yaml` | `varity-platform:services/varity-gateway/src/services/public-api-openapi.ts` and its contract tests | JSON/OpenAPI structure, internal references, unique operation IDs, API-reference link, build copy |
+| MCP catalog | `public/mcp-schema.json` | `varity-mcp:src/server.ts`, `src/tools/`, tests, and published package contract | JSON/schema structure, tool-count/name uniqueness, reference-page links, build copy |
 | LLM summary | `public/llms.txt` | Current public pages and supported product claims | Required identity/artifact links, no placeholder content, build copy |
 | LLM full context | `public/llms-full.txt` | Current public pages and supported product claims | Required identity/artifact links, nontrivial full-content size, build copy |
 | Redirects and static assets | `public/` | Current hosting behavior and brand assets | Redirect invariant, Astro build, visual review where applicable |
@@ -148,10 +145,10 @@ and requires no production credential.
 
 | Change | Inspect and update together |
 |---|---|
-| Public deployment field or route | Gateway interface, OpenAPI, API reference, affected guides, MCP/CLI/portal consumers outside this repo |
-| MCP tool name or input/output contract | MCP implementation, MCP catalog, MCP reference, LLM artifacts |
-| Supported capability | Workspace manifest and gate evidence first, then affected pages and LLM artifacts |
-| Pricing language | Root pricing/positioning authority, affected pages and LLM artifacts; never hardcode live values |
+| Public deployment field or route | `varity-platform` gateway implementation, generated OpenAPI and tests; then this OpenAPI projection, API reference, affected guides, and the named client repositories |
+| MCP tool name or input/output contract | `varity-mcp:src/server.ts`, the owning `src/tools/` module and tests; then this MCP catalog, reference, and LLM artifacts |
+| Supported capability | `varity-engineering:CURRENT-STATE.md` and current executable evidence first; then affected pages and LLM artifacts |
+| Pricing language | `varity-engineering:PRICING.md` and the executable platform owner; then affected pages and LLM artifacts |
 | Page or information architecture | Page source, `astro.config.mjs`, links, metadata, sitemap behavior, local responsive review |
 | Publishing topology or artifact provenance | This file, CI/workflows, pull-request architecture declaration, and a workspace ADR when load-bearing |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,26 +1,30 @@
 # CLAUDE.md - Varity Documentation
 
-Status: repository entrypoint
-Last updated: 2026-07-18
-
 This repository publishes the public documentation at `docs.varity.so`. It is
 a static Astro/Starlight surface, not a control-plane runtime.
 
 ## Read first
 
-When this checkout is inside the Varity workspace, read the workspace root
-`CLAUDE.md`, `varity.manifest.yaml`, `POSITIONING.md`, and
-`PRICING-MODEL-CANONICAL.md` before changing product claims. Then read
-`ARCHITECTURE.md` here for content and artifact provenance.
+Read `ARCHITECTURE.md` here first for content and artifact provenance. When
+this repository is checked out through Workspace V2, use these sibling owners
+before changing product claims:
+
+- `varity-engineering:CLAUDE.md` for workspace behavior;
+- `varity-engineering:CURRENT-STATE.md` for dated shipped-state evidence;
+- `varity-engineering:POSITIONING.md` for product language;
+- `varity-engineering:PRICING.md` for executable pricing ownership;
+- `varity-engineering:ARCHITECTURE.md` for cross-repository change routing.
 
 Authority rules:
 
-- The workspace manifest and live code own shipped capability and public
-  interface reality. Documentation projects that truth; it does not create it.
-- The root positioning and pricing authorities own public language and claim
-  structure. Pricing numbers must come verbatim from the ratified
-  `PRICING-CARD-CANONICAL.md`; never invent, remember, or derive a price from
-  any other source.
+- Current runtime code, live evidence, and `varity-engineering:CURRENT-STATE.md`
+  own shipped capability and public-interface reality. Documentation projects
+  that truth; it does not create it.
+- `varity-engineering:POSITIONING.md` and `varity-engineering:PRICING.md` own
+  public language and pricing-source routing. Never invent or remember prices.
+- The public platform contract originates in
+  `varity-platform:services/varity-gateway/src/services/public-api-openapi.ts`.
+  The MCP interface originates in `varity-mcp:src/server.ts` and `src/tools/`.
 - `src/content/docs/` owns human-facing pages.
 - `public/openapi.yaml`, `public/mcp-schema.json`, `public/llms.txt`, and
   `public/llms-full.txt` are checked-in public contract projections. Update and

--- a/README.md
+++ b/README.md
@@ -7,9 +7,16 @@
 
 This repository is the source for the official Varity documentation at **[docs.varity.so](https://docs.varity.so)**, built with [Astro](https://astro.build) and [Starlight](https://starlight.astro.build).
 
+Maintainers should start with [ARCHITECTURE.md](ARCHITECTURE.md). In Workspace
+V2, cross-repository product truth belongs to
+`varity-engineering:CURRENT-STATE.md`, `POSITIONING.md`, `PRICING.md`, and
+`ARCHITECTURE.md`; public API and MCP contracts originate in `varity-platform`
+and `varity-mcp`, respectively. This repository projects those owners and does
+not replace them.
+
 ## What is Varity?
 
-Varity deploys supported source repos and runnable Docker/OCI HTTP services from the CLI, the Developer Portal, or your AI coding tool. It builds your project, provisions the backend services it detects, and returns a live URL. Pricing is one fixed monthly cost per app based on reserved hardware, so the bill does not change with traffic.
+Varity deploys supported source repos and runnable Docker/OCI HTTP services from the CLI, the Developer Portal, or your AI coding tool. It builds your project, provisions the supported services it detects, and returns a live URL. One monthly price applies to the selected resources; traffic alone does not create an additional Varity usage charge for an unchanged resource profile.
 
 Varity ships as two packages:
 
@@ -52,7 +59,7 @@ Auto-wired backend services (provisioned when Varity detects them in your depend
 This is an Astro + Starlight site. Run it locally with:
 
 ```bash
-npm install
+npm ci
 npm run dev        # http://localhost:4321
 ```
 


### PR DESCRIPTION
Summary

Makes documentation architecture self-contained, routes mutable product truth to Workspace V2 owners, and removes an unsupported Reserved Hardware statement from the repository README.

Architecture impact: updated
Reason: Cross-repository documentation provenance and change routing changed.
Affected runtime services/modules: documentation architecture only
Interfaces/data/security/topology changed: no
Architecture/ADR files: ARCHITECTURE.md

Verification

- Architecture, contract, and positioning checks passed
- Full local check reached Astro and was blocked because the isolated checkout binary is not executable
- No published page, runtime code, package, or deployment changes