### PR TITLE
docs: ship AI Gateway, machines and API contract pages; fix accuracy, mobile and a11y defects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,26 +1,36 @@
 # CLAUDE.md - Varity Documentation
 
 Status: repository entrypoint
-Last updated: 2026-07-18
+Last updated: 2026-08-09
 
 This repository publishes the public documentation at `docs.varity.so`. It is
 a static Astro/Starlight surface, not a control-plane runtime.
 
 ## Read first
 
-When this checkout is inside the Varity workspace, read the workspace root
-`CLAUDE.md`, `varity.manifest.yaml`, `POSITIONING.md`, and
-`PRICING-MODEL-CANONICAL.md` before changing product claims. Then read
-`ARCHITECTURE.md` here for content and artifact provenance.
+Cross-repository authority lives in the `varity-engineering` control
+repository, checked out at `/workspaces/varity-engineering/`. Read these before
+changing product claims:
+
+- `CURRENT-STATE.md` — dated shipped, unfinished, and blocker status.
+- `repos.yaml` — repository topology and remotes.
+- `POSITIONING.md` — stable product definition and public language.
+- `PRICING.md` — pricing-source routing; `PRICING-AND-BILLING.md` — the
+  consolidated pricing and billing model.
+
+Then read `ARCHITECTURE.md` here for content and artifact provenance.
 
 Authority rules:
 
-- The workspace manifest and live code own shipped capability and public
+- Live code and live gateway responses own shipped capability and public
   interface reality. Documentation projects that truth; it does not create it.
-- The root positioning and pricing authorities own public language and claim
-  structure. Pricing numbers must come verbatim from the ratified
-  `PRICING-CARD-CANONICAL.md`; never invent, remember, or derive a price from
-  any other source.
+  `CURRENT-STATE.md` records what has been verified shipped.
+- The control repository's positioning authority owns public language and claim
+  structure.
+- Pricing numbers are owned by the gateway, not by any document. Take them from
+  the live `GET /api/pricing` response, or from the executable owners that
+  `PRICING.md` routes to; never invent, remember, or derive a price from any
+  other source.
 - `src/content/docs/` owns human-facing pages.
 - `public/openapi.yaml`, `public/mcp-schema.json`, `public/llms.txt`, and
   `public/llms-full.txt` are checked-in public contract projections. Update and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md - Varity Documentation
 
 Status: repository entrypoint
-Last updated: 2026-08-09
+Last updated: 2026-08-19
 
 This repository publishes the public documentation at `docs.varity.so`. It is
 a static Astro/Starlight surface, not a control-plane runtime.
@@ -40,15 +40,15 @@ Authority rules:
 
 ## Verification
 
-Run the repository's complete local check before merge:
+Install dependencies with `npm install` when needed, then run the repository's
+complete local check before merge:
 
 ```bash
-npm ci
 npm run check
 ```
 
 For visual or navigation changes, also inspect the local site at
-`http://localhost:4321` and verify the affected pages on desktop and mobile.
+`http://localhost:4321` at 1440x900, 768x900, and 390x844.
 
 Every pull request must complete the `Architecture impact` block in the pull
 request template. Update `ARCHITECTURE.md` only when ownership, an interface,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,10 +73,9 @@ Then open a pull request on GitHub with a clear description of your changes.
 Every documentation page should include:
 
 1. **Frontmatter** - Metadata at the top of the file
-2. **Title** - Clear H1 heading
-3. **Introduction** - Brief overview of what the page covers
-4. **Main Content** - The actual documentation
-5. **Next Steps** - Links to related pages (when appropriate)
+2. **Introduction** - Brief overview of what the page covers
+3. **Main Content** - The actual documentation
+4. **Next Steps** - Links to related pages (when appropriate)
 
 ### Frontmatter Format
 
@@ -95,7 +94,7 @@ description: "Brief description under 160 characters for SEO."
 
 ### Headings
 
-- Use **H1** (`#`) for the page title only (one per page)
+- Use the frontmatter `title` as the page title; do not add a Markdown H1
 - Use **H2** (`##`) for major sections
 - Use **H3** (`###`) for subsections
 - Use sentence case: "Getting started" not "Getting Started"

--- a/README.md
+++ b/README.md
@@ -9,9 +9,14 @@ This repository is the source for the official Varity documentation at **[docs.v
 
 ## What is Varity?
 
-Varity deploys supported source repos and runnable Docker/OCI HTTP services from the CLI, the Developer Portal, or your AI coding tool. It builds your project, provisions the backend services it detects, and returns a live URL. Pricing is one fixed monthly cost per app based on reserved hardware, so the bill does not change with traffic.
+Varity is The Orchestration Cloud. It aggregates independent compute capacity
+and orchestrates it as one cloud. You can deploy supported source repos and
+runnable Docker/OCI HTTP services from the Developer Portal, CLI, MCP server,
+or Public API. Pricing depends on the workload and current quote; see the
+[pricing guide](https://docs.varity.so/resources/pricing/) for the supported
+models.
 
-Varity ships as two packages:
+The command-line and AI-tool integrations are distributed as:
 
 - **`varitykit`** (PyPI): the deploy CLI
 - **`@varity-labs/mcp`** (npm): the MCP server for AI coding tools (Claude Code, Cursor, Windsurf)

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,3 +1,4 @@
+import { rehypeTableScroll } from './src/plugins/rehype-table-scroll.mjs';
 // @ts-check
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
@@ -5,6 +6,7 @@ import sitemap from "@astrojs/sitemap";
 
 // https://astro.build/config
 export default defineConfig({
+  markdown: { rehypePlugins: [rehypeTableScroll] },
   site: "https://docs.varity.so",
   output: "static",
   image: {
@@ -87,6 +89,14 @@ export default defineConfig({
             rel: "preconnect",
             href: "https://fonts.gstatic.com",
             crossorigin: "anonymous",
+          },
+        },
+        // Discovered by the preload scanner in the HTML, not after CSS parse.
+        {
+          tag: "link",
+          attrs: {
+            rel: "stylesheet",
+            href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap",
           },
         },
         // Performance: Browser's preload scanner handles critical resource discovery
@@ -249,6 +259,35 @@ export default defineConfig({
             { label: "API Reference", slug: "ai-tools/api-reference" },
             { label: "AI Prompts", slug: "ai-tools/prompts" },
             { label: "CLI (varitykit)", slug: "cli/overview" },
+          ],
+        },
+
+        // ===== AI GATEWAY =====
+        {
+          label: "AI Gateway",
+          items: [
+            { label: "AI Gateway Overview", slug: "ai-gateway" },
+            { label: "Models", slug: "ai-gateway/models" },
+            { label: "OpenAI Compatibility", slug: "ai-gateway/compatibility" },
+          ],
+        },
+
+        // ===== API CONTRACT =====
+        {
+          label: "API Contract",
+          items: [
+            { label: "Errors", slug: "api/errors" },
+            { label: "Rate Limits", slug: "api/limits" },
+          ],
+        },
+
+        // ===== MACHINES =====
+        {
+          label: "Machines (VMs & GPU)",
+          items: [
+            { label: "Deployment Categories", slug: "machines" },
+            { label: "CPU Virtual Machines", slug: "machines/cpu-vms" },
+            { label: "GPU Machines", slug: "machines/gpu" },
           ],
         },
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -281,7 +281,7 @@ export default defineConfig({
               slug: "deploy/env-variables",
             },
             {
-              label: "App URLs and Names",
+              label: "App URLs and Custom Domains",
               slug: "deploy/custom-domains",
             },
             {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -48,10 +48,18 @@ Older thin-client compatibility routes are not the public resource contract. New
 
 ## Base URL And Auth
 
-All public API calls use:
+Varity exposes two public base URLs. Platform APIs (apps, deployments,
+templates, pricing, credits, API keys, webhooks) use:
 
 ```text
 https://varity.app/api
+```
+
+The AI Gateway (OpenAI-compatible inference — chat completions and model
+listing) uses:
+
+```text
+https://varity.app/v1
 ```
 
 For non-browser callers, send your Varity API key as a bearer credential:
@@ -380,18 +388,17 @@ Search Varity docs for guides, API references, and tutorials.
 
 ### `varity_cost_calculator`: Estimate costs
 
-Estimate the monthly price for your deployment profile.
+Estimate the fixed monthly price for a deployment profile. Pricing is computed by the Varity pricing service, so this tool, the CLI, and the portal render identical numbers.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `users` | number | Yes | none | Estimated monthly active users |
-| `storage_gb` | number | No | 10 | Storage needed in GB |
-| `has_database` | boolean | No | true | Whether the app uses a database |
-| `has_auth` | boolean | No | true | Whether the app uses authentication |
+| `app_profile` | string | No | `web-app` | Pre-deploy estimate preset: `static-site`, `web-app`, `web-app-db`, `ai-agent-cpu`, or `ai-agent-gpu` |
+| `subdomain` | string | No | none | A live deployment's subdomain — returns that deployment's real cost (overrides `app_profile`) |
+| `has_database` | boolean | No | none | Whether the app uses a database (selects the database-inclusive estimate) |
 
 **Annotations:** `readOnlyHint: true`
 
-**Example prompt:** "How much would it cost to host a SaaS app with 500 users on Varity?"
+**Example prompt:** "How much would it cost to host a web app with a database on Varity?"
 
 ---
 
@@ -649,7 +656,7 @@ Here is the practical build-and-deploy flow using the MCP tools:
 
 1. **"Check if my environment is ready"** → `varity_doctor`
 2. **"Install dependencies"** → `varity_install_deps`
-3. **"What will this cost for 200 users?"** → `varity_cost_calculator`
+3. **"What will this cost per month?"** → `varity_cost_calculator`
 4. **"Start the dev server"** → `varity_dev_server` → `varity_open_browser`
 5. **"Build for production"** → `varity_build`
 6. **"Deploy this"** → `varity_deploy`
@@ -711,7 +718,7 @@ https://mcp.varity.so
 
 **ChatGPT:** Settings → Connectors → Create → MCP server URL: `https://mcp.varity.so`
 
-The first time you connect, you'll authenticate via the Varity login page.
+Hosted OAuth login is in progress: hosted OAuth and per-user deployment authorization are not yet certified end to end. Until that verification passes, do not use the hosted endpoint for owner-scoped operations (deploys, env changes, deletes) — connect via the stdio package (`npx -y @varity-labs/mcp`) instead.
 
 ### Self-Hosted HTTP
 
@@ -3622,11 +3629,19 @@ This restores all files from `.vercel-migration-backup/`.
 ## Supported App Deployment Frameworks
 
 URL: https://docs.varity.so/deploy/what-you-can-deploy/
-Description: Supported app deployment frameworks on Varity, including Node, Python, Go, static projects, Docker image services, and current beta limits.
+Description: The three Varity deployment categories — Applications (repos, Docker images, static sites), CPU VMs, and GPU workloads — plus current beta limits.
 
 Varity is a newly launched platform in active beta. This page is the honest snapshot of what works today, what is beta, and what is not ready yet, so nothing surprises you after you deploy.
 
 ## What Deploys Today
+
+Varity serves three deployment categories:
+
+1. **Applications** — deploy from a Git repository, a prebuilt Docker image, or a static build.
+2. **CPU VMs** — dedicated virtual machines; you pick the exact machine from the marketplace.
+3. **GPU workloads** — GPU containers, GPU VMs, and GPU bare metal; you pick the exact GPU offer from the marketplace.
+
+### Applications
 
 <CardGrid>
 
@@ -3653,6 +3668,14 @@ See [Supported Frameworks](/deploy/supported-frameworks/) for the full detection
 - Static sites → `https://varity.app/<your-app>/`
 - Dynamic apps → `https://<your-app>.varity.app/`
 
+### CPU VMs
+
+Rent a dedicated CPU virtual machine when you need full control of the box rather than a managed app runtime. The VM marketplace shows the exact machines on offer — you choose the machine, region, and price before you deploy.
+
+### GPU workloads
+
+GPU compute comes in three forms: **GPU containers**, **GPU VMs**, and **GPU bare metal**. The GPU marketplace shows the exact cards on offer — you choose the card, region, and price before you deploy.
+
 ## Not Auto-Built From Source Yet
 
 Varity does not build these languages from source yet: **Rust, Ruby / Rails, Elixir / Phoenix, Java / Spring, Deno, PHP / Laravel, .NET.**
@@ -3667,7 +3690,6 @@ These aren't available in the current beta. Don't plan around them yet:
 - Cron jobs and scheduled tasks
 - Preview deployments
 - Multi-region and edge runtime
-- Dedicated GPUs for your own containers
 - A fully managed database product (see the durability note below)
 
 ## Beta Expectations
@@ -3676,7 +3698,7 @@ Varity is in guided beta. For demos, side projects, and apps that tolerate beta,
 
 - **Databases are real but beta.** Auto-wired databases work and data survives container restarts within a deployment, but this is not yet a managed database product with automated backups, high availability, or point-in-time recovery. See [Databases & Data](/deploy/databases/).
 - **Private repos:** the safest path for a private or unsupported app today is a prebuilt Docker image.
-- **Heavy or unusual workloads** (browser automation, large file/video processing, long-running jobs, GPU work) may need a hand. Reach out via [Getting Help](/getting-started/getting-help/).
+- **Heavy or unusual workloads** (browser automation, large file/video processing, long-running jobs) may need a hand. Reach out via [Getting Help](/getting-started/getting-help/).
 
 ## Start Deploying
 
@@ -3835,7 +3857,7 @@ Varity chooses the default based on the app type. You can force the mode with `-
 
 Varity is in guided beta. Use it freely for demos, side projects, AI agent apps, and apps that tolerate beta limits. Bring your own external database for business critical data until managed database durability, backups, and restore are shipped.
 
-Varity currently supports Node, Python, Go, static projects, and Docker or OCI HTTP service images. Cron jobs, preview deployments, one click rollback, and dedicated GPUs for user containers are not shipped yet.
+Varity serves three deployment categories: applications (Node, Python, Go, static projects, and Docker or OCI HTTP service images), CPU VMs, and GPU workloads (containers, VMs, and bare metal). Cron jobs, preview deployments, and one click rollback are not shipped yet.
 
 ## Next Steps
 
@@ -4061,7 +4083,7 @@ Source deployments support Node, Python, Go, and static projects. Docker image d
 
 **Supported services:** Postgres with vector extension support, Redis, MongoDB, MySQL, object storage, and model runtime services when detected from your app.
 
-**Not shipped yet:** cron jobs, preview deployments, one click rollback, managed database backups and restore, and dedicated GPUs for user containers.
+**Not shipped yet:** cron jobs, preview deployments, one click rollback, and managed database backups and restore.
 
 ## Where to Go Next
 
@@ -4451,7 +4473,7 @@ Use [Pricing and Costs](/resources/pricing/) for the current pricing workflow an
 
 Varity is in guided beta. Bring your own external managed database for business critical data until managed database durability, backups, and restore are shipped.
 
-Varity may not be the right fit yet if you need cron jobs, preview deployments, one click rollback, dedicated GPUs for your own containers, or a source build for Rust, Ruby, Elixir, Java, Deno, PHP, or .NET.
+Varity may not be the right fit yet if you need cron jobs, preview deployments, one click rollback, or a source build for Rust, Ruby, Elixir, Java, Deno, PHP, or .NET.
 
 Those unsupported source stacks can still deploy when packaged as runnable Docker or OCI HTTP service images.
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -236,6 +236,8 @@ The OpenAPI document contains these 18 public paths:
 | `GET`, `PATCH` | `/api/deployments/{deployment_id}/env` | List environment variable keys or update values |
 | `POST` | `/api/deployments/{deployment_id}/redeploy` | Redeploy in place |
 | `POST` | `/api/deployments/{deployment_id}/restart` | Restart in place |
+| `GET`, `PUT`, `DELETE` | `/api/deployments/{deployment_id}/domain` | Read, attach, or remove a custom domain |
+| `POST` | `/api/deployments/{deployment_id}/domain/verify` | Observe DNS and verify HTTPS serving |
 | `GET` | `/api/templates` | List templates |
 | `GET` | `/api/templates/{template_id}` | Read a template |
 | `POST` | `/api/templates/{template_id}/deploy` | Deploy a template |
@@ -1796,14 +1798,12 @@ Varity filters out platform-specific environment variables from other providers 
 
 ---
 
-## App URLs and Names on Varity
+## App URLs and Custom Domains on Varity
 
 URL: https://docs.varity.so/deploy/custom-domains/
-Description: Set your Varity app name. Static apps use varity.app/{name}, and dynamic apps use {name}.varity.app.
+Description: Set your Varity app name, and attach your own domain to a deployment with a CNAME for a subdomain or an A plus TXT record for a root domain.
 
-Every Varity deployment gets a public URL based on its hosting type: **static apps** are served at `https://varity.app/{name}/`, and **dynamic apps** get their own subdomain at `https://{name}.varity.app/`. This guide covers how to set a custom app name and list the `varity.app` names registered to your account.
-
-External custom domain support is not available yet. Use your assigned `varity.app` URL for current beta deployments.
+Every Varity deployment gets a public URL based on its hosting type: **static apps** are served at `https://varity.app/{name}/`, and **dynamic apps** get their own subdomain at `https://{name}.varity.app/`. You can also attach **your own domain** to a deployment. This guide covers both.
 
 ## How Your Domain Is Assigned
 
@@ -1846,9 +1846,113 @@ https://my-app.varity.app/
 
 **Claim your name early.** Subdomain names are first-come, first-served. Once you've registered a name, it's yours as long as you have an active deployment.
 
-## View Your Registered Domains
+## Attach Your Own Domain
 
-List all domains registered to your account:
+You can point a domain you own at a deployment. Both subdomains (`app.example.com`) and root domains (`example.com`) are supported.
+
+A deployment must serve a public web endpoint to take a custom domain, and each deployment holds **one** custom hostname at a time. Remove the current hostname before attaching a different one.
+
+### From the developer portal
+
+1. Open your deployment in the dashboard and find the **Custom domain** card.
+2. Enter the hostname you want to use and attach it. Varity responds with the exact DNS records to create.
+3. Create those records at your DNS provider, then return to the card and run the verification check.
+
+### From the API
+
+Attach a hostname with `PUT /deployments/{deployment_id}/domain`:
+
+```bash
+curl -X PUT https://varity.app/api/deployments/$DEPLOYMENT_ID/domain \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"hostname": "app.example.com"}'
+```
+
+Read the current state at any time:
+
+```bash
+curl https://varity.app/api/deployments/$DEPLOYMENT_ID/domain \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+The response tells you whether the deployment supports a custom domain, and returns the record it is waiting for:
+
+```json
+{
+  "supported": true,
+  "domain": {
+    "hostname": "app.example.com",
+    "recordType": "cname",
+    "recordName": "app",
+    "expectedCname": "your-app.varity.app",
+    "state": "pending_dns",
+    "dns": { "status": "pending" },
+    "certificate": { "status": "pending" },
+    "serving": { "status": "pending" }
+  }
+}
+```
+
+## Create the DNS Records
+
+The records depend on whether you are attaching a subdomain or a root domain. Use the values returned by the API rather than copying the examples below.
+
+A subdomain routes with a single CNAME record pointing at the value in `expectedCname`:
+
+| Type  | Name (Host) | Value               |
+|-------|-------------|---------------------|
+| CNAME | `app`       | `expectedCname`     |
+
+A root domain cannot hold a CNAME, so it takes an A record pointing at `expectedA`, plus the TXT record in `challenge` that proves the zone is yours. Both are required:
+
+| Type | Name (Host)      | Value              |
+|------|------------------|--------------------|
+| A    | `@`              | `expectedA`        |
+| TXT  | `challenge.name` | `challenge.value`  |
+
+**Enter the Host field relative to your zone.** Registrars append the zone automatically, so the Host for `app.example.com` inside the zone `example.com` is `app`, not `app.example.com`. Varity returns the correct value in `recordName`, using `@` for a root domain.
+
+Wildcard hostnames, IP addresses, and reserved or private-suffix hosts cannot be attached.
+
+## Verify the Domain
+
+After the records are live, ask Varity to observe DNS and confirm the domain serves over HTTPS:
+
+```bash
+curl -X POST https://varity.app/api/deployments/$DEPLOYMENT_ID/domain/verify \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+The domain moves through these states:
+
+| `state`               | Meaning                                                        |
+|-----------------------|----------------------------------------------------------------|
+| `pending_dns`         | Waiting for your DNS records to resolve to the expected values |
+| `certificate_pending` | DNS is verified; the certificate is being issued               |
+| `active`              | The domain is serving your app over HTTPS                      |
+| `error`               | A check failed; see `errorCode`                                |
+
+The `dns`, `certificate`, and `serving` blocks each carry their own `status` and `checkedAt`, so you can see which stage is outstanding. When DNS resolves to something other than the expected value, `dns.status` is `mismatch` and the `observedCnames`, `observedA`, and `observedTxt` fields show what Varity actually saw — usually the fastest way to spot a typo or a record left in place from a previous host.
+
+Two error codes are reported: `dns_lookup_failed` when the records cannot be resolved, and `https_verification_failed` when the hostname does not yet serve over HTTPS.
+
+DNS changes take time to propagate. If verification fails immediately after you create the records, wait for your provider's TTL to expire and run it again.
+
+## Remove a Domain
+
+Detach the hostname to free it for another deployment:
+
+```bash
+curl -X DELETE https://varity.app/api/deployments/$DEPLOYMENT_ID/domain \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+Your app stays reachable at its `varity.app` URL.
+
+## View Your Registered Names
+
+List the `varity.app` names registered to your account:
 
 ```bash
 varitykit domains list
@@ -1866,7 +1970,7 @@ Your Domains (2)
 └─────────────┴──────────────────────────────────┴──────────────────┘
 ```
 
-You must be logged in to list your domains. Run `varitykit login` first if you see a "Not logged in" message.
+You must be logged in to list your names. Run `varitykit login` first if you see a "Not logged in" message.
 
 ## Redeploy Under the Same Name
 
@@ -1880,18 +1984,17 @@ varitykit app deploy --name my-app
 varitykit app deploy --name my-app
 ```
 
+An attached custom domain survives a redeploy. You do not need to re-create the DNS records.
+
 ## SSL / HTTPS
 
-All `varity.app` subdomains are served over HTTPS automatically. No certificate setup is required. SSL is provisioned and renewed by Varity.
-
-## External Domains
-
-External custom domains are on the roadmap, but they are not part of the current beta. Do not configure DNS records for a custom domain until the dashboard exposes that workflow.
+All `varity.app` subdomains are served over HTTPS automatically, and certificates for attached custom domains are issued and renewed by Varity once DNS is verified. No certificate setup is required in either case.
 
 ## Related
 
 - [Deploy Your App](/deploy/deploy-your-app): full deployment guide
 - [CLI Reference: deploy](/cli/commands/deploy): all `app deploy` flags
+- [API Reference](/ai-tools/api-reference): the full public platform API
 
 ---
 
@@ -3512,7 +3615,7 @@ This restores all files from `.vercel-migration-backup/`.
 
 - [Deploy your app](/deploy/deploy-your-app): understand what happens during deploy
 - [Environment variables](/deploy/env-variables): how credentials work
-- [Custom domains](/deploy/custom-domains): set a custom subdomain for your app
+- [Custom domains](/deploy/custom-domains): attach your own domain to a deployment
 
 ---
 
@@ -3560,7 +3663,6 @@ If you try one of those as a source project, you get a clear unsupported-stack e
 
 These aren't available in the current beta. Don't plan around them yet:
 
-- Custom domains (your app lives at its `varity.app` URL for now)
 - Rollback as a one-click feature; recover by [redeploying a known-good version](/deploy/rollback/)
 - Cron jobs and scheduled tasks
 - Preview deployments
@@ -3655,7 +3757,7 @@ For the exact framework matrix, use [Supported Frameworks](/deploy/supported-fra
 | Input | You provide source, a GitHub repo, dashboard settings, MCP request, or Docker image | [Deploy Your App](/deploy/deploy-your-app/) |
 | Build | Varity builds supported source projects or pulls a runnable image | [Supported Frameworks](/deploy/supported-frameworks/) |
 | Configure | Varity applies hosting, variables, services, and URL defaults | [Deployment Defaults](/deploy/intelligent-orchestration/) |
-| Launch | Your app becomes available on its Varity URL | [App URLs and Names](/deploy/custom-domains/) |
+| Launch | Your app becomes available on its Varity URL | [App URLs and Custom Domains](/deploy/custom-domains/) |
 | Operate | You use logs, status, environment updates, redeploy, and support | [Troubleshooting Deploys](/deploy/deployment-troubleshooting/) |
 
 ## Deploy Lifecycle
@@ -3733,7 +3835,7 @@ Varity chooses the default based on the app type. You can force the mode with `-
 
 Varity is in guided beta. Use it freely for demos, side projects, AI agent apps, and apps that tolerate beta limits. Bring your own external database for business critical data until managed database durability, backups, and restore are shipped.
 
-Varity currently supports Node, Python, Go, static projects, and Docker or OCI HTTP service images. External custom domains, cron jobs, preview deployments, one click rollback, and dedicated GPUs for user containers are not shipped yet.
+Varity currently supports Node, Python, Go, static projects, and Docker or OCI HTTP service images. Cron jobs, preview deployments, one click rollback, and dedicated GPUs for user containers are not shipped yet.
 
 ## Next Steps
 
@@ -3959,7 +4061,7 @@ Source deployments support Node, Python, Go, and static projects. Docker image d
 
 **Supported services:** Postgres with vector extension support, Redis, MongoDB, MySQL, object storage, and model runtime services when detected from your app.
 
-**Not shipped yet:** external custom domains, cron jobs, preview deployments, one click rollback, managed database backups and restore, and dedicated GPUs for user containers.
+**Not shipped yet:** cron jobs, preview deployments, one click rollback, managed database backups and restore, and dedicated GPUs for user containers.
 
 ## Where to Go Next
 
@@ -4349,7 +4451,7 @@ Use [Pricing and Costs](/resources/pricing/) for the current pricing workflow an
 
 Varity is in guided beta. Bring your own external managed database for business critical data until managed database durability, backups, and restore are shipped.
 
-Varity may not be the right fit yet if you need external custom domains today, cron jobs, preview deployments, one click rollback, dedicated GPUs for your own containers, or a source build for Rust, Ruby, Elixir, Java, Deno, PHP, or .NET.
+Varity may not be the right fit yet if you need cron jobs, preview deployments, one click rollback, dedicated GPUs for your own containers, or a source build for Rust, Ruby, Elixir, Java, Deno, PHP, or .NET.
 
 Those unsupported source stacks can still deploy when packaged as runnable Docker or OCI HTTP service images.
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -56,7 +56,7 @@ claude mcp add varity -- npx -y @varity-labs/mcp
 - [Recover a Previous Version](https://docs.varity.so/deploy/rollback/): Recover after a bad Varity deploy by redeploying a known-good version under the same app name.
 - [Supported Frameworks on Varity](https://docs.varity.so/deploy/supported-frameworks/): Which frameworks Varity supports today, what gets auto-detected, and how to request support for languages not yet available.
 - [Migrate from Vercel to Varity](https://docs.varity.so/deploy/vercel-migration/): Move your existing Vercel app to Varity in under 3 minutes. The CLI and MCP tools handle code transforms, dependency cleanup, and deployment automatically.
-- [Supported App Deployment Frameworks](https://docs.varity.so/deploy/what-you-can-deploy/): Supported app deployment frameworks on Varity, including Node, Python, Go, static projects, Docker image services, and current beta limits.
+- [Supported App Deployment Frameworks](https://docs.varity.so/deploy/what-you-can-deploy/): The three Varity deployment categories — Applications (repos, Docker images, static sites), CPU VMs, and GPU workloads — plus current beta limits.
 - [Getting Help with Varity](https://docs.varity.so/getting-started/getting-help/): Find Varity support through documentation, Discord, GitHub issues, and setup checks when deploys need attention.
 - [How Varity Deployments Work](https://docs.varity.so/getting-started/how-varity-works/): The Varity deploy lifecycle from project input to live URL, status, logs, and redeploys.
 - [Getting Started with Varity](https://docs.varity.so/getting-started/): Get started with Varity. Deploy supported source apps, AI agents, and runnable Docker services.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,6 @@
 # Varity Docs
 
-> Varity is predictable cloud hosting for supported Node, Python, Go, static, AI agent, and runnable Docker/OCI HTTP service deployments.
+> Varity runs supported Node, Python, Go, static, AI agent, and runnable Docker/OCI HTTP service deployments, rents CPU virtual machines and GPU machines by the hour, and serves an OpenAI-compatible inference API at https://varity.app/v1.
 
 Use these docs as the public Varity documentation context. Current MCP install command:
 
@@ -77,3 +77,11 @@ claude mcp add varity -- npx -y @varity-labs/mcp
 - [Troubleshooting Varity Deploys](https://docs.varity.so/resources/troubleshooting/): Fix common Varity issues: CLI not found, build errors, authentication failures, deployment problems, and database connection troubleshooting.
 - [Build an App Using Only AI (No Code Required)](https://docs.varity.so/tutorials/build-with-ai/): Build and deploy an app with your AI editor. Varity MCP handles setup checks, the deploy workflow, and cost estimation.
 - [Deploy an AI Agent or LLM App](https://docs.varity.so/tutorials/deploy-ai-agent/): Step-by-step guide to deploying a Python or Node.js AI agent on Varity. Auto-detected compute and optional local model server included.
+- [Varity AI Gateway](https://docs.varity.so/ai-gateway/): OpenAI-compatible inference API at https://varity.app/v1. Point any OpenAI client at it and change nothing else.
+- [AI Gateway Models](https://docs.varity.so/ai-gateway/models/): The live model catalog with context windows, max completion tokens, tool-call and streaming support, and per-million-token prices.
+- [AI Gateway OpenAI Compatibility](https://docs.varity.so/ai-gateway/compatibility/): Which OpenAI endpoints are supported, which return 404, per-model capability differences, and the data-handling contract.
+- [Machine Catalogs](https://docs.varity.so/machines/): The four machine catalogs: CPU virtual machines, GPU containers, GPU virtual machines, and GPU bare metal.
+- [CPU Virtual Machines](https://docs.varity.so/machines/cpu-vms/): All CPU VM sizes with vCPU, memory, disk, hourly price, monthly cap, OS images, and how billing stops.
+- [GPU Machines](https://docs.varity.so/machines/gpu/): GPU card models, host specs, regions and hourly rates across containers, virtual machines, and bare metal. Rates track available supply.
+- [API Errors](https://docs.varity.so/api/errors/): The error envelope, the full error code reference with per-code anchors, fault attribution, and correlation IDs.
+- [API Rate Limits](https://docs.varity.so/api/limits/): Per-account rate limit classes, response headers, the 429 response, and how to retry correctly.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -43,7 +43,7 @@ claude mcp add varity -- npx -y @varity-labs/mcp
 - [Command Line App Deploy with Varity CLI](https://docs.varity.so/cli/): Use the Varity CLI for command line app deploys, setup checks, and terminal workflows with varitykit.
 - [VarityKit CLI Overview Guide](https://docs.varity.so/cli/overview/): VarityKit CLI overview: deploy apps, run diagnostics, and manage domains. A familiar Python-based deploy CLI.
 - [Auto Wired Services on Varity](https://docs.varity.so/deploy/auto-wired-services/): Varity reads your dependencies and automatically provisions the databases and services your app needs. No configuration required.
-- [App URLs and Names on Varity](https://docs.varity.so/deploy/custom-domains/): Set your Varity app name. Static apps use varity.app/{name}, and dynamic apps use {name}.varity.app.
+- [App URLs and Custom Domains on Varity](https://docs.varity.so/deploy/custom-domains/): Set your Varity app name, and attach your own domain to a deployment with a CNAME for a subdomain or an A plus TXT record for a root domain.
 - [Deploy Apps with Postgres, Redis, MongoDB, and MySQL](https://docs.varity.so/deploy/databases/): Deploy an app with Postgres, Redis, MongoDB, or MySQL on Varity, including injected connection details and beta durability boundaries.
 - [Deploy a Docker Image on Varity](https://docs.varity.so/deploy/deploy-docker-image/): Deploy public or private runnable Docker images to Varity from the CLI, the Developer Portal, or your AI coding tool. No repo and no build step required.
 - [Deploy from the Dashboard](https://docs.varity.so/deploy/deploy-from-dashboard/): Deploy a GitHub repo, a Docker image, or a ready-made template from the Varity developer dashboard without using the command line.

--- a/public/mcp-schema.json
+++ b/public/mcp-schema.json
@@ -4,7 +4,7 @@
   "server": {
     "name": "varity",
     "package": "@varity-labs/mcp",
-    "version": "2.3.6",
+    "version": "2.3.9",
     "docs": "https://docs.varity.so/ai-tools/mcp-server-spec/",
     "install": {
       "claudeCode": "claude mcp add varity -- npx -y @varity-labs/mcp",

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Varity Public Platform API",
-    "version": "2026-07-10",
+    "version": "2026-07-25",
     "description": "Gateway-owned resource API for deploying and operating Varity apps."
   },
   "servers": [
@@ -16,6 +16,360 @@
     }
   ],
   "paths": {
+    "/deployment-profiles": {
+      "get": {
+        "operationId": "getDeploymentProfiles",
+        "summary": "Get normalized deployment profiles",
+        "description": "Returns customer-facing profiles, prices, and aggregate availability without exposing supplier identity or native inventory.",
+        "parameters": [
+          {
+            "name": "workload",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "gpu",
+                "cpu"
+              ]
+            }
+          },
+          {
+            "name": "execution_class",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "container",
+                "virtual_machine",
+                "bare_metal",
+                "cpu_virtual_machine"
+              ]
+            }
+          },
+          {
+            "name": "contract_version",
+            "in": "query",
+            "required": false,
+            "description": "Request the resource-, location-, runtime-, and access-complete GPU container catalog. Omit during a rolling v1 compatibility window.",
+            "schema": {
+              "const": "gpu-container-profiles-v2"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized GPU deployment profile catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/GpuContainerProfileCatalogV1"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GpuContainerProfileCatalog"
+                    },
+                    {
+                      "$ref": "#/components/schemas/MachineProfileCatalog"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/pricing/accelerator-quote": {
+      "post": {
+        "operationId": "issueAcceleratorQuote",
+        "summary": "Issue an exact hourly accelerator quote for a GPU workload",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/PrepareGpuContainerQuoteRequest"
+                  },
+                  {
+                    "$ref": "#/components/schemas/CreateApplicationDeploymentRequest"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Exact quote",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceleratorQuote"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/pricing/machine-quote": {
+      "post": {
+        "operationId": "issueMachineQuote",
+        "summary": "Issue an exact quote for a self-managed machine",
+        "description": "Resolves the selected Varity profile and OS image against current normalized inventory and its exact customer price.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MachineQuoteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Exact owner-bound machine quote",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineQuote"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/machines": {
+      "get": {
+        "operationId": "listMachines",
+        "summary": "List owner-scoped self-managed machines",
+        "responses": {
+          "200": {
+            "description": "Normalized owner machine inventory",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "machines"
+                  ],
+                  "properties": {
+                    "machines": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Machine"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createMachine",
+        "summary": "Create a self-managed machine",
+        "description": "Accepts a Varity profile, normalized OS image, and SSH public key. Supplier identity and native infrastructure identifiers are never public.",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 8,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9._:-]+$"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMachineRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Machine operation accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineAcceptance"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/machines/{machine_id}/actions": {
+      "post": {
+        "operationId": "runMachineAction",
+        "summary": "Run a bounded synchronous action on one machine",
+        "description": "Restarts or soft-reboots the machine in place. Not a durable operation: the machine keeps its identity, access, and billing.",
+        "parameters": [
+          {
+            "name": "machine_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MachineActionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Observed machine state after the action was applied",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineActionResult"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/machines/{machine_id}": {
+      "get": {
+        "operationId": "getMachine",
+        "summary": "Get one owner-scoped self-managed machine",
+        "parameters": [
+          {
+            "name": "machine_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Normalized machine lifecycle, access, and billing truth",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Machine"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteMachine",
+        "summary": "Delete one owner-scoped self-managed machine",
+        "description": "Acceptance is not closure proof. Allocation, SSH access, and billing closure reconcile independently.",
+        "parameters": [
+          {
+            "name": "machine_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 8,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9._:-]+$"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Machine deletion accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineAcceptance"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/deployment-capabilities": {
+      "get": {
+        "operationId": "getDeploymentCapabilities",
+        "summary": "Get the provider-neutral deployment catalog",
+        "description": "Returns user-visible workload and execution choices with their current availability. Live inventory and implementation-specific identifiers are not part of this contract.",
+        "responses": {
+          "200": {
+            "description": "Deployment capability catalog",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeploymentCapabilities"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
     "/deployments": {
       "get": {
         "operationId": "listDeployments",
@@ -173,6 +527,171 @@
               }
             }
           },
+          "202": {
+            "description": "Deletion accepted (durable path): route removal, compute close, and billing stop reconcile as distinct durable facts.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "status",
+                    "deleted",
+                    "run_id",
+                    "status_url"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "app_name": {
+                      "type": "string"
+                    },
+                    "subdomain": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "deleting",
+                        "deleted"
+                      ]
+                    },
+                    "deleted": {
+                      "type": "boolean"
+                    },
+                    "run_id": {
+                      "type": "string"
+                    },
+                    "status_url": {
+                      "type": "string"
+                    },
+                    "replayed": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/deployments/{deployment_id}/domain": {
+      "get": {
+        "operationId": "getDeploymentDomain",
+        "summary": "Read custom-domain state",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/DeploymentId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Custom-domain state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomDomainEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      },
+      "put": {
+        "operationId": "attachDeploymentDomain",
+        "summary": "Attach one hostname (subdomain CNAME or apex A + TXT)",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/DeploymentId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "hostname"
+                ],
+                "properties": {
+                  "hostname": {
+                    "type": "string",
+                    "examples": [
+                      "app.example.com",
+                      "example.com"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Custom domain attached",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomDomainEnvelope"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "removeDeploymentDomain",
+        "summary": "Remove the custom hostname",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/DeploymentId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Custom domain removed"
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/deployments/{deployment_id}/domain/verify": {
+      "post": {
+        "operationId": "verifyDeploymentDomain",
+        "summary": "Observe DNS and verify HTTPS serving",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/DeploymentId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Updated custom-domain state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomDomainEnvelope"
+                }
+              }
+            }
+          },
           "default": {
             "$ref": "#/components/responses/PublicError"
           }
@@ -208,7 +727,8 @@
     "/deployments/{deployment_id}/restart": {
       "post": {
         "operationId": "restartDeployment",
-        "summary": "Restart in place",
+        "summary": "Restart a deployment as a verified replacement",
+        "description": "Provisions a fresh verified replacement from the saved deployment configuration: the current version keeps serving until the replacement passes health and routing checks, then traffic switches atomically. Deployments that cannot be reconstructed from saved configuration answer 409; where the platform cannot restart at all it answers 501.",
         "parameters": [
           {
             "$ref": "#/components/parameters/DeploymentId"
@@ -220,10 +740,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AcceptedMutation"
+                  "type": "object",
+                  "required": [
+                    "status",
+                    "run_id",
+                    "status_url"
+                  ],
+                  "properties": {
+                    "status": {
+                      "const": "restarting"
+                    },
+                    "run_id": {
+                      "type": "string"
+                    },
+                    "status_url": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }
+          },
+          "409": {
+            "$ref": "#/components/responses/PublicError"
+          },
+          "501": {
+            "$ref": "#/components/responses/PublicError"
           },
           "default": {
             "$ref": "#/components/responses/PublicError"
@@ -497,6 +1039,7 @@
       "get": {
         "operationId": "estimatePricing",
         "summary": "Estimate fixed monthly cost",
+        "description": "Managed Cloud pricing is a fixed preset menu (starter, growth, scale, pro). Static sites are free.",
         "parameters": [
           {
             "name": "profile",
@@ -512,9 +1055,26 @@
             }
           },
           {
+            "name": "preset",
+            "in": "query",
+            "required": false,
+            "description": "Managed Cloud preset id (starter, growth, scale, pro).",
+            "schema": {
+              "type": "string",
+              "examples": [
+                "starter",
+                "growth",
+                "scale",
+                "pro"
+              ]
+            }
+          },
+          {
             "name": "cpu",
             "in": "query",
             "required": false,
+            "deprecated": true,
+            "description": "Deprecated: mapped to the smallest satisfying Managed Cloud preset. Use `preset` instead.",
             "schema": {
               "type": "number",
               "minimum": 0.25
@@ -524,6 +1084,8 @@
             "name": "memory_gb",
             "in": "query",
             "required": false,
+            "deprecated": true,
+            "description": "Deprecated: mapped to the smallest satisfying Managed Cloud preset. Use `preset` instead.",
             "schema": {
               "type": "number",
               "minimum": 0.25
@@ -533,6 +1095,8 @@
             "name": "ephemeral_gb",
             "in": "query",
             "required": false,
+            "deprecated": true,
+            "description": "Deprecated: mapped to the smallest satisfying Managed Cloud preset. Use `preset` instead.",
             "schema": {
               "type": "number",
               "minimum": 1
@@ -542,6 +1106,7 @@
             "name": "persistent_gb",
             "in": "query",
             "required": false,
+            "description": "Persistent NVMe add-on in GB, billed per GB-month on top of the preset monthly maximum.",
             "schema": {
               "type": "number",
               "minimum": 0
@@ -551,6 +1116,8 @@
             "name": "has_db",
             "in": "query",
             "required": false,
+            "deprecated": true,
+            "description": "Deprecated: accepted but ignored.",
             "schema": {
               "type": "boolean"
             }
@@ -706,8 +1273,8 @@
           }
         ],
         "operationId": "listApiKeys",
-        "summary": "List API keys in the Developer Portal",
-        "description": "Requires an authenticated Developer Portal session. Plaintext API keys are never returned.",
+        "summary": "List Cloud API keys in the Developer Portal",
+        "description": "Returns deploy-capable Cloud keys, including legacy shared keys for compatibility. Inference-only keys and plaintext are excluded.",
         "responses": {
           "200": {
             "description": "API key metadata",
@@ -731,8 +1298,8 @@
           }
         ],
         "operationId": "createApiKey",
-        "summary": "Create an API key in the Developer Portal",
-        "description": "Requires an authenticated Developer Portal session and active deploy eligibility. The plaintext key is shown once.",
+        "summary": "Create a Cloud API key in the Developer Portal",
+        "description": "Creates a deploy-only key and requires an authenticated Developer Portal session with active deploy eligibility. The plaintext key is shown once.",
         "responses": {
           "200": {
             "description": "New API key",
@@ -782,6 +1349,288 @@
                       "type": "boolean"
                     }
                   }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/api-keys/inference": {
+      "get": {
+        "security": [
+          {
+            "PortalSession": []
+          }
+        ],
+        "operationId": "listInferenceApiKeys",
+        "summary": "List AI Gateway keys in the Developer Portal",
+        "description": "Returns only owner-scoped inference-only keys. Cloud deploy keys and legacy shared keys are excluded.",
+        "responses": {
+          "200": {
+            "description": "AI Gateway key metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyList"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "PortalSession": []
+          }
+        ],
+        "operationId": "createInferenceApiKey",
+        "summary": "Create a scoped AI Gateway key in the Developer Portal",
+        "description": "Creates an inference-only key for the authenticated owner. The plaintext key is shown once; owner and authority fields are assigned server-side.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateInferenceApiKey"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "New scoped inference key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssuedInferenceApiKey"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/api-keys/audit": {
+      "get": {
+        "security": [
+          {
+            "PortalSession": []
+          }
+        ],
+        "operationId": "listApiKeyAuditEvents",
+        "summary": "List owner-scoped API key lifecycle events",
+        "description": "Returns secret-free issuance, rotation, and revocation evidence for the authenticated owner.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500,
+              "default": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "API key lifecycle events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyAuditList"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/ai-gateway/attachments": {
+      "get": {
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "PortalSession": []
+          }
+        ],
+        "operationId": "listAiGatewayAttachments",
+        "summary": "List Varity Cloud AI Gateway attachments",
+        "description": "Returns owner-scoped, secret-free attachment state. Provider identities, credential values, vault references, and internal deployment-operation identifiers are never returned.",
+        "responses": {
+          "200": {
+            "description": "AI Gateway attachment list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiGatewayAttachmentList"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "PortalSession": []
+          }
+        ],
+        "operationId": "attachAiGatewayToDeployment",
+        "summary": "Attach the Varity AI Gateway to a Cloud deployment",
+        "description": "Creates a deployment-bound inference workload credential, seals it in Varity custody, and injects only its opaque protected-input reference into the verified replacement deployment.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/RequiredIdempotencyKey"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAiGatewayAttachment"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Attachment accepted or converging",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiGatewayAttachmentResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/ai-gateway/attachments/{attachment_id}": {
+      "get": {
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "PortalSession": []
+          }
+        ],
+        "operationId": "getAiGatewayAttachment",
+        "summary": "Get one Varity Cloud AI Gateway attachment",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AttachmentId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AI Gateway attachment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiGatewayAttachmentResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "PortalSession": []
+          }
+        ],
+        "operationId": "detachAiGatewayFromDeployment",
+        "summary": "Detach the Varity AI Gateway from a Cloud deployment",
+        "description": "Replaces the deployment without the workload secret reference, then revokes the credential and confirms protected-input removal.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AttachmentId"
+          },
+          {
+            "$ref": "#/components/parameters/RequiredIdempotencyKey"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Detach accepted or converging",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiGatewayAttachmentResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/PublicError"
+          }
+        }
+      }
+    },
+    "/ai-gateway/attachments/{attachment_id}/rotate": {
+      "post": {
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "PortalSession": []
+          }
+        ],
+        "operationId": "rotateAiGatewayAttachment",
+        "summary": "Rotate a Cloud deployment AI Gateway credential",
+        "description": "Preserves the attachment identity while replacing the protected workload credential and revoking the old credential after the replacement is proven.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AttachmentId"
+          },
+          {
+            "$ref": "#/components/parameters/RequiredIdempotencyKey"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Rotation accepted or converging",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiGatewayAttachmentResponse"
                 }
               }
             }
@@ -843,6 +1692,15 @@
           "type": "string"
         }
       },
+      "AttachmentId": {
+        "name": "attachment_id",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "pattern": "^vai_[A-Za-z0-9_-]{20,64}$"
+        }
+      },
       "IdempotencyKey": {
         "name": "Idempotency-Key",
         "in": "header",
@@ -850,6 +1708,17 @@
         "schema": {
           "type": "string",
           "maxLength": 160
+        }
+      },
+      "RequiredIdempotencyKey": {
+        "name": "Idempotency-Key",
+        "in": "header",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160,
+          "pattern": "^[A-Za-z0-9._:-]+$"
         }
       }
     },
@@ -866,6 +1735,1422 @@
       }
     },
     "schemas": {
+      "CreateGpuContainerRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "execution_class",
+          "profile_id",
+          "ssh_public_key",
+          "accelerator_quote_token"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
+          },
+          "execution_class": {
+            "const": "container"
+          },
+          "profile_id": {
+            "type": "string",
+            "pattern": "^gpo-[0-9a-f]{24}$"
+          },
+          "ssh_public_key": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10000,
+            "writeOnly": true,
+            "description": "OpenSSH public key. Private key material is forbidden."
+          },
+          "accelerator_quote_token": {
+            "type": "string",
+            "minLength": 16,
+            "maxLength": 8192,
+            "writeOnly": true
+          }
+        }
+      },
+      "PrepareGpuContainerQuoteRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "execution_class",
+          "profile_id"
+        ],
+        "properties": {
+          "execution_class": {
+            "const": "container"
+          },
+          "profile_id": {
+            "type": "string",
+            "pattern": "^gpo-[0-9a-f]{24}$"
+          }
+        }
+      },
+      "GpuContainerProfileCatalogV1": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema_version",
+          "workload",
+          "execution_class",
+          "profiles"
+        ],
+        "properties": {
+          "schema_version": {
+            "const": "gpu-container-profiles-v1"
+          },
+          "workload": {
+            "const": "gpu"
+          },
+          "execution_class": {
+            "const": "container"
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GpuContainerProfileV1"
+            }
+          }
+        }
+      },
+      "GpuContainerProfileV1": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Rolling-release compatibility profile. Request v2 before presenting this profile as deployable.",
+        "required": [
+          "id",
+          "label",
+          "execution_class",
+          "accelerator",
+          "hardware",
+          "customer_price",
+          "availability"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/GpuContainerProfile/properties/id"
+          },
+          "label": {
+            "$ref": "#/components/schemas/GpuContainerProfile/properties/label"
+          },
+          "execution_class": {
+            "const": "container"
+          },
+          "accelerator": {
+            "$ref": "#/components/schemas/AcceleratorProfileSelection"
+          },
+          "hardware": {
+            "$ref": "#/components/schemas/GpuContainerProfile/properties/hardware"
+          },
+          "customer_price": {
+            "$ref": "#/components/schemas/GpuContainerProfile/properties/customer_price"
+          },
+          "availability": {
+            "$ref": "#/components/schemas/GpuProfileAvailability"
+          }
+        }
+      },
+      "GpuContainerProfileCatalog": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema_version",
+          "workload",
+          "execution_class",
+          "profiles"
+        ],
+        "properties": {
+          "schema_version": {
+            "const": "gpu-container-profiles-v2"
+          },
+          "workload": {
+            "const": "gpu"
+          },
+          "execution_class": {
+            "const": "container"
+          },
+          "profiles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GpuContainerProfile"
+            }
+          }
+        }
+      },
+      "GpuContainerProfile": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "label",
+          "execution_class",
+          "accelerator",
+          "hardware",
+          "resources",
+          "locations",
+          "runtime",
+          "access",
+          "customer_price",
+          "availability"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^gpo-[0-9a-f]{24}$"
+          },
+          "label": {
+            "type": "string"
+          },
+          "execution_class": {
+            "const": "container"
+          },
+          "accelerator": {
+            "$ref": "#/components/schemas/AcceleratorProfileSelection"
+          },
+          "hardware": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "vendor",
+              "model",
+              "vram_mb",
+              "interface",
+              "count"
+            ],
+            "properties": {
+              "vendor": {
+                "const": "NVIDIA"
+              },
+              "model": {
+                "type": "string"
+              },
+              "vram_mb": {
+                "type": "integer"
+              },
+              "interface": {
+                "type": "string",
+                "enum": [
+                  "pcie",
+                  "sxm"
+                ]
+              },
+              "count": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 24
+              }
+            }
+          },
+          "resources": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "cpu_units",
+              "memory_mb",
+              "storage_mb"
+            ],
+            "properties": {
+              "cpu_units": {
+                "type": "number",
+                "exclusiveMinimum": 0
+              },
+              "memory_mb": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "storage_mb": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "locations": {
+            "type": "array",
+            "maxItems": 256,
+            "uniqueItems": true,
+            "description": "Current location availability for this exact offer. Final placement is reported after activation.",
+            "items": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$"
+            }
+          },
+          "runtime": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "label",
+              "provider_default"
+            ],
+            "properties": {
+              "label": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128
+              },
+              "ports": {
+                "type": "array",
+                "maxItems": 64,
+                "uniqueItems": true,
+                "items": {
+                  "type": "string",
+                  "pattern": "^[1-9][0-9]{0,4}/(?:tcp|udp)$"
+                }
+              },
+              "startup_command": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "minLength": 1,
+                "maxLength": 4096
+              },
+              "provider_default": {
+                "const": true
+              }
+            }
+          },
+          "access": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "mode",
+              "requires_public_key"
+            ],
+            "properties": {
+              "mode": {
+                "const": "ssh"
+              },
+              "requires_public_key": {
+                "const": true
+              }
+            }
+          },
+          "customer_price": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "hourly_usd",
+              "currency",
+              "billing_period",
+              "price_basis",
+              "pricing_policy_version"
+            ],
+            "properties": {
+              "hourly_usd": {
+                "type": "number",
+                "exclusiveMinimum": 0
+              },
+              "currency": {
+                "const": "USD"
+              },
+              "billing_period": {
+                "const": "hour"
+              },
+              "price_basis": {
+                "const": "exact",
+                "description": "The exact current customer price for this offer; a signed quote is required before create."
+              },
+              "pricing_policy_version": {
+                "type": "string"
+              }
+            }
+          },
+          "availability": {
+            "$ref": "#/components/schemas/GpuProfileAvailability"
+          }
+        }
+      },
+      "GpuProfileAvailability": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "status",
+          "matching_capacity_count",
+          "aggregate_available_units",
+          "source_age_seconds"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "available",
+              "no_capacity",
+              "temporarily_unavailable"
+            ]
+          },
+          "matching_capacity_count": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "aggregate_available_units": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "source_age_seconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0,
+            "maximum": 86400
+          }
+        }
+      },
+      "AcceleratorRequest": {
+        "$ref": "#/components/schemas/AcceleratorProfileSelection"
+      },
+      "AcceleratorProfileSelection": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "profile_id",
+          "count",
+          "alternatives"
+        ],
+        "description": "Required Public API selection. The opaque live offer and its normalized card hardware are revalidated before quote issuance and durable acceptance.",
+        "properties": {
+          "profile_id": {
+            "type": "string",
+            "pattern": "^gpo-[0-9a-f]{24}$"
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 24
+          },
+          "alternatives": {
+            "$ref": "#/components/schemas/AcceleratorRequirement/properties/alternatives"
+          }
+        }
+      },
+      "AcceleratorRequirement": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "count",
+          "alternatives"
+        ],
+        "description": "Normalized hardware facts embedded in one selected live card.",
+        "properties": {
+          "count": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 24
+          },
+          "alternatives": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 8,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "vendor",
+                "model",
+                "vram_mb"
+              ],
+              "properties": {
+                "vendor": {
+                  "type": "string",
+                  "enum": [
+                    "nvidia"
+                  ]
+                },
+                "model": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9][a-z0-9-]{0,63}$"
+                },
+                "vram_mb": {
+                  "type": "integer",
+                  "minimum": 1024,
+                  "maximum": 262144,
+                  "multipleOf": 1024
+                },
+                "interface": {
+                  "type": "string",
+                  "enum": [
+                    "pcie",
+                    "sxm"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "AcceleratorQuote": {
+        "type": "object",
+        "required": [
+          "quote_token",
+          "quote_reference",
+          "resource_fingerprint",
+          "hourly_usd",
+          "authorization_usd",
+          "valid_until"
+        ],
+        "properties": {
+          "quote_token": {
+            "type": "string",
+            "description": "Signed client-carried bearer. Do not inspect or log it; pass it unchanged as accelerator_quote_token on create."
+          },
+          "quote_reference": {
+            "type": "string"
+          },
+          "resource_fingerprint": {
+            "type": "string"
+          },
+          "hourly_usd": {
+            "type": "number"
+          },
+          "authorization_usd": {
+            "type": "number"
+          },
+          "currency": {
+            "const": "USD"
+          },
+          "billing_period": {
+            "const": "hour"
+          },
+          "valid_until": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "pricing_policy_version": {
+            "type": "string"
+          },
+          "availability": {
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        }
+      },
+      "MachineQuoteRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "profile_id",
+          "execution_class",
+          "os_image"
+        ],
+        "properties": {
+          "profile_id": {
+            "type": "string",
+            "pattern": "^mp-[0-9a-f]{24}$"
+          },
+          "execution_class": {
+            "type": "string",
+            "enum": [
+              "virtual_machine",
+              "bare_metal",
+              "cpu_virtual_machine"
+            ]
+          },
+          "os_image": {
+            "type": "string",
+            "pattern": "^os-[a-z0-9](?:[a-z0-9-]{0,42}[a-z0-9])?-[0-9a-f]{12}$"
+          },
+          "additional_storage_gb": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 32768,
+            "description": "Additional NVMe storage beyond the included boot disk. Only valid when execution_class is cpu_virtual_machine; omitting it means none."
+          }
+        }
+      },
+      "MachineQuote": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "quote_token",
+          "quote_reference",
+          "resource_fingerprint",
+          "hourly_usd",
+          "authorization_usd",
+          "currency",
+          "billing_period",
+          "valid_until",
+          "pricing_policy_version"
+        ],
+        "properties": {
+          "quote_token": {
+            "type": "string",
+            "writeOnly": true
+          },
+          "quote_reference": {
+            "type": "string"
+          },
+          "resource_fingerprint": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "additional_storage_gb": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 32768,
+            "description": "Echoed additional NVMe storage priced into hourly_usd. Present exactly when the quote request carried additional_storage_gb."
+          },
+          "hourly_usd": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          },
+          "authorization_usd": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          },
+          "currency": {
+            "const": "USD"
+          },
+          "billing_period": {
+            "const": "hour"
+          },
+          "valid_until": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "pricing_policy_version": {
+            "type": "string"
+          }
+        }
+      },
+      "MachineProfileCatalog": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "execution_class",
+          "profiles"
+        ],
+        "properties": {
+          "execution_class": {
+            "type": "string",
+            "enum": [
+              "virtual_machine",
+              "bare_metal",
+              "cpu_virtual_machine"
+            ]
+          },
+          "profiles": {
+            "type": "array",
+            "maxItems": 1024,
+            "items": {
+              "$ref": "#/components/schemas/MachineProfile"
+            }
+          }
+        }
+      },
+      "MachineProfile": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema_version",
+          "profile_id",
+          "execution_class",
+          "hardware",
+          "region",
+          "availability",
+          "customer_price",
+          "os_images"
+        ],
+        "properties": {
+          "schema_version": {
+            "const": "public-machine-profile-v1"
+          },
+          "profile_id": {
+            "type": "string",
+            "pattern": "^mp-[0-9a-f]{24}$"
+          },
+          "execution_class": {
+            "type": "string",
+            "enum": [
+              "virtual_machine",
+              "bare_metal",
+              "cpu_virtual_machine"
+            ]
+          },
+          "display_name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "description": "Varity plan name. Present exactly when execution_class is cpu_virtual_machine."
+          },
+          "cpu_class": {
+            "type": "string",
+            "enum": [
+              "dedicated",
+              "shared"
+            ],
+            "description": "Present exactly when execution_class is cpu_virtual_machine."
+          },
+          "monthly_cap_microusd": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000000000000000,
+            "description": "Hard monthly price cap for hourly billing. Present exactly when execution_class is cpu_virtual_machine."
+          },
+          "hardware": {
+            "$ref": "#/components/schemas/MachineHardware"
+          },
+          "region": {
+            "type": "string",
+            "maxLength": 64,
+            "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+){0,7}$"
+          },
+          "availability": {
+            "type": "string",
+            "enum": [
+              "available",
+              "temporarily_unavailable"
+            ]
+          },
+          "customer_price": {
+            "$ref": "#/components/schemas/MachineHourlyPrice"
+          },
+          "os_images": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 64,
+            "items": {
+              "$ref": "#/components/schemas/MachineOsImage"
+            }
+          }
+        }
+      },
+      "MachineHardware": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "cpu_units",
+          "memory_mb",
+          "storage_mb"
+        ],
+        "properties": {
+          "cpu_units": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 256
+          },
+          "memory_mb": {
+            "type": "integer",
+            "minimum": 1024,
+            "maximum": 2097152
+          },
+          "storage_mb": {
+            "type": "integer",
+            "minimum": 10240,
+            "maximum": 33554432
+          },
+          "accelerator": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MachineAccelerator"
+              }
+            ],
+            "description": "Present exactly when execution_class is virtual_machine or bare_metal; absent for cpu_virtual_machine."
+          }
+        }
+      },
+      "MachineAccelerator": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "count",
+          "alternatives"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 24
+          },
+          "alternatives": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "vendor",
+                "model",
+                "vram_mb"
+              ],
+              "properties": {
+                "vendor": {
+                  "const": "nvidia"
+                },
+                "model": {
+                  "type": "string",
+                  "pattern": "^[a-z0-9][a-z0-9-]{0,63}$"
+                },
+                "vram_mb": {
+                  "type": "integer",
+                  "minimum": 1024,
+                  "maximum": 262144,
+                  "multipleOf": 1024
+                },
+                "interface": {
+                  "type": "string",
+                  "enum": [
+                    "pcie",
+                    "sxm"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "MachineHourlyPrice": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "amount_microusd",
+          "currency",
+          "billing_period"
+        ],
+        "properties": {
+          "amount_microusd": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000000000000000
+          },
+          "currency": {
+            "const": "USD"
+          },
+          "billing_period": {
+            "const": "hour"
+          }
+        }
+      },
+      "MachineOsImage": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "label"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^os-[a-z0-9](?:[a-z0-9-]{0,42}[a-z0-9])?-[0-9a-f]{12}$"
+          },
+          "label": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256
+          }
+        }
+      },
+      "CreateMachineRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "profile_id",
+          "execution_class",
+          "os_image",
+          "ssh_public_key",
+          "accelerator_quote_token"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
+          },
+          "profile_id": {
+            "type": "string",
+            "pattern": "^mp-[0-9a-f]{24}$"
+          },
+          "execution_class": {
+            "type": "string",
+            "enum": [
+              "virtual_machine",
+              "bare_metal",
+              "cpu_virtual_machine"
+            ]
+          },
+          "os_image": {
+            "type": "string",
+            "pattern": "^os-[a-z0-9](?:[a-z0-9-]{0,42}[a-z0-9])?-[0-9a-f]{12}$"
+          },
+          "additional_storage_gb": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 32768,
+            "description": "Additional NVMe storage beyond the included boot disk. Only valid when execution_class is cpu_virtual_machine; omitting it means none."
+          },
+          "ssh_public_key": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 10000,
+            "writeOnly": true
+          },
+          "accelerator_quote_token": {
+            "type": "string",
+            "minLength": 16,
+            "maxLength": 4096,
+            "writeOnly": true
+          }
+        }
+      },
+      "MachineAcceptance": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "replayed",
+          "machine_id",
+          "operation"
+        ],
+        "properties": {
+          "replayed": {
+            "type": "boolean"
+          },
+          "machine_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "additional_storage_gb": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 32768,
+            "description": "Echoed additional NVMe storage. Present exactly when the create request carried additional_storage_gb."
+          },
+          "operation": {
+            "$ref": "#/components/schemas/MachineLifecycle"
+          }
+        }
+      },
+      "MachineLifecycle": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "operation_id",
+          "operation",
+          "status",
+          "stage",
+          "accepted_at",
+          "execution_deadline_at",
+          "outcome",
+          "cleanup_state",
+          "support_reference"
+        ],
+        "properties": {
+          "operation_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "operation": {
+            "type": "string",
+            "enum": [
+              "create_machine",
+              "delete_deployment"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "accepted",
+              "running",
+              "succeeded",
+              "failed"
+            ]
+          },
+          "stage": {
+            "type": "string",
+            "enum": [
+              "accepted",
+              "admission",
+              "allocation",
+              "health",
+              "access",
+              "route",
+              "cleanup",
+              "terminal"
+            ]
+          },
+          "accepted_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "execution_deadline_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "outcome": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MachineOutcome"
+              }
+            ]
+          },
+          "cleanup_state": {
+            "type": "string",
+            "enum": [
+              "not_required",
+              "required",
+              "running",
+              "retrying",
+              "complete"
+            ]
+          },
+          "support_reference": {
+            "type": "string"
+          }
+        }
+      },
+      "MachineOutcome": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "classification",
+          "stage",
+          "code",
+          "action_code",
+          "diagnostic_code",
+          "terminal_at"
+        ],
+        "properties": {
+          "classification": {
+            "type": "string"
+          },
+          "stage": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "action_code": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "diagnostic_code": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "terminal_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Machine": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "machine_id",
+          "name",
+          "profile_id",
+          "execution_class",
+          "os_image",
+          "hardware",
+          "region",
+          "lifecycle",
+          "access",
+          "billing"
+        ],
+        "properties": {
+          "machine_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "profile_id": {
+            "type": "string",
+            "pattern": "^mp-[0-9a-f]{24}$"
+          },
+          "execution_class": {
+            "type": "string",
+            "enum": [
+              "virtual_machine",
+              "bare_metal",
+              "cpu_virtual_machine"
+            ]
+          },
+          "cpu_class": {
+            "type": "string",
+            "enum": [
+              "dedicated",
+              "shared"
+            ],
+            "description": "Only cpu_virtual_machine machines may carry a CPU family."
+          },
+          "os_image": {
+            "type": "string",
+            "pattern": "^os-[a-z0-9](?:[a-z0-9-]{0,42}[a-z0-9])?-[0-9a-f]{12}$"
+          },
+          "hardware": {
+            "$ref": "#/components/schemas/MachineHardware"
+          },
+          "region": {
+            "type": "string"
+          },
+          "lifecycle": {
+            "$ref": "#/components/schemas/MachineLifecycle"
+          },
+          "access": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MachineSshAccess"
+              }
+            ]
+          },
+          "billing": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MachineBilling"
+              }
+            ]
+          }
+        }
+      },
+      "MachineSshAccess": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "protocol",
+          "host",
+          "port",
+          "username"
+        ],
+        "properties": {
+          "protocol": {
+            "const": "ssh"
+          },
+          "host": {
+            "type": "string"
+          },
+          "port": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "username": {
+            "type": "string",
+            "pattern": "^[a-z_][a-z0-9_-]{0,31}$"
+          }
+        }
+      },
+      "MachineBilling": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "state",
+          "customer_price",
+          "observed_at"
+        ],
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "active",
+              "stopped"
+            ]
+          },
+          "customer_price": {
+            "$ref": "#/components/schemas/MachineHourlyPrice"
+          },
+          "monthly_cap_microusd": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000000000000000,
+            "description": "Hard monthly price cap for hourly billing. Present exactly when the machine execution_class is cpu_virtual_machine."
+          },
+          "month_to_date": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MachineMonthToDate"
+              }
+            ],
+            "description": "Month-to-date billed usage. May appear only when the machine execution_class is cpu_virtual_machine; null while the first billed hour is pending."
+          },
+          "observed_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "MachineMonthToDate": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "compute_microusd",
+          "storage_microusd",
+          "month_started_at"
+        ],
+        "properties": {
+          "compute_microusd": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 1000000000000000,
+            "description": "Month-to-date compute charge, capped by monthly_cap_microusd."
+          },
+          "storage_microusd": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 1000000000000000,
+            "description": "Month-to-date additional-storage charge; not capped."
+          },
+          "month_started_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "MachineActionRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "action"
+        ],
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": [
+              "restart",
+              "soft_reboot"
+            ]
+          }
+        }
+      },
+      "MachineActionResult": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "machine_id",
+          "action",
+          "machine_state",
+          "observed_at"
+        ],
+        "properties": {
+          "machine_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "restart",
+              "soft_reboot"
+            ]
+          },
+          "machine_state": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]{0,63}$"
+          },
+          "observed_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "DeploymentCapabilities": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema_version",
+          "auto_detect",
+          "workloads"
+        ],
+        "properties": {
+          "schema_version": {
+            "const": "deployment-capabilities-v1"
+          },
+          "auto_detect": {
+            "$ref": "#/components/schemas/AutoDetectCapability"
+          },
+          "workloads": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeploymentWorkloadCapability"
+            }
+          }
+        }
+      },
+      "AutoDetectCapability": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "availability",
+          "source_types",
+          "recommendation_targets"
+        ],
+        "properties": {
+          "availability": {
+            "const": "available"
+          },
+          "source_types": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "repository"
+              ]
+            }
+          },
+          "recommendation_targets": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "static_site",
+                "web_service"
+              ]
+            }
+          }
+        }
+      },
+      "DeploymentWorkloadCapability": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "fulfillment",
+          "options"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "enum": [
+              "static_site",
+              "web_service",
+              "gpu",
+              "virtual_machine"
+            ]
+          },
+          "fulfillment": {
+            "type": "string",
+            "enum": [
+              "static",
+              "dynamic_compute"
+            ]
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeploymentExecutionOption"
+            }
+          }
+        }
+      },
+      "DeploymentExecutionOption": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "execution_class",
+          "management",
+          "access_modes",
+          "billing_cadence",
+          "source_types",
+          "required_inputs",
+          "availability"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "enum": [
+              "automatic",
+              "static",
+              "container",
+              "virtual_machine",
+              "bare_metal",
+              "cpu_virtual_machine"
+            ]
+          },
+          "execution_class": {
+            "type": "string",
+            "enum": [
+              "automatic",
+              "static",
+              "container",
+              "virtual_machine",
+              "bare_metal",
+              "cpu_virtual_machine"
+            ]
+          },
+          "management": {
+            "type": "string",
+            "enum": [
+              "managed",
+              "self_managed"
+            ]
+          },
+          "access_modes": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": [
+                "public_http",
+                "forwarded_ports",
+                "ssh"
+              ]
+            }
+          },
+          "billing_cadence": {
+            "type": "string",
+            "enum": [
+              "fixed_monthly",
+              "hourly"
+            ]
+          },
+          "source_types": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "repository",
+                "image",
+                "template",
+                "os_image"
+              ]
+            }
+          },
+          "required_inputs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "availability": {
+            "type": "string",
+            "enum": [
+              "available",
+              "temporarily_unavailable"
+            ]
+          }
+        }
+      },
       "PublicError": {
         "type": "object",
         "required": [
@@ -918,13 +3203,18 @@
             "type": "string"
           },
           "subdomain": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "type": "string",
             "enum": [
               "deploying",
               "live",
+              "failed",
+              "deleting",
               "deleted",
               "unknown"
             ]
@@ -937,7 +3227,10 @@
             ]
           },
           "public_url": {
-            "type": "string",
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "uri"
           },
           "created_at": {
@@ -967,8 +3260,196 @@
           "resource_profile": {
             "$ref": "#/components/schemas/ResourceProfile"
           },
+          "access": {
+            "$ref": "#/components/schemas/DeploymentAccess"
+          },
           "billing": {
             "$ref": "#/components/schemas/DeploymentBilling"
+          },
+          "operation_deployment_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Durable deployment-operation identity (dashed UUID) when the app was deployed through the durable path; delete by this id for independently reconciled route/compute/billing teardown."
+          }
+        }
+      },
+      "CustomDomain": {
+        "type": "object",
+        "required": [
+          "hostname",
+          "state",
+          "dns",
+          "certificate",
+          "serving",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "hostname": {
+            "type": "string"
+          },
+          "recordType": {
+            "type": "string",
+            "enum": [
+              "cname",
+              "a"
+            ],
+            "description": "Absent means cname."
+          },
+          "recordName": {
+            "type": "string",
+            "description": "Registrar Host field relative to the zone: the bare label for a subdomain, @ for an apex."
+          },
+          "expectedCname": {
+            "type": "string",
+            "description": "Subdomain claims only."
+          },
+          "expectedA": {
+            "type": "string",
+            "description": "Apex claims only: the A record target."
+          },
+          "challenge": {
+            "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
+            "description": "Apex claims only: the mandatory TXT ownership proof.",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "pending_dns",
+              "certificate_pending",
+              "active",
+              "error"
+            ]
+          },
+          "dns": {
+            "type": "object",
+            "required": [
+              "status"
+            ],
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "mismatch",
+                  "verified",
+                  "error"
+                ]
+              },
+              "observedCnames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "observedA": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "observedTxt": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "checkedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "certificate": {
+            "type": "object",
+            "required": [
+              "status"
+            ],
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "active",
+                  "error"
+                ]
+              },
+              "checkedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "serving": {
+            "type": "object",
+            "required": [
+              "status"
+            ],
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "active",
+                  "error"
+                ]
+              },
+              "checkedAt": {
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "errorCode": {
+            "type": "string",
+            "enum": [
+              "dns_lookup_failed",
+              "https_verification_failed"
+            ]
+          }
+        }
+      },
+      "CustomDomainEnvelope": {
+        "type": "object",
+        "required": [
+          "supported",
+          "domain"
+        ],
+        "properties": {
+          "supported": {
+            "type": "boolean"
+          },
+          "domain": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CustomDomain"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         }
       },
@@ -1030,6 +3511,38 @@
             "items": {
               "type": "string"
             }
+          },
+          "accelerator": {
+            "$ref": "#/components/schemas/AcceleratorRequirement"
+          }
+        }
+      },
+      "DeploymentAccess": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "additionalProperties": false,
+        "required": [
+          "protocol",
+          "host",
+          "port",
+          "username"
+        ],
+        "properties": {
+          "protocol": {
+            "const": "ssh"
+          },
+          "host": {
+            "type": "string"
+          },
+          "port": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "username": {
+            "type": "string"
           }
         }
       },
@@ -1047,6 +3560,29 @@
           },
           "accrued_this_month_usd": {
             "type": "number"
+          },
+          "billing_model": {
+            "type": "string",
+            "enum": [
+              "fixed_monthly",
+              "hourly_resource_reservation"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "active",
+              "stopped"
+            ]
+          },
+          "hourly_cost_usd": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          },
+          "hourlyUsd": {
+            "type": "number",
+            "exclusiveMinimum": 0
           },
           "currency": {
             "type": "string"
@@ -1074,7 +3610,6 @@
           "app_name",
           "status",
           "runtime",
-          "public_url",
           "run_id",
           "status_url"
         ],
@@ -1086,7 +3621,10 @@
             "type": "string"
           },
           "subdomain": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "const": "deploying"
@@ -1100,13 +3638,20 @@
           },
           "public_url": {
             "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "description": "Absent on the durable path: the URL is only projected after the canonical route is proven."
           },
           "run_id": {
             "type": "string"
           },
           "status_url": {
             "type": "string"
+          },
+          "deployment_id": {
+            "type": "string"
+          },
+          "replayed": {
+            "type": "boolean"
           }
         }
       },
@@ -1124,7 +3669,10 @@
             "type": "string"
           },
           "subdomain": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "status": {
             "type": "string"
@@ -1153,6 +3701,7 @@
             "type": "string",
             "enum": [
               "queued",
+              "accepted",
               "running",
               "succeeded",
               "failed"
@@ -1176,6 +3725,76 @@
               "string",
               "null"
             ]
+          },
+          "public_status": {
+            "type": "string",
+            "enum": [
+              "deploying",
+              "live",
+              "failed",
+              "deleting",
+              "deleted"
+            ]
+          },
+          "id": {
+            "type": "string",
+            "description": "Durable deployment id on durable-path runs."
+          },
+          "deployment_id": {
+            "type": "string"
+          },
+          "operation": {
+            "type": "string",
+            "enum": [
+              "create_public_image",
+              "create_gpu_container",
+              "delete_deployment"
+            ]
+          },
+          "active_release_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "cleanup_state": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "support_id": {
+            "type": "string"
+          },
+          "error_message": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Deterministic failure sentence (closed vocabulary keyed by the sealed outcome code)."
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri"
+          },
+          "public_url": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri"
+          },
+          "access": {
+            "$ref": "#/components/schemas/DeploymentAccess"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
           }
         }
       },
@@ -1184,7 +3803,8 @@
         "required": [
           "lines",
           "count",
-          "complete"
+          "complete",
+          "observed_at"
         ],
         "properties": {
           "lines": {
@@ -1198,19 +3818,23 @@
           },
           "complete": {
             "type": "boolean",
-            "description": "False when the returned window may be partial, for example when the live runtime source was momentarily unavailable. When false, warning_code is set and the request is safe to retry for a complete window."
+            "description": "False when one of the bounded runtime-observation sources was unavailable."
           },
           "observed_at": {
-            "type": ["string", "null"],
-            "description": "ISO 8601 timestamp of the live runtime read behind this window, or null when no live read was captured."
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
           },
           "warning_code": {
             "type": "string",
-            "description": "Present only when `complete` is false (e.g. `logs_incomplete`)."
+            "enum": [
+              "logs_incomplete"
+            ]
           },
           "retryable": {
-            "type": "boolean",
-            "description": "Present only when `complete` is false; the read is safe to retry."
+            "type": "boolean"
           }
         }
       },
@@ -1218,25 +3842,10 @@
         "type": "object",
         "required": [
           "events",
-          "complete"
+          "complete",
+          "observed_at"
         ],
         "properties": {
-          "complete": {
-            "type": "boolean",
-            "description": "False when the returned events may be partial, for example when the live runtime source was momentarily unavailable. When false, warning_code is set and the request is safe to retry."
-          },
-          "observed_at": {
-            "type": ["string", "null"],
-            "description": "ISO 8601 timestamp of the live runtime read behind these events, or null when no live read was captured."
-          },
-          "warning_code": {
-            "type": "string",
-            "description": "Present only when `complete` is false (e.g. `events_incomplete`)."
-          },
-          "retryable": {
-            "type": "boolean",
-            "description": "Present only when `complete` is false; the read is safe to retry."
-          },
           "events": {
             "type": "array",
             "items": {
@@ -1262,6 +3871,26 @@
                 }
               }
             }
+          },
+          "complete": {
+            "type": "boolean",
+            "description": "False when the bounded runtime-observation source was unavailable."
+          },
+          "observed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "warning_code": {
+            "type": "string",
+            "enum": [
+              "events_incomplete"
+            ]
+          },
+          "retryable": {
+            "type": "boolean"
           }
         }
       },
@@ -1286,18 +3915,40 @@
             ],
             "properties": {
               "runtime_state": {
-                "type": ["string", "null"],
-                "enum": ["healthy", "unhealthy", "unknown", null]
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "healthy",
+                  "unhealthy",
+                  "unknown",
+                  null
+                ]
               },
               "runtime_reason": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "route_state": {
-                "type": ["string", "null"],
-                "enum": ["healthy", "unhealthy", "unknown", null]
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "enum": [
+                  "healthy",
+                  "unhealthy",
+                  "unknown",
+                  null
+                ]
               },
               "route_reason": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "consecutive_runtime_failures": {
                 "type": "integer"
@@ -1306,7 +3957,10 @@
                 "type": "integer"
               },
               "freshness_at": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "format": "date-time"
               },
               "services": {
@@ -1333,7 +3987,10 @@
                     },
                     "state": {
                       "type": "string",
-                      "enum": ["healthy", "degraded"]
+                      "enum": [
+                        "healthy",
+                        "degraded"
+                      ]
                     },
                     "replicas": {
                       "type": "integer"
@@ -1383,23 +4040,37 @@
               "properties": {
                 "runtime_state": {
                   "type": "string",
-                  "enum": ["healthy", "unhealthy", "unknown"]
+                  "enum": [
+                    "healthy",
+                    "unhealthy",
+                    "unknown"
+                  ]
                 },
                 "runtime_reason": {
                   "type": "string"
                 },
                 "route_state": {
                   "type": "string",
-                  "enum": ["healthy", "unhealthy", "unknown"]
+                  "enum": [
+                    "healthy",
+                    "unhealthy",
+                    "unknown"
+                  ]
                 },
                 "route_reason": {
                   "type": "string"
                 },
                 "route_status": {
-                  "type": ["integer", "null"]
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
                 },
                 "observed_at": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "format": "date-time"
                 }
               }
@@ -1467,7 +4138,22 @@
         }
       },
       "CreateDeploymentRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CreateApplicationDeploymentRequest"
+          },
+          {
+            "$ref": "#/components/schemas/CreateGpuContainerRequest"
+          }
+        ]
+      },
+      "CreateApplicationDeploymentRequest": {
         "type": "object",
+        "not": {
+          "required": [
+            "execution_class"
+          ]
+        },
         "properties": {
           "name": {
             "type": "string"
@@ -1535,6 +4221,136 @@
           },
           "resource_profile": {
             "$ref": "#/components/schemas/ResourceProfile"
+          },
+          "ingress": {
+            "$ref": "#/components/schemas/IngressPolicy"
+          },
+          "volumes": {
+            "type": "array",
+            "maxItems": 4,
+            "items": {
+              "$ref": "#/components/schemas/VolumeSpec"
+            }
+          },
+          "dedicated_ip": {
+            "type": "boolean",
+            "default": false
+          },
+          "tee": {
+            "type": "string",
+            "enum": [
+              "cpu",
+              "cpu-gpu"
+            ]
+          },
+          "reclamation_min_window_seconds": {
+            "type": "integer",
+            "minimum": 60,
+            "maximum": 2592000
+          },
+          "accelerator": {
+            "$ref": "#/components/schemas/AcceleratorRequest"
+          },
+          "accelerator_quote_token": {
+            "type": "string",
+            "description": "The quote_token from POST /pricing/accelerator-quote. Required with accelerator; deploy-api rejects an accelerator without its exact quote and vice versa."
+          }
+        }
+      },
+      "IngressPolicy": {
+        "type": "object",
+        "description": "Optional HTTP ingress policy; defaults preserve historical behavior.",
+        "properties": {
+          "max_body_bytes": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1073741824,
+            "default": 104857600
+          },
+          "read_timeout_ms": {
+            "type": "integer",
+            "minimum": 1000,
+            "maximum": 600000,
+            "default": 60000
+          },
+          "send_timeout_ms": {
+            "type": "integer",
+            "minimum": 1000,
+            "maximum": 600000,
+            "default": 60000
+          },
+          "retry_tries": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10,
+            "default": 3
+          },
+          "retry_timeout_ms": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 600000,
+            "default": 60000
+          },
+          "retry_cases": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 10,
+            "items": {
+              "type": "string",
+              "enum": [
+                "error",
+                "timeout",
+                "403",
+                "404",
+                "429",
+                "500",
+                "502",
+                "503",
+                "504",
+                "off"
+              ]
+            },
+            "default": [
+              "error",
+              "timeout"
+            ]
+          }
+        }
+      },
+      "VolumeSpec": {
+        "type": "object",
+        "required": [
+          "name",
+          "size_gb",
+          "mount"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]{0,31}$"
+          },
+          "size_gb": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "storage_class": {
+            "type": "string",
+            "enum": [
+              "beta1",
+              "beta2",
+              "beta3",
+              "ram"
+            ],
+            "default": "beta3"
+          },
+          "mount": {
+            "type": "string",
+            "maxLength": 256
+          },
+          "read_only": {
+            "type": "boolean",
+            "default": false
           }
         }
       },
@@ -1666,6 +4482,13 @@
           },
           "mode": {
             "type": "string"
+          },
+          "preset_id": {
+            "type": "string",
+            "description": "Managed Cloud preset backing this estimate (absent for static)."
+          },
+          "pricing_policy_version": {
+            "type": "string"
           }
         }
       },
@@ -1713,31 +4536,129 @@
         "type": "object",
         "required": [
           "id",
+          "name",
           "tier",
+          "principal_type",
+          "services",
+          "allowed_models",
+          "privacy_floor",
+          "rotation_generation",
           "active"
         ],
         "properties": {
           "id": {
+            "type": "string",
+            "pattern": "^vki_[A-Za-z0-9_-]{20,64}$"
+          },
+          "name": {
             "type": "string"
           },
           "tier": {
             "type": "string"
           },
-          "created_at": {
+          "principal_type": {
+            "type": "string",
+            "enum": [
+              "human",
+              "workload"
+            ]
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "deploy",
+                "inference"
+              ]
+            }
+          },
+          "project_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "application_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "deployment_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "environment": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "allowed_models": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "privacy_floor": {
+            "type": "string",
+            "enum": [
+              "private",
+              "anonymized"
+            ]
+          },
+          "upstream_budget_usd": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "requests_per_minute": {
             "type": [
               "integer",
+              "null"
+            ]
+          },
+          "concurrency_limit": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "expires_at": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "attachment_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "rotation_generation": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "created_at": {
+            "type": [
+              "number",
               "null"
             ]
           },
           "last_used_at": {
             "type": [
-              "integer",
+              "number",
               "null"
             ]
           },
           "revoked_at": {
             "type": [
-              "integer",
+              "number",
               "null"
             ]
           },
@@ -1762,8 +4683,382 @@
           }
         }
       },
+      "CreateInferenceApiKey": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "allowed_models",
+          "privacy_floor"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80
+          },
+          "project_id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "application_id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "environment": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "allowed_models": {
+            "type": "array",
+            "minItems": 0,
+            "maxItems": 64,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z0-9][a-z0-9.-]{0,95}$"
+            },
+            "description": "Empty means every current and future admitted model for this human key."
+          },
+          "privacy_floor": {
+            "type": "string",
+            "enum": [
+              "private",
+              "anonymized"
+            ]
+          },
+          "upstream_budget_usd": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10000
+          },
+          "requests_per_minute": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10000
+          },
+          "concurrency_limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000
+          },
+          "expires_at": {
+            "type": "number"
+          }
+        }
+      },
+      "IssuedInferenceApiKey": {
+        "type": "object",
+        "required": [
+          "api_key",
+          "key"
+        ],
+        "properties": {
+          "api_key": {
+            "type": "string",
+            "writeOnly": true
+          },
+          "key": {
+            "$ref": "#/components/schemas/ApiKey"
+          }
+        }
+      },
+      "CreateAiGatewayAttachment": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "deployment_id",
+          "allowed_models",
+          "privacy_floor"
+        ],
+        "properties": {
+          "deployment_id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "project_id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "allowed_models": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 64,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z0-9][a-z0-9.-]{0,95}$"
+            }
+          },
+          "privacy_floor": {
+            "type": "string",
+            "enum": [
+              "private",
+              "anonymized"
+            ]
+          },
+          "upstream_budget_usd": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10000
+          },
+          "requests_per_minute": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10000
+          },
+          "concurrency_limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000
+          },
+          "expires_at": {
+            "type": "number"
+          }
+        }
+      },
+      "AiGatewayAttachment": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "deployment_id",
+          "project_id",
+          "application_id",
+          "environment",
+          "allowed_models",
+          "privacy_floor",
+          "upstream_budget_usd",
+          "requests_per_minute",
+          "concurrency_limit",
+          "expires_at",
+          "public_base_url",
+          "status",
+          "key_id",
+          "rotation_generation",
+          "last_error_code",
+          "created_at",
+          "updated_at",
+          "detached_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^vai_[A-Za-z0-9_-]{20,64}$"
+          },
+          "deployment_id": {
+            "type": "string"
+          },
+          "project_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "application_id": {
+            "type": "string"
+          },
+          "environment": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "allowed_models": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "privacy_floor": {
+            "type": "string",
+            "enum": [
+              "private",
+              "anonymized"
+            ]
+          },
+          "upstream_budget_usd": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "requests_per_minute": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "concurrency_limit": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "expires_at": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "public_base_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "attaching",
+              "active",
+              "rotating",
+              "detaching",
+              "detached",
+              "failed"
+            ]
+          },
+          "key_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "pattern": "^vki_[A-Za-z0-9_-]{20,64}$"
+          },
+          "rotation_generation": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "last_error_code": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "type": "number"
+          },
+          "updated_at": {
+            "type": "number"
+          },
+          "detached_at": {
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        }
+      },
+      "AiGatewayAttachmentResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "attachment"
+        ],
+        "properties": {
+          "attachment": {
+            "$ref": "#/components/schemas/AiGatewayAttachment"
+          }
+        }
+      },
+      "AiGatewayAttachmentList": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "attachments"
+        ],
+        "properties": {
+          "attachments": {
+            "type": "array",
+            "maxItems": 500,
+            "items": {
+              "$ref": "#/components/schemas/AiGatewayAttachment"
+            }
+          }
+        }
+      },
+      "ApiKeyAuditEvent": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "key_id",
+          "principal_type",
+          "occurred_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^vka_[A-Za-z0-9_-]{20,64}$"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "issued",
+              "rotated",
+              "revoked"
+            ]
+          },
+          "key_id": {
+            "type": "string",
+            "pattern": "^vki_[A-Za-z0-9_-]{20,64}$"
+          },
+          "principal_type": {
+            "type": "string",
+            "enum": [
+              "human",
+              "workload"
+            ]
+          },
+          "project_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "application_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "deployment_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "attachment_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "occurred_at": {
+            "type": "number"
+          }
+        }
+      },
+      "ApiKeyAuditList": {
+        "type": "object",
+        "required": [
+          "events"
+        ],
+        "properties": {
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiKeyAuditEvent"
+            }
+          }
+        }
+      },
       "WebhookEventType": {
         "type": "string",
+        "description": "deployment.restart_requested is accepted only for backward-compatible subscription storage; it is not emitted while verified restart is unavailable.",
         "enum": [
           "deployment.accepted",
           "deployment.progress",

--- a/src/components/DocsHome.astro
+++ b/src/components/DocsHome.astro
@@ -3,6 +3,14 @@ import { Icon } from '@astrojs/starlight/components';
 
 const entryPaths = [
   {
+    title: 'AI inference',
+    href: '/ai-gateway/',
+    icon: 'open-book',
+    summary: 'OpenAI-compatible endpoint, 42 models. Swap one base_url and your existing client works.',
+    action: 'Call a model',
+    command: 'curl https://varity.app/v1/models',
+  },
+  {
     title: 'AI editor',
     href: '/ai-tools/mcp-server-spec/',
     icon: 'laptop',
@@ -16,12 +24,12 @@ const entryPaths = [
     icon: 'seti:shell',
     summary: 'Install varitykit and deploy from a supported project folder.',
     action: 'Deploy with CLI',
-    command: 'pipx install varitykit\nvaritykit app deploy',
+    command: 'pipx install varitykit\nvaritykit login\nvaritykit app deploy',
   },
   {
     title: 'Dashboard',
     href: '/deploy/deploy-from-dashboard/',
-    icon: 'rocket',
+    icon: 'laptop',
     summary: 'Deploy from the Developer Portal when you want a visual flow.',
     action: 'Open dashboard guide',
     command: 'developer.store.varity.so',
@@ -29,7 +37,7 @@ const entryPaths = [
   {
     title: 'Docker image',
     href: '/deploy/deploy-docker-image/',
-    icon: 'seti:docker',
+    icon: 'cloud-download',
     summary: 'Deploy a public or private Docker or OCI HTTP service image.',
     action: 'Deploy an image',
     command: 'varitykit app deploy --image <ref>',
@@ -39,7 +47,7 @@ const entryPaths = [
 const platformGroups = [
   {
     title: 'Start',
-    icon: 'rocket',
+    icon: 'approve-check',
     description: 'Install Varity, connect your tool, and ship the first app.',
     links: [
       ['Install', '/getting-started/installation/'],
@@ -103,6 +111,8 @@ const commonTasks = [
   ['Deploy a Next.js app', '/guides/deploy-nextjs/'],
   ['Deploy a Python app', '/getting-started/quickstart-python/'],
   ['Migration guide', '/deploy/vercel-migration/'],
+  ['Call an LLM', '/ai-gateway/'],
+  ['Rent a CPU VM or GPU', '/machines/'],
   ['Set environment variables', '/deploy/env-variables/'],
   ['Estimate costs', '/resources/pricing/'],
   ['Get help', '/getting-started/getting-help/'],
@@ -418,7 +428,9 @@ const trustLinks = [
 
   .primary-action {
     background: var(--color-brand);
-    color: #031312;
+    /* Was #031312 on var(--color-brand). Light mode redefines that token to
+       #0f766e, giving 3.47:1 and failing AA. White on #0f766e is 5.47:1. */
+    color: #ffffff;
   }
 
   .secondary-action {

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -102,6 +102,24 @@ function findSection(sidebar: unknown): string | null {
   return null;
 }
 
+function findSectionHref(entries: any, label: string): string | null {
+  if (!Array.isArray(entries)) return null;
+  for (const entry of entries) {
+    if (entry?.label === label) {
+      if (entry.href) return entry.href;
+      const first = Array.isArray(entry.entries)
+        ? entry.entries.find((e: any) => e?.href)
+        : null;
+      return first?.href ?? null;
+    }
+    if (Array.isArray(entry?.entries)) {
+      const found = findSectionHref(entry.entries, label);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
 const sectionLabel = findSection(route?.sidebar);
 
 const breadcrumbItems: BreadcrumbItem[] = [
@@ -113,11 +131,17 @@ const breadcrumbItems: BreadcrumbItem[] = [
   },
 ];
 let pos = 2;
-if (sectionLabel) {
+// Google requires `item` on every ListItem except the last. Emitting the section
+// crumb without one made the whole breadcrumb FAIL on all 54 non-home pages.
+// A two-level breadcrumb that validates beats a three-level one that errors, so
+// the crumb is only emitted when the section resolves to a real URL.
+const sectionHref = sectionLabel ? findSectionHref(route?.sidebar, sectionLabel) : null;
+if (sectionLabel && sectionHref) {
   breadcrumbItems.push({
     "@type": "ListItem",
     position: pos++,
     name: sectionLabel,
+    item: new URL(sectionHref, SITE).href,
   });
 }
 // Don't duplicate the Home crumb for the homepage itself.

--- a/src/content/docs/ai-gateway/compatibility.mdx
+++ b/src/content/docs/ai-gateway/compatibility.mdx
@@ -1,0 +1,210 @@
+---
+title: AI Gateway OpenAI Compatibility
+description: Exactly which parts of the OpenAI API surface the Varity AI Gateway implements, and which parts it does not.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import PageMeta from '../../../components/PageMeta.astro';
+
+<PageMeta
+  author="Varity Team"
+  authorRole="Core Contributors"
+  lastUpdated="August 2026"
+  stability="beta"
+/>
+
+"OpenAI-compatible" is a claim about a surface, not a promise about all of it.
+This page states the boundary. An exclusion you discover at runtime instead of
+reading it here is a documentation bug. If you hit one, report it.
+
+Everything below was checked against the live gateway at `https://varity.app/v1`.
+
+## Endpoints
+
+| Endpoint | Status |
+|----------|--------|
+| `POST /v1/chat/completions` | **Supported.** Requires a bearer API key. |
+| `GET /v1/models` | **Supported.** Public, no key required. |
+| `GET /v1/models/{id}` | **Not implemented.** Returns `404`. Fetch the list and filter client-side. |
+| `POST /v1/completions` (legacy text completions) | **Not implemented.** Returns `404`. |
+| `POST /v1/responses` | **Not implemented.** Returns `404`. |
+| `POST /v1/embeddings` | **Not implemented.** Returns `404`. |
+| `/v1/assistants` | **Not implemented.** Returns `404`. |
+| `/v1/files` | **Not implemented.** Returns `404`. |
+| `/v1/vector_stores` | **Not implemented.** Returns `404`. |
+| `POST /v1/images/generations` | **Not implemented.** Returns `404`. |
+| `POST /v1/audio/speech` | **Not implemented.** Returns `404`. |
+| `POST /v1/audio/transcriptions` | **Not implemented.** Returns `404`. |
+| `POST /v1/moderations` | **Not implemented.** Returns `404`. |
+| `/v1/batches` | **Not implemented.** Returns `404`. |
+| `/v1/fine_tuning/jobs` | **Not implemented.** Returns `404`. |
+
+Beyond the OpenAI surface, the gateway serves its own endpoints. These have no
+OpenAI equivalent, so a client written against the OpenAI spec will not find
+them, but they are public and stable.
+
+| Endpoint | Status |
+|----------|--------|
+| `GET /v1/openapi.json` | **Supported.** Public, no key required. The machine-readable contract for this surface, including the data-handling block below. |
+| `GET /v1/inference/requests` | **Supported.** Requires a bearer API key. Per-request metadata. |
+| `GET /v1/inference/usage` | **Supported.** Requires a bearer API key. |
+| `GET /v1/inference/policy` | **Supported.** Requires a bearer API key. |
+| `GET /v1/inference/performance` | **Supported.** Requires a bearer API key. Accepts `window` of `1h`, `24h`, `7d`, or `30d`. |
+
+For the OpenAI-compatible surface, the gateway is a **chat-completions gateway**. Text generation is the product;
+embeddings, files, assistants, batch, fine-tuning, images, audio, and moderation
+are not part of it. Unimplemented routes return an HTML `404` page, not a JSON
+error envelope. A client that assumes every failure parses as JSON throws a
+parse error rather than surfacing a clean status. Branch on the HTTP status
+code, not on the body.
+
+A non-`/v1` health probe is also available:
+
+| Endpoint | Status |
+|----------|--------|
+| `GET /health` | **Supported.** Public. Returns `{"status":"healthy","service":"varity-gateway","version":"1.13.49"}`. |
+
+<Aside type="caution">
+Any OpenAI SDK helper that touches an unimplemented route will fail, including
+`client.embeddings.create(...)`, the Assistants and Responses APIs, and file
+upload helpers. Only the `chat.completions` and `models` namespaces work.
+</Aside>
+
+## Per-Model Capabilities
+
+Compatibility is not uniform across models. Each catalog entry carries a
+`capabilities` object, and you must read it. The same request that works
+against one model can be unsupported on another.
+
+| Capability | Models supporting it |
+|------------|----------------------|
+| `chat_completions` | 42 of 42 |
+| `streaming` | 42 of 42 |
+| `tool_calls` | **11 of 42** |
+| `streaming_tool_calls` | **7 of 42** |
+
+### Tool calling is the exception, not the default
+
+Only 11 of the 42 models accept `tools` / `tool_choice`. If your agent framework
+assumes function calling works everywhere, as most do, it will break on the other
+31. These are the models reporting `tool_calls: true`:
+
+| Model ID | Name | Tool calls while streaming |
+|----------|------|----------------------------|
+| `model-01e5cfb9cd019cee62a62b13` | Gemma 4 Uncensored | Yes |
+| `model-afb55f3c0379fce9fb050497` | Google Gemma 3 27B Instruct | No |
+| `model-1bcd5b1a9fc32ffb985afc6b` | Grok 4.20 | Yes |
+| `model-4e27cf37044481968f24c858` | Grok 4.3 | Yes |
+| `model-7ac496866ed390aa843e23ea` | Grok 4.5 | Yes |
+| `model-0bf4d9df75eb028b048a51ed` | Grok Build 0.1 | Yes |
+| `model-c09137265edddbdec9dfda8b` | Llama 3.2 3B | No |
+| `llama-3-3-70b` | Llama 3.3 70B | No |
+| `model-ca8c32ffa3e6ec1adee98495` | Mistral Small 3.2 24B Instruct | No |
+| `model-38c8e473186cf182a89ee7ff` | Role Play Uncensored | Yes |
+| `model-665e90a28adb3a74b27bb064` | Uncensored 1.2 | Yes |
+
+Four of those eleven support tool calls only in non-streaming mode
+(`tool_calls: true`, `streaming_tool_calls: false`): `llama-3-3-70b`,
+`model-afb55f3c0379fce9fb050497`, `model-c09137265edddbdec9dfda8b`, and
+`model-ca8c32ffa3e6ec1adee98495`. Combining `stream: true` with `tools` on those
+is outside the supported surface. Drop `stream` or pick a model from the seven
+that report `streaming_tool_calls: true`.
+
+Resolve this at runtime rather than hardcoding:
+
+```python
+models = {m["id"]: m for m in client.models.list().model_dump()["data"]}
+
+def supports_tools(model_id, streaming=False):
+    caps = models[model_id]["capabilities"]
+    return caps["streaming_tool_calls"] if streaming else caps["tool_calls"]
+```
+
+<Aside type="note">
+The OpenAI Python SDK exposes only the fields it knows about on typed objects.
+Varity's extra fields (`capabilities`, `context_window`, `customer_pricing`)
+arrive as extra JSON, so read the raw dict (or call `/v1/models` directly with an
+HTTP client) rather than expecting SDK attributes for them.
+</Aside>
+
+## Model Identifiers
+
+Varity model ids are **not** OpenAI model ids. There is no `gpt-4o`, no
+`gpt-3.5-turbo`, and no aliasing layer that maps OpenAI names onto Varity
+models. A request naming an OpenAI model id is a request for a model that does
+not exist here.
+
+Most ids are opaque, in the form `model-<hex>`; a handful are readable, such as
+`glm-5-1`, `glm-5-2`, `llama-3-3-70b`, and `qwen-3-5-35b-a3b`. Always take ids
+from [the catalog](/ai-gateway/models/).
+
+## Limits That Differ From OpenAI
+
+- **`max_completion_tokens` is per-model and often small.** Values in the catalog run from 4,096 up to 131,072, independent of the context window (which runs from 128,000 to 2,000,000). A 2M-token context does not mean a long reply is allowed.
+- **No cached-input discount.** Every model returns `cached_input` equal to `input`. Prompt caching does not currently reduce price.
+- **Rate limits are advertised in response headers.** `GET /v1/models` returns `ratelimit-limit: 120` with `ratelimit-policy: 120;w=60`. Read `ratelimit-remaining` and `ratelimit-reset` at runtime instead of assuming a fixed budget.
+
+## Errors
+
+The error envelope matches OpenAI's shape and adds two fields:
+
+```json
+{
+  "error": {
+    "message": "The API key is invalid or revoked.",
+    "type": "authentication_error",
+    "code": "invalid_api_key",
+    "param": null,
+    "retryable": false,
+    "request_id": "626e1d39-9b9b-46d6-8781-1dc280dfe85c"
+  }
+}
+```
+
+- `retryable` is a boolean OpenAI does not send. Use it instead of guessing from the status code whether to retry.
+- `request_id` is also returned as the `x-request-id` response header on every response, successful or not.
+
+Observed authentication codes:
+
+| Condition | Status | `code` |
+|-----------|--------|--------|
+| No `Authorization` header | `401` | `authentication_required` |
+| Invalid or revoked key | `401` | `invalid_api_key` |
+
+Authentication is evaluated **before** request-body validation, so an
+unauthenticated request with an invalid `model` returns the authentication
+error, not a model error. Do not use the error type to infer that your payload
+was accepted.
+
+## Privacy And Data Retention
+
+The gateway publishes its data-handling contract as an `x-varity-data-handling`
+block at the root of `GET /v1/openapi.json`. It is machine-readable, so you can
+assert against it in CI rather than taking a page's word for it.
+
+| Field | Value |
+|-------|-------|
+| `inference_metadata_retention_days` | `30` |
+| `stored_content` | `[]` |
+| `content_never_stored` | `prompts`, `responses`, `tool_arguments`, `uploaded_content`, `playground_conversations` |
+| `financial_and_security_records` | `separate_retention_classes` |
+
+Prompt and response bodies are never written to the inference records. What is
+retained for 30 days is request metadata: model and provider identifiers, token
+counts, latency, fallback count, error code, and timestamps. Read it back with
+`GET /v1/inference/requests`.
+
+This is the property usually searched for as zero data retention, or ZDR.
+
+## Privacy Routing
+
+Every model in the catalog reports `privacy: "private"` with
+`privacy_routes: ["private"]`. This field has no OpenAI equivalent; it is
+Varity-specific catalog metadata describing how the model is routed. There is
+currently no non-private route to choose between.
+
+## Next Steps
+
+- **[AI Gateway Overview](/ai-gateway/)**: base URL, auth, quickstart, streaming
+- **[Models](/ai-gateway/models/)**: the full catalog with limits and prices
+- **[Public API Reference](/ai-tools/api-reference/)**: the `/api` platform contract

--- a/src/content/docs/ai-gateway/index.mdx
+++ b/src/content/docs/ai-gateway/index.mdx
@@ -1,0 +1,277 @@
+---
+title: Varity AI Gateway
+description: OpenAI-compatible inference on Varity. Point any OpenAI client at https://varity.app/v1 and change nothing else.
+---
+
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import PageMeta from '../../../components/PageMeta.astro';
+
+<PageMeta
+  author="Varity Team"
+  authorRole="Core Contributors"
+  lastUpdated="August 2026"
+  stability="beta"
+/>
+
+The Varity AI Gateway is an OpenAI-compatible inference API. It speaks the same
+chat-completions wire format as the OpenAI API, so every OpenAI SDK, framework
+adapter, and agent runtime already knows how to talk to it. The integration is a
+one-line base-URL swap.
+
+```text
+https://varity.app/v1
+```
+
+## Fastest Path
+
+Set two variables and send a request. This is the whole integration.
+
+<Tabs>
+  <TabItem label="curl">
+
+    ```bash
+    curl https://varity.app/v1/chat/completions \
+      -H "Authorization: Bearer $VARITY_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "model": "glm-5-2",
+        "messages": [
+          { "role": "user", "content": "Say hello in one sentence." }
+        ]
+      }'
+    ```
+
+  </TabItem>
+  <TabItem label="Python">
+
+    ```python
+    # pip install openai
+    import os
+    from openai import OpenAI
+
+    client = OpenAI(
+        base_url="https://varity.app/v1",
+        api_key=os.environ["VARITY_API_KEY"],
+    )
+
+    response = client.chat.completions.create(
+        model="glm-5-2",
+        messages=[{"role": "user", "content": "Say hello in one sentence."}],
+    )
+
+    print(response.choices[0].message.content)
+    ```
+
+  </TabItem>
+  <TabItem label="Node">
+
+    ```javascript
+    // npm install openai
+    import OpenAI from "openai";
+
+    const client = new OpenAI({
+      baseURL: "https://varity.app/v1",
+      apiKey: process.env.VARITY_API_KEY,
+    });
+
+    const response = await client.chat.completions.create({
+      model: "glm-5-2",
+      messages: [{ role: "user", content: "Say hello in one sentence." }],
+    });
+
+    console.log(response.choices[0].message.content);
+    ```
+
+  </TabItem>
+</Tabs>
+
+`base_url` / `baseURL` is the only line that differs from an OpenAI setup. Model
+ids come from the Varity catalog, not OpenAI's. See
+[Models](/ai-gateway/models/) for the full list.
+
+## Confirm The Gateway Before You Have A Key
+
+`GET /v1/models` is public. Run it right now, with no credential, and you get a
+`200` plus the live catalog:
+
+```bash
+curl https://varity.app/v1/models
+```
+
+```json
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "glm-5-2",
+      "display_name": "GLM 5.2",
+      "object": "model",
+      "owned_by": "varity",
+      "capabilities": {
+        "chat_completions": true,
+        "tool_calls": false,
+        "streaming": true,
+        "streaming_tool_calls": false
+      },
+      "context_window": 1000000,
+      "max_completion_tokens": 131072,
+      "privacy": "private",
+      "privacy_routes": ["private"],
+      "availability": { "status": "available" },
+      "customer_pricing": {
+        "status": "configured",
+        "currency": "usd",
+        "unit": "per_million_tokens",
+        "input": 1.47,
+        "output": 4.62,
+        "cached_input": 1.47
+      }
+    }
+  ]
+}
+```
+
+The gateway also exposes an unauthenticated health probe:
+
+```bash
+curl https://varity.app/health
+```
+
+```json
+{ "status": "healthy", "service": "varity-gateway", "version": "1.13.49" }
+```
+
+## Authentication
+
+Inference requests require a Varity API key sent as a bearer credential:
+
+```text
+Authorization: Bearer $VARITY_API_KEY
+```
+
+Create keys in the [Developer Portal settings page](https://developer.store.varity.so/dashboard/settings). Key plaintext is shown once
+at creation and is never returned again. The same key format is used across the
+Varity [public API](/ai-tools/api-reference/).
+
+Auth is enforced on `/v1/chat/completions`. A request with no `Authorization`
+header returns `401`:
+
+```json
+{
+  "error": {
+    "message": "A Bearer API key is required.",
+    "type": "authentication_error",
+    "code": "authentication_required",
+    "param": null,
+    "retryable": false,
+    "request_id": "516c24ef-ba5a-4e3d-8f32-0a609ae5d298"
+  }
+}
+```
+
+A malformed or revoked key returns `401` with `code: "invalid_api_key"` and the
+message `The API key is invalid or revoked.`
+
+<Aside type="note">
+Authentication is checked before the request body is validated. An unauthenticated
+request naming a nonexistent model still returns the authentication error, not a
+model error.
+</Aside>
+
+## Streaming
+
+Set `stream: true` for server-sent events, exactly as with OpenAI. Every model in
+the catalog reports `"streaming": true`.
+
+<Tabs>
+  <TabItem label="curl">
+
+    ```bash
+    curl https://varity.app/v1/chat/completions \
+      -H "Authorization: Bearer $VARITY_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "model": "glm-5-2",
+        "stream": true,
+        "messages": [
+          { "role": "user", "content": "Count to five." }
+        ]
+      }'
+    ```
+
+  </TabItem>
+  <TabItem label="Python">
+
+    ```python
+    stream = client.chat.completions.create(
+        model="glm-5-2",
+        messages=[{"role": "user", "content": "Count to five."}],
+        stream=True,
+    )
+
+    for chunk in stream:
+        delta = chunk.choices[0].delta.content
+        if delta:
+            print(delta, end="")
+    ```
+
+  </TabItem>
+  <TabItem label="Node">
+
+    ```javascript
+    const stream = await client.chat.completions.create({
+      model: "glm-5-2",
+      messages: [{ role: "user", content: "Count to five." }],
+      stream: true,
+    });
+
+    for await (const chunk of stream) {
+      process.stdout.write(chunk.choices[0]?.delta?.content ?? "");
+    }
+    ```
+
+  </TabItem>
+</Tabs>
+
+Streaming *tool calls* are a narrower capability than streaming text, and are
+only supported on some models. Check `capabilities.streaming_tool_calls` before
+you combine `stream: true` with `tools`. See
+[Compatibility](/ai-gateway/compatibility/).
+
+## Errors
+
+Errors use the OpenAI error envelope, with two Varity additions: `retryable` and
+`request_id`.
+
+| Field | Meaning |
+|-------|---------|
+| `error.message` | Human-readable description |
+| `error.type` | Error class, for example `authentication_error` |
+| `error.code` | Stable machine code, for example `invalid_api_key` |
+| `error.param` | Offending request field, or `null` |
+| `error.retryable` | Whether retrying the same request can succeed |
+| `error.request_id` | Correlation id, also returned as the `x-request-id` response header |
+
+Quote `request_id` in any support request. It is present on both the response
+body and the `x-request-id` header on every response, including successful ones.
+
+## Rate Limits
+
+`GET /v1/models` returns standard rate-limit headers:
+
+```text
+ratelimit-limit: 120
+ratelimit-policy: 120;w=60
+ratelimit-remaining: 119
+ratelimit-reset: 60
+```
+
+That is 120 requests per 60-second window on the catalog endpoint. Read the
+`ratelimit-remaining` and `ratelimit-reset` headers rather than hardcoding a
+budget; the policy is served live and can change.
+
+## Next Steps
+
+- **[Models](/ai-gateway/models/)**: the full live catalog with context windows, limits, and prices
+- **[Compatibility](/ai-gateway/compatibility/)**: exactly what the OpenAI surface includes and excludes
+- **[Public API Reference](/ai-tools/api-reference/)**: the `/api` platform contract for deploys and operations

--- a/src/content/docs/ai-gateway/models.mdx
+++ b/src/content/docs/ai-gateway/models.mdx
@@ -1,0 +1,155 @@
+---
+title: AI Gateway Models
+description: Ids, context windows, completion limits, tool-calling and streaming support, and per-token pricing in the live Varity AI Gateway model catalog.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import PageMeta from '../../../components/PageMeta.astro';
+
+<PageMeta
+  author="Varity Team"
+  authorRole="Core Contributors"
+  lastUpdated="August 2026"
+  stability="beta"
+/>
+
+The catalog is served live. This page is a snapshot of it; the endpoint is the
+source of truth:
+
+```bash
+curl https://varity.app/v1/models
+```
+
+`GET /v1/models` is public and needs no API key. It returns an OpenAI-shaped
+`{ "object": "list", "data": [...] }` response. Varity adds fields OpenAI does
+not return: `display_name`, `capabilities`, `context_window`,
+`max_completion_tokens`, `privacy`, `privacy_routes`, `availability`, and
+`customer_pricing`.
+
+<Aside type="tip" icon="approve-check">
+Do not hardcode this table. Resolve models at runtime from `/v1/models` and read
+`capabilities` per model. The catalog changes without a docs release.
+</Aside>
+
+## Catalog
+
+**42 models** were listed at the time of writing, all reporting
+`availability.status: "available"` and `chat_completions: true`.
+
+Pass the `id` column verbatim as the `model` field of a chat-completions
+request. Note that most ids are opaque `model-<hash>` strings rather than
+vendor-style names; the `display_name` is a label, not an identifier.
+
+Prices are USD per million tokens, taken from each model's `customer_pricing`
+object.
+
+| Model ID | Name | Context window | Max completion tokens | Tool calls | Streaming | Input / 1M | Output / 1M |
+|----------|------|----------------|-----------------------|------------|-----------|------------|-------------|
+| `model-23ceb717e8b9fbdf4170804c` | DeepSeek V3.2 | 160,000 | 32,768 | No | Yes | $0.3465 | $0.504 |
+| `model-01e5cfb9cd019cee62a62b13` | Gemma 4 Uncensored | 256,000 | 8,192 | Yes | Yes | $0.170625 | $0.525 |
+| `model-e7a95bbb411e58c5b94bd949` | GLM 4.6 | 198,000 | 16,384 | No | Yes | $0.4515 | $1.8375 |
+| `model-84999d7f31100ae1be7e4ee9` | GLM 4.7 | 198,000 | 16,384 | No | Yes | $0.5775 | $2.7825 |
+| `model-4d0399841ad2104adac8673f` | GLM 4.7 Flash | 128,000 | 16,384 | No | Yes | $0.063 | $0.42 |
+| `model-8f0e33a63784a2569979827d` | GLM 4.7 Flash Heretic | 200,000 | 24,000 | No | Yes | $0.0735 | $0.42 |
+| `model-975fe730d6699badb8f13ca0` | GLM 5 | 198,000 | 32,000 | No | Yes | $1.05 | $3.36 |
+| `glm-5-1` | GLM 5.1 | 200,000 | 80,000 | No | Yes | $1.617 | $5.082 |
+| `glm-5-2` | GLM 5.2 | 1,000,000 | 131,072 | No | Yes | $1.47 | $4.62 |
+| `model-afb55f3c0379fce9fb050497` | Google Gemma 3 27B Instruct | 198,000 | 16,384 | Yes | Yes | $0.126 | $0.21 |
+| `model-592b84ed19d414fc58b3c1b8` | Google Gemma 4 26B A4B Instruct | 256,000 | 8,192 | No | Yes | $0.1365 | $0.42 |
+| `model-da12ebb256e118bd1b7f4c86` | Google Gemma 4 31B Instruct | 256,000 | 8,192 | No | Yes | $0.126 | $0.378 |
+| `model-1bcd5b1a9fc32ffb985afc6b` | Grok 4.20 | 2,000,000 | 128,000 | Yes | Yes | $1.491 | $2.9715 |
+| `model-13cb7872bbc7954e8ae400d8` | Grok 4.20 Multi-Agent | 2,000,000 | 128,000 | No | Yes | $1.491 | $2.9715 |
+| `model-4e27cf37044481968f24c858` | Grok 4.3 | 1,000,000 | 32,000 | Yes | Yes | $1.491 | $2.9715 |
+| `model-7ac496866ed390aa843e23ea` | Grok 4.5 | 500,000 | 32,000 | Yes | Yes | $2.3835 | $7.14 |
+| `model-0bf4d9df75eb028b048a51ed` | Grok Build 0.1 | 256,000 | 65,536 | Yes | Yes | $1.05 | $2.1 |
+| `model-b5bcc7a2b398465798a0759a` | Hermes 3 Llama 3.1 405b | 128,000 | 16,384 | No | Yes | $1.155 | $3.15 |
+| `model-35fec70a1356b5981dba26d9` | Inkling | 524,288 | 65,536 | No | Yes | $1.3125 | $5.315625 |
+| `model-547bc7d442bda226b1ac0d52` | Kimi K2.5 | 256,000 | 65,536 | No | Yes | $0.588 | $3.675 |
+| `model-932fa0c5bc52d3ea2e193584` | Kimi K2.6 | 256,000 | 65,536 | No | Yes | $0.7875 | $3.675 |
+| `model-28805f587470f2b9e31381f8` | Kimi K2.7 Code | 256,000 | 65,536 | No | Yes | $0.7875 | $3.675 |
+| `model-93e21d329a7b4dd9514d9c9f` | Kimi K3 | 1,000,000 | 131,072 | No | Yes | $3.9375 | $19.6875 |
+| `model-c09137265edddbdec9dfda8b` | Llama 3.2 3B | 128,000 | 4,096 | Yes | Yes | $0.1575 | $0.63 |
+| `llama-3-3-70b` | Llama 3.3 70B | 128,000 | 4,096 | Yes | Yes | $0.735 | $2.94 |
+| `model-36acfa144b41de8ac1c27944` | MiniMax M2.5 | 198,000 | 32,768 | No | Yes | $0.2835 | $0.9975 |
+| `model-c783b8f80c60041a340bdb07` | MiniMax M2.7 | 198,000 | 32,768 | No | Yes | $0.39375 | $1.575 |
+| `model-ca8c32ffa3e6ec1adee98495` | Mistral Small 3.2 24B Instruct | 256,000 | 16,384 | Yes | Yes | $0.0984375 | $0.2625 |
+| `model-305938ab9ebc39e1beb95ac4` | Mistral Small 4 | 256,000 | 65,536 | No | Yes | $0.196875 | $0.7875 |
+| `model-adeed85bab462c43614e8e1c` | NVIDIA Nemotron 3 Nano 30B | 128,000 | 16,384 | No | Yes | $0.07875 | $0.315 |
+| `model-2207a53b5a3f856264ce7753` | NVIDIA Nemotron 3 Ultra | 256,000 | 32,768 | No | Yes | $0.65625 | $3.28125 |
+| `model-94ab4b38ef8b46c8cdf5ffa0` | OpenAI GPT OSS 120B | 128,000 | 16,384 | No | Yes | $0.0735 | $0.315 |
+| `model-ab4d70a40590dc6ed07d5187` | Qwen 3 235B A22B Instruct 2507 | 128,000 | 16,384 | No | Yes | $0.1575 | $0.7875 |
+| `model-366edcdf75d467e68639879b` | Qwen 3 235B A22B Thinking 2507 | 128,000 | 16,384 | No | Yes | $0.4725 | $3.675 |
+| `model-bbb8171a9ad936cd006e9640` | Qwen 3 Coder 480B Turbo | 256,000 | 65,536 | No | Yes | $0.3675 | $1.575 |
+| `model-2f3b522ed43cc37cb7cac581` | Qwen 3 Next 80b | 256,000 | 16,384 | No | Yes | $0.3675 | $1.995 |
+| `qwen-3-5-35b-a3b` | Qwen 3.5 35B A3B | 256,000 | 16,384 | No | Yes | $0.328125 | $1.3125 |
+| `model-e838b0fde95335963c1bc9d4` | Qwen 3.5 9B | 256,000 | 32,768 | No | Yes | $0.105 | $0.1575 |
+| `model-f660e96789aa9606296abe39` | Qwen 3.6 27B | 256,000 | 65,536 | No | Yes | $0.34125 | $3.4125 |
+| `model-be42cfa83562024c857a01fb` | Qwen3 VL 235B | 128,000 | 16,384 | No | Yes | $0.2205 | $1.995 |
+| `model-38c8e473186cf182a89ee7ff` | Role Play Uncensored | 128,000 | 4,096 | Yes | Yes | $0.525 | $2.1 |
+| `model-665e90a28adb3a74b27bb064` | Uncensored 1.2 | 128,000 | 8,192 | Yes | Yes | $0.21 | $0.945 |
+
+## Reading The Catalog Fields
+
+Each entry in `data` carries these Varity fields:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string | Pass this as `model` in a request |
+| `display_name` | string | Human label only, never an identifier |
+| `capabilities.chat_completions` | boolean | `true` on all 42 models |
+| `capabilities.tool_calls` | boolean | `true` on 11 of 42 models |
+| `capabilities.streaming` | boolean | `true` on all 42 models |
+| `capabilities.streaming_tool_calls` | boolean | `true` on 7 of 42 models |
+| `context_window` | integer | Total tokens, input plus output |
+| `max_completion_tokens` | integer | Ceiling on generated tokens |
+| `privacy` | string | `"private"` on every model in the catalog |
+| `privacy_routes` | array | `["private"]` on every model in the catalog |
+| `availability.status` | string | `"available"` on every model, with an `observed_at` timestamp |
+| `customer_pricing` | object | See below |
+| `refreshed_at` | string | When the gateway last refreshed the entry |
+
+### Pricing
+
+Every model returns `customer_pricing.status: "configured"` with concrete
+numbers:
+
+```json
+"customer_pricing": {
+  "status": "configured",
+  "version": "2026-07-28.v3.d74e3f5155b10314",
+  "currency": "usd",
+  "unit": "per_million_tokens",
+  "input": 1.47,
+  "output": 4.62,
+  "cached_input": 1.47
+}
+```
+
+`cached_input` equals `input` on all 42 models. Cached input tokens are not
+discounted today. Always read `unit` and `currency` rather than assuming; the
+`version` string identifies the price set the numbers came from.
+
+Across the catalog, input prices run from $0.063 to $3.9375 per million tokens
+and output prices from $0.1575 to $19.6875 per million tokens.
+
+### Context Windows
+
+Context windows range from 128,000 to 2,000,000 tokens. `max_completion_tokens`
+is a separate, much smaller ceiling on any single response, and it goes as low as
+4,096 on some models. A large context window does not imply a large answer.
+
+## Picking A Model
+
+- **Need tool calling?** Only 11 models support it, and only 7 support tool calls while streaming. See [Compatibility](/ai-gateway/compatibility/) for the exact lists.
+- **Need a very large context?** `model-13cb7872bbc7954e8ae400d8` (Grok 4.20 Multi-Agent) and `model-1bcd5b1a9fc32ffb985afc6b` (Grok 4.20) both report 2,000,000 tokens.
+- **Cost sensitive?** `model-4d0399841ad2104adac8673f` (GLM 4.7 Flash) is the cheapest input price in the catalog at $0.063 per million input tokens.
+
+<Aside type="caution">
+There is no per-model retrieval route. `GET /v1/models/{id}` returns `404`; fetch
+the list and filter it client-side.
+</Aside>
+
+## Next Steps
+
+- **[AI Gateway Overview](/ai-gateway/)**: base URL, auth, and the quickstart snippets
+- **[Compatibility](/ai-gateway/compatibility/)**: supported and unsupported OpenAI surface

--- a/src/content/docs/ai-tools/api-reference.mdx
+++ b/src/content/docs/ai-tools/api-reference.mdx
@@ -240,6 +240,8 @@ The OpenAPI document contains these 18 public paths:
 | `GET`, `PATCH` | `/api/deployments/{deployment_id}/env` | List environment variable keys or update values |
 | `POST` | `/api/deployments/{deployment_id}/redeploy` | Redeploy in place |
 | `POST` | `/api/deployments/{deployment_id}/restart` | Restart in place |
+| `GET`, `PUT`, `DELETE` | `/api/deployments/{deployment_id}/domain` | Read, attach, or remove a custom domain |
+| `POST` | `/api/deployments/{deployment_id}/domain/verify` | Observe DNS and verify HTTPS serving |
 | `GET` | `/api/templates` | List templates |
 | `GET` | `/api/templates/{template_id}` | Read a template |
 | `POST` | `/api/templates/{template_id}/deploy` | Deploy a template |

--- a/src/content/docs/ai-tools/api-reference.mdx
+++ b/src/content/docs/ai-tools/api-reference.mdx
@@ -9,11 +9,11 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="July 2026"
+  lastUpdated="August 2026"
   stability="beta"
 />
 
-Varity's public API is a resource API for apps, deployments, templates, pricing, credits, API keys, and webhooks. Use it for direct integrations, custom agents, launchpads, internal tools, and backend services that need to deploy or operate Varity apps without the dashboard.
+Varity's public API is a resource API for deployments, self-managed machines, templates, pricing and quotes, credits, API keys, AI Gateway attachments, and webhooks. Use it for direct integrations, custom agents, launchpads, internal tools, and backend services that need to deploy or operate Varity apps without the dashboard.
 
 The machine-readable source is:
 
@@ -28,19 +28,24 @@ Older thin-client compatibility routes are not the public resource contract. New
 
 Varity exposes two public base URLs:
 
-**Platform APIs** (apps, deployments, templates, pricing, credits, API keys, webhooks — everything on this page):
+**Platform APIs** cover apps, deployments, templates, pricing, credits, API keys, and webhooks. That is everything on this page:
 
 ```text
 https://varity.app/api
 ```
 
-**AI Gateway** (OpenAI-compatible inference — chat completions and model listing):
+**AI Gateway** covers OpenAI-compatible inference. Chat completions and model listing:
 
 ```text
 https://varity.app/v1
 ```
 
-Point any OpenAI-compatible client at `https://varity.app/v1` for inference; the `/api` routes below are the platform resource contract.
+These are two different products with two different contracts:
+
+- **`/api/*` is the platform surface.** Resource CRUD for deployments, machines, templates, pricing, credits, keys, and webhooks. Everything on this page. Errors use the [Varity error envelope](/api/errors/).
+- **`/v1/*` is the OpenAI-compatible inference surface.** Chat completions and model listing. Point any OpenAI client at it by setting the base URL. It has its own error shape and its own rate limits, documented in the [AI Gateway](/ai-gateway/) docs. Nothing on this page applies to it.
+
+A single Varity API key does not automatically work on both surfaces: keys are scoped per product, and using one out of scope returns `403 credential_scope_violation`. Create AI Gateway keys in the Developer Portal, or via `POST /api/api-keys/inference`.
 
 For non-browser callers, send your Varity API key as a bearer credential:
 
@@ -48,11 +53,22 @@ For non-browser callers, send your Varity API key as a bearer credential:
 Authorization: Bearer $VARITY_API_KEY
 ```
 
-Create API keys in the Developer Portal settings page. API key plaintext is shown once. Listing and revoking keys require an authenticated Developer Portal session; plaintext keys are never returned after creation.
+Create API keys in the [Developer Portal settings page](https://developer.store.varity.so/dashboard/settings). API key plaintext is shown once. Listing and revoking keys require an authenticated Developer Portal session; plaintext keys are never returned after creation.
 
 ## Deploy
 
-`POST /api/deployments` creates a deployment from one source: repository, image, or template. Use `Idempotency-Key` on create requests so normal retries and replays cannot create duplicate deployments. Do not fire concurrent create requests with the same idempotency key; atomic concurrent idempotency is a backend hardening follow-up for v1.
+`POST /api/deployments` creates a deployment from one source: repository, image, or template. It returns `202 Accepted`. Creation is asynchronous.
+
+Always send an `Idempotency-Key` on creates so a retry cannot produce a duplicate deployment:
+
+- Format: `[A-Za-z0-9._:-]`, 8 to 128 characters. Anything else returns `400 invalid_idempotency_key`.
+- Retention: 24 hours.
+- Replaying the same key with the **same** body returns the original result, flagged `replayed: true`.
+- Reusing the same key with a **different** body returns `409 idempotency_key_reused`.
+
+The header is optional on `POST /api/deployments`, `POST /api/templates/{id}/deploy`, `POST /api/machines`, and `DELETE /api/machines/{id}`, and **required** on every `/api/ai-gateway/attachments` mutation.
+
+Do not fire concurrent create requests with the same idempotency key; atomic concurrent idempotency is a backend hardening follow-up for v1.
 
 <Tabs>
   <TabItem label="Repository">
@@ -101,7 +117,9 @@ Create API keys in the Developer Portal settings page. API key plaintext is show
   </TabItem>
 </Tabs>
 
-The response includes a Varity deployment id, public URL, run id, and `status_url`. Poll the run until it reaches `succeeded` or `failed`:
+The `202` response includes `id`, `app_name`, `status: "deploying"`, `runtime`, `run_id`, and `status_url`. `public_url` is **not** guaranteed on acceptance. On the durable path the URL is only projected once the canonical route is proven, so read it from the deployment once the run succeeds rather than from the create response.
+
+Poll the run until it reaches `succeeded` or `failed`:
 
 ```bash
 curl "https://varity.app/api/deployments/runs/$RUN_ID?app=my-app" \
@@ -220,6 +238,14 @@ The response includes `signing_secret` once. Store it to verify webhook deliveri
 
 The signature is `v1=` plus an HMAC-SHA256 over `timestamp.body` using the webhook signing secret. Webhook endpoint URLs must be public HTTPS URLs; local and private hosts are rejected.
 
+Subscribable event types:
+
+`deployment.accepted`, `deployment.progress`, `deployment.live`, `deployment.failed`, `deployment.unhealthy`, `deployment.env_updated`, `deployment.redeploy_requested`, `deployment.redeploy_completed`, `deployment.restart_requested`, `deployment.deleted`, `credit.updated`.
+
+<Aside type="note">
+`deployment.restart_requested` is accepted for backward-compatible subscription storage only. It is not emitted while verified restart is unavailable.
+</Aside>
+
 Webhook handlers should be idempotent. Delivery-time DNS/IP revalidation, durable delivery queue hardening, and additional signing-secret custody hardening remain non-blocking v1 follow-ups.
 
 List webhooks and delivery status:
@@ -236,9 +262,119 @@ curl -X DELETE https://varity.app/api/webhooks/$WEBHOOK_ID \
   -H "Authorization: Bearer $VARITY_API_KEY"
 ```
 
+## Machines
+
+Self-managed machines are a separate resource from deployments: you get a machine you administer, not a managed app. Quote first, then create.
+
+```bash
+curl -X POST https://varity.app/api/pricing/machine-quote \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ ... }'
+
+curl -X POST https://varity.app/api/machines \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: machine-001" \
+  -d '{ ... }'
+```
+
+Create and delete return `202`. List, read, and run bounded synchronous actions:
+
+```bash
+curl https://varity.app/api/machines \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+
+curl https://varity.app/api/machines/$MACHINE_ID \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+
+curl -X POST https://varity.app/api/machines/$MACHINE_ID/actions \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ ... }'
+```
+
+Request and response schemas are in the OpenAPI document; read it rather than hand-copying field lists.
+
+## Profiles, Capabilities, And Quotes
+
+Before deploying, discover what is actually available instead of assuming a catalog.
+
+`GET /api/deployment-capabilities` returns the provider-neutral catalog of workloads and execution options.
+
+`GET /api/deployment-profiles` returns normalized profiles, prices, and aggregate availability for a scope. Both `workload` and `execution_class` are required:
+
+```bash
+curl "https://varity.app/api/deployment-profiles?workload=gpu&execution_class=container" \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+`workload` is one of `gpu`, `virtual_machine`, `cpu`. `execution_class` is one of `container`, `virtual_machine`, `bare_metal`, `cpu_virtual_machine`. An invalid combination returns `422 deployment_profile_scope_invalid`.
+
+For the resource-, location-, runtime-, and access-complete GPU container catalog, pass `contract_version=gpu-container-profiles-v2`. Omit it during the rolling v1 compatibility window.
+
+Profiles carry availability, not a price commitment. For an exact hourly figure, take a quote:
+
+```bash
+curl -X POST https://varity.app/api/pricing/accelerator-quote \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ ... }'
+```
+
+Quotes draw from a generous per-minute budget, not the hourly mutation budget. Comparing prices will not exhaust your ability to manage running resources.
+
+## AI Gateway Attachments
+
+Attaching the Varity AI Gateway to a Cloud deployment injects a scoped inference credential into that deployment, so your app can call `/v1` without you managing a key by hand.
+
+```bash
+curl -X POST https://varity.app/api/ai-gateway/attachments \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: attach-my-app-001" \
+  -d '{ ... }'
+```
+
+`Idempotency-Key` is **required** on attach, detach, and rotate. All three return `202`. Attachment ids match `vai_[A-Za-z0-9_-]{20,64}`.
+
+```bash
+curl https://varity.app/api/ai-gateway/attachments \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+
+curl -X POST https://varity.app/api/ai-gateway/attachments/$ATTACHMENT_ID/rotate \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Idempotency-Key: rotate-my-app-001"
+```
+
+These routes accept either an API key or a Developer Portal session.
+
+## Errors And Rate Limits
+
+Every platform-API error returns the same envelope:
+
+```json
+{
+  "code": "authentication_required",
+  "message": "A Bearer API key is required.",
+  "action": "Send Authorization: Bearer <VARITY_API_KEY>.",
+  "retryable": false,
+  "docs_url": "https://docs.varity.so/api/errors#authentication_required",
+  "correlation_id": "3e0dbab4-bb81-4e95-a9b6-baefeff0e52e"
+}
+```
+
+Branch on `code` and `retryable`, never on `message`. Send an `X-Request-Id` header and it comes back as `correlation_id`; include it in support requests.
+
+Rate limits are enforced per account and per class of request. Reads get 300 per minute, deployment creates get 10 per hour. Exhausting one returns `429 rate_limited` with a `Retry-After` header. Honor it.
+
+See **[API Errors](/api/errors/)** and **[Rate Limits](/api/limits/)** for the full reference.
+
 ## Endpoint Summary
 
-The OpenAPI document contains these 18 public paths:
+The live OpenAPI document at `https://varity.app/api/openapi.json` defines **33 paths and 45 operations**. This is the full list; the document itself is authoritative.
+
+### Deployments
 
 | Methods | Path | Purpose |
 |---------|------|---------|
@@ -247,21 +383,64 @@ The OpenAPI document contains these 18 public paths:
 | `GET`, `DELETE` | `/api/deployments/{deployment_id}` | Read or delete a deployment |
 | `GET` | `/api/deployments/{deployment_id}/logs` | Read deployment logs |
 | `GET` | `/api/deployments/{deployment_id}/events` | Read deployment events |
+| `GET` | `/api/deployments/{deployment_id}/health-history` | Read durable runtime and route health history |
 | `GET`, `PATCH` | `/api/deployments/{deployment_id}/env` | List environment variable keys or update values |
 | `POST` | `/api/deployments/{deployment_id}/redeploy` | Redeploy in place |
-| `POST` | `/api/deployments/{deployment_id}/restart` | Restart in place |
+| `POST` | `/api/deployments/{deployment_id}/restart` | Restart as a verified replacement |
 | `GET`, `PUT`, `DELETE` | `/api/deployments/{deployment_id}/domain` | Read, attach, or remove a custom domain |
 | `POST` | `/api/deployments/{deployment_id}/domain/verify` | Observe DNS and verify HTTPS serving |
+
+### Machines
+
+| Methods | Path | Purpose |
+|---------|------|---------|
+| `GET`, `POST` | `/api/machines` | List or create self-managed machines |
+| `GET`, `DELETE` | `/api/machines/{machine_id}` | Read or delete one machine |
+| `POST` | `/api/machines/{machine_id}/actions` | Run a bounded synchronous action |
+
+### Catalog And Pricing
+
+| Methods | Path | Purpose |
+|---------|------|---------|
+| `GET` | `/api/deployment-capabilities` | Provider-neutral deployment catalog |
+| `GET` | `/api/deployment-profiles` | Normalized profiles, prices, and availability |
+| `GET` | `/api/pricing/estimate` | Estimate fixed monthly cost |
+| `POST` | `/api/pricing/accelerator-quote` | Exact hourly GPU quote |
+| `POST` | `/api/pricing/machine-quote` | Exact machine quote |
+| `GET` | `/api/credits` | Read credit and deploy eligibility |
+
+### Templates
+
+| Methods | Path | Purpose |
+|---------|------|---------|
 | `GET` | `/api/templates` | List templates |
 | `GET` | `/api/templates/{template_id}` | Read a template |
 | `POST` | `/api/templates/{template_id}/deploy` | Deploy a template |
-| `GET` | `/api/pricing/estimate` | Estimate fixed monthly cost |
-| `GET` | `/api/credits` | Read credit and deploy eligibility |
+
+### Webhooks
+
+| Methods | Path | Purpose |
+|---------|------|---------|
 | `GET`, `POST` | `/api/webhooks` | List or create webhooks |
 | `DELETE` | `/api/webhooks/{webhook_id}` | Delete a webhook |
-| `GET`, `POST` | `/api/api-keys` | List or create API keys in the Developer Portal |
-| `DELETE` | `/api/api-keys/{key_id}` | Revoke an API key in the Developer Portal |
-| `GET` | `/api/openapi.json` | Read the live OpenAPI contract |
+
+### AI Gateway Attachments
+
+| Methods | Path | Purpose |
+|---------|------|---------|
+| `GET`, `POST` | `/api/ai-gateway/attachments` | List or create attachments |
+| `GET`, `DELETE` | `/api/ai-gateway/attachments/{attachment_id}` | Read or detach one attachment |
+| `POST` | `/api/ai-gateway/attachments/{attachment_id}/rotate` | Rotate the deployment credential |
+
+### Keys And Contract
+
+| Methods | Path | Purpose | Auth |
+|---------|------|---------|------|
+| `GET`, `POST` | `/api/api-keys` | List or create Cloud API keys | Portal session |
+| `DELETE` | `/api/api-keys/{key_id}` | Revoke an API key | Portal session |
+| `GET`, `POST` | `/api/api-keys/inference` | List or create scoped AI Gateway keys | Portal session |
+| `GET` | `/api/api-keys/audit` | List key lifecycle events | Portal session |
+| `GET` | `/api/openapi.json` | Read the live OpenAPI contract | None |
 
 <Aside type="caution">
 Public API responses use Varity product resources only. Internal implementation details are not part of this contract.
@@ -273,6 +452,9 @@ API-key management endpoints are Developer Portal session routes in v1. API keys
 
 ## Next Steps
 
+- **[API Errors](/api/errors/)**: the error envelope and every error code
+- **[Rate Limits](/api/limits/)**: budgets, headers, and retry guidance
+- **[AI Gateway](/ai-gateway/)**: the OpenAI-compatible `/v1` inference surface
 - **[MCP Server Spec](/ai-tools/mcp-server-spec/)**: the tool reference for AI editors
 - **[Deploy a Docker Image](/deploy/deploy-docker-image/)**: image-deploy details
 - **[Environment Variables](/deploy/env-variables/)**: runtime configuration

--- a/src/content/docs/ai-tools/api-reference.mdx
+++ b/src/content/docs/ai-tools/api-reference.mdx
@@ -26,11 +26,21 @@ Older thin-client compatibility routes are not the public resource contract. New
 
 ## Base URL And Auth
 
-All public API calls use:
+Varity exposes two public base URLs:
+
+**Platform APIs** (apps, deployments, templates, pricing, credits, API keys, webhooks — everything on this page):
 
 ```text
 https://varity.app/api
 ```
+
+**AI Gateway** (OpenAI-compatible inference — chat completions and model listing):
+
+```text
+https://varity.app/v1
+```
+
+Point any OpenAI-compatible client at `https://varity.app/v1` for inference; the `/api` routes below are the platform resource contract.
 
 For non-browser callers, send your Varity API key as a bearer credential:
 

--- a/src/content/docs/ai-tools/mcp-server-spec.mdx
+++ b/src/content/docs/ai-tools/mcp-server-spec.mdx
@@ -15,7 +15,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 
 The Varity MCP server (`@varity-labs/mcp`) gives AI editors a full set of tools for the full build and deploy workflow. It runs locally via stdio. Install the current npm package.
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 The MCP server works with **any editor that supports MCP**: Cursor, Claude Code, VS Code (Copilot), Windsurf, and more. Setup takes under a minute.
 </Aside>
 
@@ -137,7 +137,7 @@ Estimate the fixed monthly price for a deployment profile. Pricing is computed b
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `app_profile` | string | No | `web-app` | Pre-deploy estimate preset: `static-site`, `web-app`, `web-app-db`, `ai-agent-cpu`, or `ai-agent-gpu` |
-| `subdomain` | string | No | none | A live deployment's subdomain — returns that deployment's real cost (overrides `app_profile`) |
+| `subdomain` | string | No | none | A live deployment's subdomain. Returns that deployment's real cost (overrides `app_profile`) |
 | `has_database` | boolean | No | none | Whether the app uses a database (selects the database-inclusive estimate) |
 
 **Annotations:** `readOnlyHint: true`
@@ -462,7 +462,7 @@ https://mcp.varity.so
 
 **ChatGPT:** Settings → Connectors → Create → MCP server URL: `https://mcp.varity.so`
 
-Hosted OAuth login is in progress: hosted OAuth and per-user deployment authorization are not yet certified end to end. Until that verification passes, do not use the hosted endpoint for owner-scoped operations (deploys, env changes, deletes) — connect via the stdio package (`npx -y @varity-labs/mcp`) instead.
+Hosted OAuth login is in progress: hosted OAuth and per-user deployment authorization are not yet certified end to end. Until that verification passes, do not use the hosted endpoint for owner-scoped operations (deploys, env changes, deletes). Connect via the stdio package (`npx -y @varity-labs/mcp`) instead.
 
 ### Self-Hosted HTTP
 

--- a/src/content/docs/ai-tools/mcp-server-spec.mdx
+++ b/src/content/docs/ai-tools/mcp-server-spec.mdx
@@ -132,18 +132,17 @@ Search Varity docs for guides, API references, and tutorials.
 
 ### `varity_cost_calculator`: Estimate costs
 
-Estimate the monthly price for your deployment profile.
+Estimate the fixed monthly price for a deployment profile. Pricing is computed by the Varity pricing service, so this tool, the CLI, and the portal render identical numbers.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `users` | number | Yes | none | Estimated monthly active users |
-| `storage_gb` | number | No | 10 | Storage needed in GB |
-| `has_database` | boolean | No | true | Whether the app uses a database |
-| `has_auth` | boolean | No | true | Whether the app uses authentication |
+| `app_profile` | string | No | `web-app` | Pre-deploy estimate preset: `static-site`, `web-app`, `web-app-db`, `ai-agent-cpu`, or `ai-agent-gpu` |
+| `subdomain` | string | No | none | A live deployment's subdomain — returns that deployment's real cost (overrides `app_profile`) |
+| `has_database` | boolean | No | none | Whether the app uses a database (selects the database-inclusive estimate) |
 
 **Annotations:** `readOnlyHint: true`
 
-**Example prompt:** "How much would it cost to host a SaaS app with 500 users on Varity?"
+**Example prompt:** "How much would it cost to host a web app with a database on Varity?"
 
 ---
 
@@ -401,7 +400,7 @@ Here is the practical build-and-deploy flow using the MCP tools:
 
 1. **"Check if my environment is ready"** → `varity_doctor`
 2. **"Install dependencies"** → `varity_install_deps`
-3. **"What will this cost for 200 users?"** → `varity_cost_calculator`
+3. **"What will this cost per month?"** → `varity_cost_calculator`
 4. **"Start the dev server"** → `varity_dev_server` → `varity_open_browser`
 5. **"Build for production"** → `varity_build`
 6. **"Deploy this"** → `varity_deploy`
@@ -463,7 +462,7 @@ https://mcp.varity.so
 
 **ChatGPT:** Settings → Connectors → Create → MCP server URL: `https://mcp.varity.so`
 
-The first time you connect, you'll authenticate via the Varity login page.
+Hosted OAuth login is in progress: hosted OAuth and per-user deployment authorization are not yet certified end to end. Until that verification passes, do not use the hosted endpoint for owner-scoped operations (deploys, env changes, deletes) — connect via the stdio package (`npx -y @varity-labs/mcp`) instead.
 
 ### Self-Hosted HTTP
 

--- a/src/content/docs/ai-tools/overview.mdx
+++ b/src/content/docs/ai-tools/overview.mdx
@@ -18,7 +18,7 @@ Varity is built to be driven from your AI coding tool. Add the MCP server once, 
 ## Available Tools
 
 <CardGrid>
-  <Card title="MCP Server" icon="rocket">
+  <Card title="MCP Server">
     Model Context Protocol server for Cursor, Claude Code, VS Code, and Windsurf. Deploy, search docs, and manage apps from your AI editor.
 
     [View Spec →](/ai-tools/mcp-server-spec)
@@ -67,14 +67,14 @@ AI assistants can reference our documentation in machine-readable formats:
 | `llms.txt` | `https://docs.varity.so/llms.txt` | Summary: what Varity is, key APIs, common patterns |
 | `llms-full.txt` | `https://docs.varity.so/llms-full.txt` | Detailed: full documentation content for deep context |
 
-Point any AI tool at one of these URLs for instant Varity context. Use `llms.txt` for quick context in chat-based LLMs (ChatGPT, Gemini), and `llms-full.txt` when the AI needs comprehensive documentation.
+Point any AI tool at one of these URLs for instant Varity context. Use `llms.txt` for quick context in chat-based LLMs (ChatGPT, Gemini), and `llms-full.txt` when the AI needs the full text.
 
 ## AI-Friendly Patterns
 
 When you point an AI tool at Varity's LLM-optimized docs, it learns to use developer-friendly language:
 
 - "Deploy your application" (not platform-specific hosting terms)
-- "Sign in" (the user just sees a normal login screen)
+- "Sign in" (the user sees a normal login screen)
 - "Your backend is configured automatically" (no infrastructure jargon)
 
 It also learns the real deploy flow: detect the framework, choose the hosting mode, auto-wire any databases or caches your app needs, and return a live URL, all without changing your code.

--- a/src/content/docs/ai-tools/prompts.mdx
+++ b/src/content/docs/ai-tools/prompts.mdx
@@ -5,7 +5,7 @@ description: Ready-to-paste prompts for deploying to Varity from Claude Code, Cu
 
 Varity is built for AI coding tools. You describe what you want in plain English, and your AI assistant deploys it for you. Copy any prompt below into Claude Code, Cursor, Windsurf, or ChatGPT.
 
-You only need to connect the Varity MCP once. After that, just ask.
+You connect the Varity MCP once.
 
 ## Connect the Varity MCP (one time)
 

--- a/src/content/docs/api/errors.mdx
+++ b/src/content/docs/api/errors.mdx
@@ -1,0 +1,247 @@
+---
+title: API Errors
+description: The Varity public API error envelope, the verified error codes, and which failures are safe to retry.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import PageMeta from '../../../components/PageMeta.astro';
+
+<PageMeta
+  author="Varity Team"
+  authorRole="Core Contributors"
+  lastUpdated="August 2026"
+  stability="beta"
+/>
+
+Every error from the Varity platform API (`https://varity.app/api`) returns the same JSON envelope. Program against `code` and `retryable`; show `message` and `action` to humans.
+
+## The Error Envelope
+
+```json
+{
+  "code": "authentication_required",
+  "message": "A Bearer API key is required.",
+  "action": "Send Authorization: Bearer <VARITY_API_KEY>.",
+  "retryable": false,
+  "docs_url": "https://docs.varity.so/api/errors#authentication_required",
+  "correlation_id": "3e0dbab4-bb81-4e95-a9b6-baefeff0e52e"
+}
+```
+
+| Field | Type | Always present | Meaning |
+|-------|------|----------------|---------|
+| <span id="code"></span>`code` | string | yes | Stable machine-readable identifier. Branch on this, never on `message`. |
+| <span id="message"></span>`message` | string | yes | Human-readable statement of what went wrong. |
+| <span id="action"></span>`action` | string | yes | What the caller should actually do next. |
+| <span id="retryable"></span>`retryable` | boolean | yes | Whether retrying the same request can succeed. |
+| <span id="docs_url"></span>`docs_url` | string (uri) | yes | Deep link to this page, anchored at the code. |
+| <span id="field"></span>`field` | string | no | The offending request field, on validation failures. |
+| <span id="correlation_id"></span>`correlation_id` | string | no | Request correlation identifier. See below. |
+
+<Aside type="caution">
+`message` and `action` are written for people and may be reworded at any time. Only `code`, `retryable`, and the HTTP status are contract. Treat an unrecognized `code` as its HTTP status class.
+</Aside>
+
+## Caller Fault, Platform Fault, Provider Fault
+
+The single most useful thing about a Varity error is *whose problem it is*. The HTTP status tells you the class; `retryable` tells you whether to try again.
+
+**Caller fault: `4xx`, `retryable: false`.** Your request is wrong. Retrying the identical request produces the identical error. Fix the request, the credential, or the account state. This covers bad input (`400`, `422`), authentication (`401`), scope (`403`), missing resources (`404`), and conflicts (`409`).
+
+**Platform fault: `5xx`, `retryable: true`.** A Varity component could not answer. The request may still be valid. Retry with exponential backoff and jitter.
+
+**Provider fault: `5xx` and `409`, `retryable: true`.** A downstream compute or inference supplier was unavailable or out of capacity. Varity does not expose supplier identity in the public contract; you see it as an unavailable-or-capacity code. Retry with backoff, and for capacity errors consider a different profile.
+
+The reliable rule: **retry when and only when `retryable` is `true`.** Do not infer retryability from the status code alone. `409 gpu_capacity_unavailable` is retryable while `409 idempotency_key_reused` is not.
+
+## Error Codes
+
+Every code below is emitted by the live gateway. Statuses and `retryable` values are as implemented.
+
+### Authentication And Authorization
+
+| Code | HTTP | Retryable | Cause |
+|------|------|-----------|-------|
+| <span id="authentication_required"></span>`authentication_required` | 401 | no | No `Authorization: Bearer` header was sent. |
+| <span id="invalid_api_key"></span>`invalid_api_key` | 401 | no | The API key is invalid or revoked. |
+| <span id="api_key_owner_unbound"></span>`api_key_owner_unbound` | 401 | no | The key is not bound to an owner account. |
+| <span id="per_user_api_key_required"></span>`per_user_api_key_required` | 401 | no | The route requires a per-user API key. |
+| <span id="credential_scope_violation"></span>`credential_scope_violation` | 403 | no | The credential is valid but not scoped to this product or resource. |
+| <span id="portal_session_required"></span>`portal_session_required` | 403 | no | The route requires a Developer Portal session, not an API key. |
+| <span id="api_key_auth_unavailable"></span>`api_key_auth_unavailable` | 503 | yes | The key authentication service could not be reached. |
+| <span id="api_key_verification_unavailable"></span>`api_key_verification_unavailable` | 502/503 | yes | Key verification is temporarily unavailable. |
+
+<Aside type="note">
+API keys cannot manage other API keys. The `/api/api-keys*` routes are Developer Portal session routes; an API key on them returns `portal_session_required`.
+</Aside>
+
+### Request Validation
+
+| Code | HTTP | Retryable | Cause |
+|------|------|-----------|-------|
+| <span id="invalid_env"></span>`invalid_env` | 400 | no | Malformed environment-variable update payload. |
+| <span id="invalid_idempotency_key"></span>`invalid_idempotency_key` | 400 | no | The key is not `[A-Za-z0-9._:-]{8,128}`. |
+| <span id="invalid_run_id"></span>`invalid_run_id` | 400 | no | Malformed run identifier. |
+| <span id="invalid_webhook_url"></span>`invalid_webhook_url` | 400 | no | The webhook URL is not a public HTTPS URL. |
+| <span id="invalid_webhook_id"></span>`invalid_webhook_id` | 400 | no | Malformed webhook identifier. |
+| <span id="invalid_api_key_id"></span>`invalid_api_key_id` | 400 | no | Malformed API key identifier. |
+| <span id="invalid_inference_key_request"></span>`invalid_inference_key_request` | 400 | no | Malformed AI Gateway key request. |
+| <span id="invalid_ai_attachment_request"></span>`invalid_ai_attachment_request` | 400 | no | Malformed AI Gateway attachment request. |
+| <span id="preset_unavailable"></span>`preset_unavailable` | 400 | no | The requested resource preset cannot be served. |
+| <span id="accelerator_profile_invalid"></span>`accelerator_profile_invalid` | 422 | no | The accelerator profile selection is not valid. |
+| <span id="invalid_accelerator_quote_request"></span>`invalid_accelerator_quote_request` | 422 | no | The GPU quote request failed validation. |
+| <span id="machine_request_invalid"></span>`machine_request_invalid` | 422 | no | The machine create request failed validation. |
+| <span id="machine_quote_request_invalid"></span>`machine_quote_request_invalid` | 422 | no | The machine quote request failed validation. |
+| <span id="deployment_profile_scope_invalid"></span>`deployment_profile_scope_invalid` | 422 | no | `workload` and `execution_class` do not form a valid scope. |
+| <span id="deployment_profile_contract_invalid"></span>`deployment_profile_contract_invalid` | 422 | no | The requested profile contract version is not valid. |
+| <span id="unsupported_deployment_request"></span>`unsupported_deployment_request` | 400/422 | no | The deployment request shape is not supported. |
+
+Validation errors may carry a `field` naming the offending property.
+
+### Not Found And Conflict
+
+| Code | HTTP | Retryable | Cause |
+|------|------|-----------|-------|
+| <span id="not_found"></span>`not_found` | 404 | no | The resource does not exist or is not owned by you. |
+| <span id="deployment_not_found"></span>`deployment_not_found` | 404 | no | No such deployment for this owner. |
+| <span id="deployment_run_not_found"></span>`deployment_run_not_found` | 404 | no | No such deployment run. |
+| <span id="template_not_found"></span>`template_not_found` | 404 | no | No such template. |
+| <span id="webhook_not_found"></span>`webhook_not_found` | 404 | no | No such webhook. |
+| <span id="idempotency_key_reused"></span>`idempotency_key_reused` | 409 | no | The key was reused with a different request body. |
+| <span id="legacy_deployment_retired"></span>`legacy_deployment_retired` | 409 | no | The deployment predates the current runtime contract. |
+| <span id="legacy_run_retired"></span>`legacy_run_retired` | 410 | no | The run record is retired and permanently gone. |
+| <span id="restart_unavailable"></span>`restart_unavailable` | 409/501/503 | varies | Restart is not possible for this deployment. `503` is retryable; `409` and `501` are not. |
+| <span id="template_not_certified"></span>`template_not_certified` | 409/503 | varies | The template is not certified, or certification could not be checked. `503` is retryable; `409` is not. |
+
+<Aside type="caution">
+`idempotency_key_reused` is a `409` that is **not** retryable. It means you sent a key you already used with a *different* body. Change the key or send the original body. Replaying the identical body with the same key returns the original result, not this error.
+</Aside>
+
+### Capacity And Billing
+
+| Code | HTTP | Retryable | Cause |
+|------|------|-----------|-------|
+| <span id="billing_or_credit_required"></span>`billing_or_credit_required` | 402 | no | No payment method and no active starter credit. |
+| <span id="gpu_capacity_unavailable"></span>`gpu_capacity_unavailable` | 409 | yes | No accelerator capacity right now for the requested profile. |
+
+`gpu_capacity_unavailable` is the one common `409` you should retry. Capacity is a moving target; back off and retry, or quote a different profile.
+
+### Upstream And Platform Unavailability
+
+All of these are `retryable: true`. They mean a Varity subsystem or a downstream provider did not answer, not that your request was wrong.
+
+| Code | HTTP | Cause |
+|------|------|-------|
+| <span id="deploy_service_unavailable"></span>`deploy_service_unavailable` | 502/503 | The deploy service could not be reached. |
+| <span id="deploy_status_unavailable"></span>`deploy_status_unavailable` | 502 | Run status could not be read. |
+| <span id="deployment_read_unavailable"></span>`deployment_read_unavailable` | 502 | The deployment record could not be read. |
+| <span id="logs_unavailable"></span>`logs_unavailable` | 502/503 | The log source could not be reached. |
+| <span id="credit_state_unavailable"></span>`credit_state_unavailable` | 503 | Credit state could not be read. |
+| <span id="billing_summary_unavailable"></span>`billing_summary_unavailable` | 503 | The billing summary could not be read. |
+| <span id="webhook_state_unavailable"></span>`webhook_state_unavailable` | 503 | Webhook state could not be read. |
+| <span id="custom_domain_unavailable"></span>`custom_domain_unavailable` | 503 | Custom-domain state could not be read. |
+| <span id="gpu_quote_unavailable"></span>`gpu_quote_unavailable` | 503 | A GPU quote could not be issued. |
+| <span id="idempotency_unavailable"></span>`idempotency_unavailable` | 503 | The idempotency store could not be reached. |
+| <span id="api_key_management_unavailable"></span>`api_key_management_unavailable` | 502/503 | Key management could not be reached. |
+| <span id="ai_attachment_unavailable"></span>`ai_attachment_unavailable` | 502 | AI Gateway attachment state could not be read. |
+| <span id="env_update_failed"></span>`env_update_failed` | 5xx (varies) | The environment update did not apply. |
+| <span id="redeploy_failed"></span>`redeploy_failed` | 5xx (varies) | The redeploy did not start. |
+| <span id="deployment_delete_failed"></span>`deployment_delete_failed` | 5xx (varies) | The delete did not complete. |
+
+### Rate Limiting
+
+| Code | HTTP | Retryable | Cause |
+|------|------|-----------|-------|
+| <span id="rate_limited"></span>`rate_limited` | 429 | yes | An account rate-limit budget is exhausted. |
+
+Read the `Retry-After` header and wait. See [Rate Limits](/api/limits/) for the budgets and headers.
+
+## Responses That Do Not Use The Standard Envelope
+
+A few routes predate the envelope and answer with their own shape. They still carry a `code`, but not `retryable` or `docs_url`. Parse defensively: read `code` from the top level, and fall back to `error.code` and `detail.code`.
+
+`GET /api/deployments/{id}/health-history` on failure returns `503` with the code nested under `error`:
+
+```json
+{ "error": { "code": "history_unavailable", "message": "Runtime history is temporarily unavailable.", "retryable": true } }
+```
+
+An unrepresentable deploy request returns `422` with the code nested under `detail`:
+
+```json
+{ "detail": { "stage": "acceptance", "code": "unsupported_deployment_request", "message": "This deploy request cannot be represented by the durable operation engine." } }
+```
+
+An unknown pricing profile or preset returns `400` and fails closed by returning the valid menu, using `error` in place of `message`:
+
+```json
+{ "code": "profile_unknown", "error": "Unknown pricing profile \"bogus\"", "profiles": ["web-app"], "presets": ["starter"] }
+```
+
+The `preset_unknown` code follows the same shape. All of these are caller-fault except `history_unavailable`, which is retryable.
+
+These codes are real and you will see them, but they are not in the table above because they do not use the envelope:
+
+| code | HTTP | shape | retryable |
+|---|---|---|---|
+| <span id="profile_unknown"></span>`profile_unknown` | 400 | top-level `code` + `error`, plus the valid `profiles` and `presets` menu | no |
+| <span id="preset_unknown"></span>`preset_unknown` | 400 | top-level `code` + `error`, plus the valid `presets` menu | no |
+| <span id="history_unavailable"></span>`history_unavailable` | 503 | nested under `error` | yes |
+| <span id="unsupported_deployment_request"></span>`unsupported_deployment_request` | 422 | nested under `detail` | no |
+
+## Partial Reads Are Not Errors
+
+Log, event, and health reads return `200` with a `complete` flag rather than failing when the live source is briefly unavailable. When `complete` is `false` the window may be partial and a `warning_code` is set (`logs_incomplete`, `events_incomplete`). This is a successful response describing an incomplete window. Retry the read for a complete one; do not treat it as a failure.
+
+## Correlation IDs
+
+Every error carries a `correlation_id` when one is available. It is the single most useful thing you can give support.
+
+**Supply your own.** Send an `X-Request-Id` header and the platform echoes that exact value back as `correlation_id`:
+
+```bash
+curl https://varity.app/api/credits \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "X-Request-Id: my-service-20260822-0001"
+```
+
+```json
+{ "code": "authentication_required", "correlation_id": "my-service-20260822-0001" }
+```
+
+If you do not send one, the platform assigns a UUID. Log `correlation_id` on every non-2xx response alongside your own request context. When you open a support request, include it. With it, a failure is traceable end to end; without it, it usually is not.
+
+## Handling Errors In Code
+
+```python
+import time, random, requests
+
+def call(method, url, **kw):
+    for attempt in range(5):
+        r = requests.request(method, url, **kw)
+        if r.status_code < 400:
+            return r.json()
+
+        err = r.json()
+        if not err.get("retryable"):
+            raise RuntimeError(
+                f"{err['code']}: {err['message']} "
+                f"({err['action']}) correlation_id={err.get('correlation_id')}"
+            )
+
+        # Honor the server's window when it gives one.
+        wait = float(r.headers.get("Retry-After", 2 ** attempt))
+        time.sleep(wait + random.uniform(0, 0.5))
+
+    raise RuntimeError("retries exhausted")
+```
+
+<Aside type="note">
+The envelope covers routes in the published contract. A request to a path that is not a Varity API route is handled by the edge router and can return an HTML `404` rather than this JSON envelope. Always check `Content-Type` before parsing an error body.
+</Aside>
+
+## Next Steps
+
+- **[Rate Limits](/api/limits/)**: budgets, headers, and retry guidance
+- **[Public API Reference](/ai-tools/api-reference/)**: endpoints and examples
+- **[AI Gateway](/ai-gateway/)**: the OpenAI-compatible inference surface, which has its own error shape

--- a/src/content/docs/api/limits.mdx
+++ b/src/content/docs/api/limits.mdx
@@ -1,0 +1,134 @@
+---
+title: Rate Limits
+description: Varity public API rate-limit budgets, the response headers clients can program against, and how to retry correctly.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import PageMeta from '../../../components/PageMeta.astro';
+
+<PageMeta
+  author="Varity Team"
+  authorRole="Core Contributors"
+  lastUpdated="August 2026"
+  stability="beta"
+/>
+
+The Varity platform API (`https://varity.app/api`) enforces rate limits per account. When a budget is exhausted the request fails with `429` and the `rate_limited` error code.
+
+## Budgets Are Per Account And Per Class
+
+Limits are keyed to the **authenticated account**, not to the API key, the route, or the client IP. Two keys owned by the same account draw from the same budgets, and so does a Developer Portal session for that account.
+
+Requests are grouped into classes, and each class has its own budget. A budget is shared across **every route in that class**. Exhausting the read budget on `/api/deployments` also blocks `/api/credits`.
+
+| Class | Budget | Window | Covers |
+|-------|--------|--------|--------|
+| Read | 300 requests | 1 minute | Listing and reading deployments, machines, templates, credits, profiles, capabilities, keys, attachments |
+| Quote | 120 requests | 1 minute | `/api/pricing/estimate`, `/api/pricing/accelerator-quote`, `/api/pricing/machine-quote` |
+| Logs | 120 requests | 1 minute | `/api/deployments/{id}/logs` and `/api/deployments/{id}/events` |
+| Stop | 120 requests | 1 minute | Deleting deployments and machines, revoking API keys |
+| Deploy create | 10 requests | 1 hour | `POST /api/deployments`, `POST /api/templates/{id}/deploy`, `POST /api/machines` |
+| Mutation | 30 requests | 1 hour | Redeploy, restart, env updates, webhooks, key creation, AI Gateway attachments |
+
+Two of these deserve explanation.
+
+**Quotes are cheap on purpose.** A price quote allocates nothing and changes nothing, so it draws from a generous per-minute budget rather than the hourly mutation budget. Comparing prices across profiles will not exhaust your ability to manage running resources.
+
+**Stopping is never throttled into unavailability.** Delete and credential revocation are safety controls. A resource you cannot turn off keeps billing, and a leaked key you cannot revoke stays live. These get their own generous per-minute budget and never draw from the hourly create budget.
+
+<Aside type="caution">
+The deploy-create budget is **10 per hour**. It is the tightest limit on the platform. If you are provisioning in bulk, pace your creates and treat `429` on a create as expected backpressure, not an error condition.
+</Aside>
+
+## Response Headers
+
+Limited routes return standard `RateLimit-*` headers. Program against these rather than hardcoding the numbers above. The headers are authoritative for your account at that moment.
+
+| Header | Meaning |
+|--------|---------|
+| `RateLimit-Limit` | Requests allowed in the current window for this class. |
+| `RateLimit-Remaining` | Requests left in the current window. |
+| `RateLimit-Reset` | Seconds until the window resets. |
+| `Retry-After` | On a `429` only: seconds to wait before retrying. |
+
+Legacy `X-RateLimit-*` headers are **not** emitted. Do not depend on them.
+
+<Aside type="note">
+Rate limiting runs **after** authentication. An unauthenticated request is rejected with `401` before it reaches a limiter, so `401` responses carry no `RateLimit-*` headers. You will only see these headers on requests that authenticated successfully.
+</Aside>
+
+Every response, limited or not, carries an `x-request-id` header. Send your own `X-Request-Id` and it is echoed back as `correlation_id` in any error body. See [API Errors](/api/errors/).
+
+## The 429 Response
+
+```json
+{
+  "code": "rate_limited",
+  "message": "Too many deployment requests.",
+  "action": "This budget is shared across your whole account for this class of request. Wait for the window in the retry-after header.",
+  "retryable": true,
+  "docs_url": "https://docs.varity.so/api/errors#rate_limited",
+  "correlation_id": "..."
+}
+```
+
+The `message` names the class that was exhausted: `Too many API requests.`, `Too many deployment requests.`, `Too many pricing requests.`, `Too many stop requests.`, `Too many mutation requests.`, or `Too many log requests.`
+
+`rate_limited` is always `retryable: true`. Retrying a *different* route in the same class will not help; the budget is shared. Wait out the window.
+
+## Retrying Correctly
+
+Honor `Retry-After`. It is the server's own statement of when the window opens, and it can be much longer than a naive backoff would guess. Hourly-window classes can return waits of many minutes.
+
+```python
+import time, random, requests
+
+def call(method, url, **kw):
+    for attempt in range(6):
+        r = requests.request(method, url, **kw)
+        if r.status_code != 429:
+            return r
+
+        # The server knows when the window opens. Trust it.
+        wait = float(r.headers.get("Retry-After", 2 ** attempt))
+        time.sleep(wait + random.uniform(0, 1))  # jitter to avoid a thundering herd
+
+    raise RuntimeError("rate limit not cleared")
+```
+
+Two rules that matter in practice:
+
+1. **Add jitter.** Fleets that all read `Retry-After: 60` and wake together re-exhaust the budget instantly.
+2. **Pace proactively.** When `RateLimit-Remaining` approaches zero, slow down before you get a `429` rather than after.
+
+## Retries And Duplicate Resources
+
+Retrying a create after a `429` is safe only if it is idempotent. Send an `Idempotency-Key` on every create so a retry cannot produce a second deployment or machine:
+
+```bash
+curl -X POST https://varity.app/api/deployments \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: deploy-my-app-001" \
+  -d '{ "name": "my-app", "repository": { "url": "https://github.com/me/my-app" } }'
+```
+
+Keys match `[A-Za-z0-9._:-]` and are at most 160 characters. Records are retained for 24 hours. Replaying the same key with the same body returns the original result; reusing it with a *different* body returns `409 idempotency_key_reused`. See [API Errors](/api/errors/#not-found-and-conflict).
+
+## Other Limits
+
+Some limits are enforced by the resource contract rather than by a request budget:
+
+- **Health history**: `GET /api/deployments/{id}/health-history` accepts `limit` with a default of 100 and a maximum of 500 observations.
+- **Idempotency keys**: 160 characters maximum, 24-hour retention.
+
+<Aside type="note">
+Account-level quotas on concurrent deployments and spend are governed by your billing state, not by these request budgets. A request that is refused for billing reasons returns `402 billing_or_credit_required`, not `429`.
+</Aside>
+
+The AI Gateway (`https://varity.app/v1`) is a separate surface with its own independent rate-limit, concurrency, and budget admission controls. Limits documented here do not apply to it. See the [AI Gateway](/ai-gateway/) docs.
+
+## Next Steps
+
+- **[API Errors](/api/errors/)**: the error envelope and every verified error code
+- **[Public API Reference](/ai-tools/api-reference/)**: endpoints and examples

--- a/src/content/docs/cli/commands/auth.mdx
+++ b/src/content/docs/cli/commands/auth.mdx
@@ -138,7 +138,7 @@ The config file may contain:
 | `gateway_api_key` | API key for the Varity gateway (auto-configured) |
 | `jwt_secret` | Database credentials (auto-configured) |
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 Deploy keys can bundle multiple credentials. When you paste a key from the developer portal, the CLI automatically extracts and saves all associated credentials (gateway key, database credentials) in one step.
 </Aside>
 

--- a/src/content/docs/cli/commands/deploy.mdx
+++ b/src/content/docs/cli/commands/deploy.mdx
@@ -63,8 +63,8 @@ varitykit app deploy --hosting dynamic
 - Persistent storage
 - Up to a fixed monthly maximum per app, prorated by running time. An unchanged profile does not cost more as traffic grows
 
-<Aside type="tip">
-Dynamic hosting is powered by cloud compute. Use `--hosting dynamic` for server-side frameworks (Next.js API routes, Express, etc.). Static hosting remains the default.
+<Aside type="tip" icon="approve-check">
+Dynamic hosting is powered by cloud compute. `--hosting` defaults to `auto`, which detects the framework and picks static or dynamic for you. Pass `--hosting dynamic` to force it for server-side frameworks (Next.js API routes, Express, and similar).
 </Aside>
 
 ## Options
@@ -167,7 +167,7 @@ varitykit app info deploy-1737492000
 Remove a deployment:
 
 ```bash
-varitykit app delete deploy-1737492000 --yes
+varitykit app delete my-app --yes
 ```
 
 ## Troubleshooting

--- a/src/content/docs/cli/commands/doctor.mdx
+++ b/src/content/docs/cli/commands/doctor.mdx
@@ -129,7 +129,7 @@ If the Memory check reports a warning (requires 3GB available), you can safely c
 
 On WSL, run `wsl --shutdown` and reopen to reclaim memory from the host OS if needed.
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 Run `varitykit doctor --fix` to automatically fix common issues like missing directories or configuration files.
 </Aside>
 

--- a/src/content/docs/cli/overview.mdx
+++ b/src/content/docs/cli/overview.mdx
@@ -18,7 +18,7 @@ VarityKit is a Python-based CLI that helps you deploy and manage applications. I
 ## What You Can Do
 
 <CardGrid>
-  <Card title="Deploy Applications" icon="rocket">
+  <Card title="Deploy Applications">
     Deploy supported Node, Python, Go, static, and Docker workloads with one command.
   </Card>
   <Card title="Migrate from Vercel" icon="seti:config">
@@ -117,7 +117,7 @@ Options:
 - **Python**: 3.11 or higher
 - **Node.js**: 20+ (for building JavaScript projects)
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 Run `varitykit doctor` to automatically check all requirements and get installation guidance for missing dependencies.
 </Aside>
 

--- a/src/content/docs/deploy/auto-wired-services.mdx
+++ b/src/content/docs/deploy/auto-wired-services.mdx
@@ -117,7 +117,7 @@ If your project includes a `prisma/schema.prisma` file, Varity reads the `dataso
 Auto-provisioned databases are in beta. They are great for getting an app running end-to-end without standing up a separate database service; bring your own managed database (via [environment variables](/deploy/env-variables)) for workloads that need durability guarantees.
 </Aside>
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 The services start automatically when you deploy. No configuration needed.
 </Aside>
 

--- a/src/content/docs/deploy/custom-domains.mdx
+++ b/src/content/docs/deploy/custom-domains.mdx
@@ -1,6 +1,6 @@
 ---
-title: App URLs and Names on Varity
-description: Set your Varity app name. Static apps use varity.app/{name}, and dynamic apps use {name}.varity.app.
+title: App URLs and Custom Domains on Varity
+description: Set your Varity app name, and attach your own domain to a deployment with a CNAME for a subdomain or an A plus TXT record for a root domain.
 ---
 
 import { Steps, Aside, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -9,15 +9,11 @@ import PageMeta from '../../../components/PageMeta.astro';
 <PageMeta
   author="Varity Team"
   authorRole="Core Contributors"
-  lastUpdated="June 2026"
+  lastUpdated="August 2026"
   stability="beta"
 />
 
-Every Varity deployment gets a public URL based on its hosting type: **static apps** are served at `https://varity.app/{name}/`, and **dynamic apps** get their own subdomain at `https://{name}.varity.app/`. This guide covers how to set a custom app name and list the `varity.app` names registered to your account.
-
-<Aside type="note">
-External custom domain support is not available yet. Use your assigned `varity.app` URL for current beta deployments.
-</Aside>
+Every Varity deployment gets a public URL based on its hosting type: **static apps** are served at `https://varity.app/{name}/`, and **dynamic apps** get their own subdomain at `https://{name}.varity.app/`. You can also attach **your own domain** to a deployment. This guide covers both.
 
 ## How Your Domain Is Assigned
 
@@ -62,9 +58,134 @@ https://my-app.varity.app/
 **Claim your name early.** Subdomain names are first-come, first-served. Once you've registered a name, it's yours as long as you have an active deployment.
 </Aside>
 
-## View Your Registered Domains
+## Attach Your Own Domain
 
-List all domains registered to your account:
+You can point a domain you own at a deployment. Both subdomains (`app.example.com`) and root domains (`example.com`) are supported.
+
+<Aside type="note">
+A deployment must serve a public web endpoint to take a custom domain, and each deployment holds **one** custom hostname at a time. Remove the current hostname before attaching a different one.
+</Aside>
+
+### From the developer portal
+
+<Steps>
+
+1. Open your deployment in the dashboard and find the **Custom domain** card.
+
+2. Enter the hostname you want to use and attach it. Varity responds with the exact DNS records to create.
+
+3. Create those records at your DNS provider, then return to the card and run the verification check.
+
+</Steps>
+
+### From the API
+
+Attach a hostname with `PUT /deployments/{deployment_id}/domain`:
+
+```bash
+curl -X PUT https://varity.app/api/deployments/$DEPLOYMENT_ID/domain \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"hostname": "app.example.com"}'
+```
+
+Read the current state at any time:
+
+```bash
+curl https://varity.app/api/deployments/$DEPLOYMENT_ID/domain \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+The response tells you whether the deployment supports a custom domain, and returns the record it is waiting for:
+
+```json
+{
+  "supported": true,
+  "domain": {
+    "hostname": "app.example.com",
+    "recordType": "cname",
+    "recordName": "app",
+    "expectedCname": "your-app.varity.app",
+    "state": "pending_dns",
+    "dns": { "status": "pending" },
+    "certificate": { "status": "pending" },
+    "serving": { "status": "pending" }
+  }
+}
+```
+
+## Create the DNS Records
+
+The records depend on whether you are attaching a subdomain or a root domain. Use the values returned by the API rather than copying the examples below.
+
+<Tabs>
+<TabItem label="Subdomain">
+
+A subdomain routes with a single CNAME record pointing at the value in `expectedCname`:
+
+| Type  | Name (Host) | Value               |
+|-------|-------------|---------------------|
+| CNAME | `app`       | `expectedCname`     |
+
+</TabItem>
+<TabItem label="Root domain">
+
+A root domain cannot hold a CNAME, so it takes an A record pointing at `expectedA`, plus the TXT record in `challenge` that proves the zone is yours. Both are required:
+
+| Type | Name (Host)      | Value              |
+|------|------------------|--------------------|
+| A    | `@`              | `expectedA`        |
+| TXT  | `challenge.name` | `challenge.value`  |
+
+</TabItem>
+</Tabs>
+
+<Aside type="caution">
+**Enter the Host field relative to your zone.** Registrars append the zone automatically, so the Host for `app.example.com` inside the zone `example.com` is `app`, not `app.example.com`. Varity returns the correct value in `recordName`, using `@` for a root domain.
+</Aside>
+
+Wildcard hostnames, IP addresses, and reserved or private-suffix hosts cannot be attached.
+
+## Verify the Domain
+
+After the records are live, ask Varity to observe DNS and confirm the domain serves over HTTPS:
+
+```bash
+curl -X POST https://varity.app/api/deployments/$DEPLOYMENT_ID/domain/verify \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+The domain moves through these states:
+
+| `state`               | Meaning                                                        |
+|-----------------------|----------------------------------------------------------------|
+| `pending_dns`         | Waiting for your DNS records to resolve to the expected values |
+| `certificate_pending` | DNS is verified; the certificate is being issued               |
+| `active`              | The domain is serving your app over HTTPS                      |
+| `error`               | A check failed; see `errorCode`                                |
+
+The `dns`, `certificate`, and `serving` blocks each carry their own `status` and `checkedAt`, so you can see which stage is outstanding. When DNS resolves to something other than the expected value, `dns.status` is `mismatch` and the `observedCnames`, `observedA`, and `observedTxt` fields show what Varity actually saw — usually the fastest way to spot a typo or a record left in place from a previous host.
+
+Two error codes are reported: `dns_lookup_failed` when the records cannot be resolved, and `https_verification_failed` when the hostname does not yet serve over HTTPS.
+
+<Aside type="tip">
+DNS changes take time to propagate. If verification fails immediately after you create the records, wait for your provider's TTL to expire and run it again.
+</Aside>
+
+## Remove a Domain
+
+Detach the hostname to free it for another deployment:
+
+```bash
+curl -X DELETE https://varity.app/api/deployments/$DEPLOYMENT_ID/domain \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+Your app stays reachable at its `varity.app` URL.
+
+## View Your Registered Names
+
+List the `varity.app` names registered to your account:
 
 ```bash
 varitykit domains list
@@ -83,7 +204,7 @@ Your Domains (2)
 ```
 
 <Aside type="tip">
-You must be logged in to list your domains. Run `varitykit login` first if you see a "Not logged in" message.
+You must be logged in to list your names. Run `varitykit login` first if you see a "Not logged in" message.
 </Aside>
 
 ## Redeploy Under the Same Name
@@ -98,15 +219,14 @@ varitykit app deploy --name my-app
 varitykit app deploy --name my-app
 ```
 
+An attached custom domain survives a redeploy. You do not need to re-create the DNS records.
+
 ## SSL / HTTPS
 
-All `varity.app` subdomains are served over HTTPS automatically. No certificate setup is required. SSL is provisioned and renewed by Varity.
-
-## External Domains
-
-External custom domains are on the roadmap, but they are not part of the current beta. Do not configure DNS records for a custom domain until the dashboard exposes that workflow.
+All `varity.app` subdomains are served over HTTPS automatically, and certificates for attached custom domains are issued and renewed by Varity once DNS is verified. No certificate setup is required in either case.
 
 ## Related
 
 - [Deploy Your App](/deploy/deploy-your-app): full deployment guide
 - [CLI Reference: deploy](/cli/commands/deploy): all `app deploy` flags
+- [API Reference](/ai-tools/api-reference): the full public platform API

--- a/src/content/docs/deploy/custom-domains.mdx
+++ b/src/content/docs/deploy/custom-domains.mdx
@@ -54,7 +54,7 @@ https://my-app.varity.app/
 - Must be unique across all Varity apps (first to register a name owns it)
 - Cannot start or end with a hyphen
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 **Claim your name early.** Subdomain names are first-come, first-served. Once you've registered a name, it's yours as long as you have an active deployment.
 </Aside>
 
@@ -164,11 +164,11 @@ The domain moves through these states:
 | `active`              | The domain is serving your app over HTTPS                      |
 | `error`               | A check failed; see `errorCode`                                |
 
-The `dns`, `certificate`, and `serving` blocks each carry their own `status` and `checkedAt`, so you can see which stage is outstanding. When DNS resolves to something other than the expected value, `dns.status` is `mismatch` and the `observedCnames`, `observedA`, and `observedTxt` fields show what Varity actually saw — usually the fastest way to spot a typo or a record left in place from a previous host.
+The `dns`, `certificate`, and `serving` blocks each carry their own `status` and `checkedAt`, so you can see which stage is outstanding. When DNS resolves to something other than the expected value, `dns.status` is `mismatch` and the `observedCnames`, `observedA`, and `observedTxt` fields show what Varity actually saw. That is usually the fastest way to spot a typo or a record left in place from a previous host.
 
 Two error codes are reported: `dns_lookup_failed` when the records cannot be resolved, and `https_verification_failed` when the hostname does not yet serve over HTTPS.
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 DNS changes take time to propagate. If verification fails immediately after you create the records, wait for your provider's TTL to expire and run it again.
 </Aside>
 
@@ -203,7 +203,7 @@ Your Domains (2)
 └─────────────┴──────────────────────────────────┴──────────────────┘
 ```
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 You must be logged in to list your names. Run `varitykit login` first if you see a "Not logged in" message.
 </Aside>
 

--- a/src/content/docs/deploy/databases.mdx
+++ b/src/content/docs/deploy/databases.mdx
@@ -52,7 +52,7 @@ Auto-wired databases are real and your data survives container restarts within a
 What this means in practice:
 
 - **Good for:** demos, prototypes, side projects, and apps that tolerate beta.
-- **For business-critical data:** bring your own external managed database (point your app at it via an environment variable) until Varity's managed-database durability ships. Your app deploys exactly the same way. It just connects to your database instead of an auto-wired one.
+- **For business-critical data:** bring your own external managed database (point your app at it via an environment variable) until Varity's managed-database durability ships. Your app deploys exactly the same way. It connects to your database instead of an auto-wired one.
 
 ## Bring Your Own Database
 

--- a/src/content/docs/deploy/deploy-docker-image.mdx
+++ b/src/content/docs/deploy/deploy-docker-image.mdx
@@ -62,7 +62,7 @@ Public and private Docker/OCI images are supported when the image starts a runna
   </TabItem>
   <TabItem label="MCP (AI coding tools)">
 
-  If you have the [Varity MCP server](/ai-tools/mcp-server-spec) installed in Claude Code, Cursor, or another AI coding tool, the `varity_deploy` tool accepts an `image` parameter (plus optional `port` and `image_credentials` for private registries). Just ask:
+  If you have the [Varity MCP server](/ai-tools/mcp-server-spec) installed in Claude Code, Cursor, or another AI coding tool, the `varity_deploy` tool accepts an `image` parameter (plus optional `port` and `image_credentials` for private registries). Ask:
 
   > "Deploy the Docker image ghcr.io/acme/my-api:1.4.2 on Varity"
 
@@ -90,7 +90,7 @@ Private images are supported in all three deploy paths:
 3. Image deploys run as dynamic apps, so your app is reachable at `https://<name>.varity.app/` (`https://varity.app/<name>` redirects there)
 4. Billing starts at deploy: up to a fixed monthly maximum for the reserved hardware, prorated by running time. It does not grow with traffic for an unchanged profile
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 Make sure your container listens on `0.0.0.0`, not `localhost`. If the app serves on a non-default port, pass `--port`.
 </Aside>
 

--- a/src/content/docs/deploy/deploy-from-dashboard.mdx
+++ b/src/content/docs/deploy/deploy-from-dashboard.mdx
@@ -63,7 +63,7 @@ A brand-new dynamic app can briefly show a connection error for a minute or two 
 Everything after deploy lives in the dashboard:
 
 <CardGrid>
-  <Card title="Status & activity" icon="rocket">
+  <Card title="Status & activity">
     See whether your app is live, and follow each deployment's progress.
   </Card>
   <Card title="Logs" icon="seti:shell">

--- a/src/content/docs/deploy/deploy-your-app.mdx
+++ b/src/content/docs/deploy/deploy-your-app.mdx
@@ -17,7 +17,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 Deploy your application to Varity from the Dashboard, CLI, or MCP server.
 
 :::note[Beta Environment]
-Varity is currently in beta. Your deployments work exactly as in production, but with test data.
+Varity is currently in beta. Deployments run on production infrastructure with real data, and every account is isolated. There are no automated backups, no high availability, and no point-in-time recovery yet. Keep your own backups for anything you cannot afford to lose.
 :::
 
 From the Dashboard, choose a GitHub repository, add environment variables, review the fixed monthly price for the reserved hardware, and deploy.
@@ -42,6 +42,7 @@ The rest of this page covers the first path: deploying your own project.
 
    ```bash
    pipx install varitykit
+   varitykit login
    ```
 
 2. **Build your project**
@@ -99,7 +100,7 @@ Choose the right hosting for your application type:
     varitykit app deploy
     ```
   </Card>
-  <Card title="Dynamic Apps" icon="rocket">
+  <Card title="Dynamic Apps">
     **Best for**: Full-stack apps, APIs, real-time applications, databases
 
     **Features**:
@@ -190,7 +191,7 @@ varitykit app deploy --name my-app
 See [App URLs & Subdomains](/deploy/custom-domains) for naming rules and the current status of bring-your-own domains.
 
 :::note[Bring your own domain]
-Pointing `myapp.com` at a Varity deployment via DNS is under development. See [App URLs & Subdomains](/deploy/custom-domains) for status.
+Pointing `myapp.com` at a Varity deployment via DNS is supported. See [App URLs & Subdomains](/deploy/custom-domains/) for the full flow.
 :::
 
 ## Troubleshooting

--- a/src/content/docs/deploy/deployment-troubleshooting.mdx
+++ b/src/content/docs/deploy/deployment-troubleshooting.mdx
@@ -51,7 +51,7 @@ This calls `varity_deploy_logs`:
 | `deployment_id` | string | Yes | The deployment ID from `varitykit app list` |
 | `limit` | number | No | Max log lines (default 100) |
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 Don't know the deployment ID? Run `varitykit app list` or call `varity_deploy_status` from your AI editor to see all deployments.
 </Aside>
 

--- a/src/content/docs/deploy/env-variables.mdx
+++ b/src/content/docs/deploy/env-variables.mdx
@@ -16,13 +16,13 @@ import PageMeta from '../../../components/PageMeta.astro';
 
 Varity manages most credentials automatically. You only need to set environment variables for services you manage yourself, like your own API keys for OpenAI, Stripe, SendGrid, and similar third-party services.
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 **No credential setup required.** Storage and service credentials are provided automatically by Varity. See [Managed Credentials](/deploy/managed-credentials) for details.
 </Aside>
 
 ## Custom Environment Variables
 
-If your app uses third-party APIs (OpenAI, Stripe, SendGrid, Resend, or any other service), you need to inject those API keys into your deployment. Varity reads them from a `.env` file during `varitykit app deploy` and passes them through to your running app.
+If your app uses third-party APIs (OpenAI, Stripe, SendGrid, Resend, or any other service), you need to inject those API keys into your deployment. Varity reads them during `varitykit app deploy` and passes them through to your running app. It looks for three filenames in precedence order: `.env.varity`, then `.env.local`, then `.env`. It uses the first one it finds.
 
 ### Step 1: Create a `.env.varity` file
 
@@ -37,7 +37,7 @@ SENDGRID_API_KEY=SG....
 MY_CUSTOM_VAR=some-value
 ```
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 `.env.varity` is the recommended file for Varity-specific production secrets. It takes precedence over `.env.local` and `.env`. Add it to your `.gitignore`.
 </Aside>
 
@@ -102,7 +102,7 @@ These variables are only needed for specific use cases:
 | `VARITY_API_URL` | Custom API endpoint | `https://varity.app` |
 | `VARITY_API_KEY` | API authentication | Auto-provided |
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 Deployment credentials for hosting (both static and dynamic) are managed automatically by Varity. No manual credential setup is needed.
 </Aside>
 
@@ -174,7 +174,7 @@ This checks:
 
 ### Variables not loading
 
-1. Check file name is exactly `.env` or `.env.local`
+1. Check the file name is one of `.env.varity`, `.env.local`, or `.env`. Those three are read, in that order, and only the first one found is used
 2. Restart your development server after changes
 3. Verify no syntax errors in the file
 4. Check framework-specific prefixes (`NEXT_PUBLIC_`, `VITE_`, etc.)

--- a/src/content/docs/deploy/managed-credentials.mdx
+++ b/src/content/docs/deploy/managed-credentials.mdx
@@ -53,8 +53,8 @@ Varity provides credentials for:
 
 During local development, shared development credentials are available automatically, so your app can connect to a database without any setup. When Varity detects that your app needs a service (for example, a database client in your dependencies), it provisions that service on deploy and injects the connection details into your app's environment.
 
-<Aside type="tip">
-Just build your app and deploy. Varity resolves and injects the credentials your app needs. You do not import an SDK or manage keys.
+<Aside type="tip" icon="approve-check">
+Build your app and deploy. Varity resolves and injects the credentials your app needs. You do not import an SDK or manage keys.
 </Aside>
 
 ## Production Deployment

--- a/src/content/docs/deploy/rollback.mdx
+++ b/src/content/docs/deploy/rollback.mdx
@@ -16,7 +16,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 If a deployment breaks your app, the way to recover today is to **redeploy a known-good version of your app**. This guide covers the recovery flow and what to watch out for.
 
 <Aside type="note">
-**One-click rollback is on the roadmap, not yet available.** There is no shipped "restore the previous live deployment" button. To recover, redeploy a working version as described below.
+**Rollback ships in the CLI: `varitykit app rollback <deployment_id> --confirm` redeploys from the stored deployment config.** There is no shipped "restore the previous live deployment" button. To recover, redeploy a working version as described below.
 </Aside>
 
 ## Recover by Redeploying a Known-Good Version
@@ -71,7 +71,7 @@ Check overall status:
 varitykit app status
 ```
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 You can also use `varity_deploy_status` from the [MCP server](/ai-tools/mcp-server-spec) to list deployments directly from your AI editor.
 </Aside>
 

--- a/src/content/docs/deploy/supported-frameworks.mdx
+++ b/src/content/docs/deploy/supported-frameworks.mdx
@@ -32,7 +32,7 @@ The following frameworks work today. Varity detects them from your project files
 ### JavaScript and TypeScript
 
 <CardGrid>
-  <Card title="Next.js" icon="rocket">
+  <Card title="Next.js">
     Full-stack React framework. Static exports and server-rendered apps both work.
 
     ```bash
@@ -41,7 +41,7 @@ The following frameworks work today. Varity detects them from your project files
     ```
   </Card>
 
-  <Card title="React" icon="rocket">
+  <Card title="React">
     Client-side React apps built with Vite or Create React App.
 
     ```bash
@@ -50,7 +50,7 @@ The following frameworks work today. Varity detects them from your project files
     ```
   </Card>
 
-  <Card title="Vue" icon="rocket">
+  <Card title="Vue">
     Vue 3 single-page applications.
 
     ```bash
@@ -59,7 +59,7 @@ The following frameworks work today. Varity detects them from your project files
     ```
   </Card>
 
-  <Card title="Astro" icon="rocket">
+  <Card title="Astro">
     Astro apps, including static documentation or content sites.
 
     ```bash
@@ -68,7 +68,7 @@ The following frameworks work today. Varity detects them from your project files
     ```
   </Card>
 
-  <Card title="Qwik" icon="rocket">
+  <Card title="Qwik">
     Qwik and QwikCity projects.
 
     ```bash
@@ -77,7 +77,7 @@ The following frameworks work today. Varity detects them from your project files
     ```
   </Card>
 
-  <Card title="Vite SPA" icon="rocket">
+  <Card title="Vite SPA">
     Vite projects are auto-detected and deployed as static apps.
 
     ```bash
@@ -86,7 +86,7 @@ The following frameworks work today. Varity detects them from your project files
     ```
   </Card>
 
-  <Card title="Express" icon="rocket">
+  <Card title="Express">
     Node.js HTTP server with Express.
 
     ```bash
@@ -95,7 +95,7 @@ The following frameworks work today. Varity detects them from your project files
     ```
   </Card>
 
-  <Card title="Fastify" icon="rocket">
+  <Card title="Fastify">
     High-performance Node.js API server.
 
     ```bash
@@ -104,7 +104,7 @@ The following frameworks work today. Varity detects them from your project files
     ```
   </Card>
 
-  <Card title="Nest.js" icon="rocket">
+  <Card title="Nest.js">
     Opinionated Node.js framework for scalable server-side apps.
 
     ```bash
@@ -113,7 +113,7 @@ The following frameworks work today. Varity detects them from your project files
     ```
   </Card>
 
-  <Card title="Koa" icon="rocket">
+  <Card title="Koa">
     Lightweight Node.js middleware framework.
 
     ```bash
@@ -122,7 +122,7 @@ The following frameworks work today. Varity detects them from your project files
     ```
   </Card>
 
-  <Card title="Hono" icon="rocket">
+  <Card title="Hono">
     Ultra-fast edge-friendly web framework for Node.js.
 
     ```bash
@@ -135,7 +135,7 @@ The following frameworks work today. Varity detects them from your project files
 ### Python
 
 <CardGrid>
-  <Card title="FastAPI" icon="rocket">
+  <Card title="FastAPI">
     Modern async Python API framework.
 
     ```bash
@@ -144,7 +144,7 @@ The following frameworks work today. Varity detects them from your project files
     ```
   </Card>
 
-  <Card title="Django" icon="rocket">
+  <Card title="Django">
     Full-featured Python web framework.
 
     ```bash
@@ -153,7 +153,7 @@ The following frameworks work today. Varity detects them from your project files
     ```
   </Card>
 
-  <Card title="Flask" icon="rocket">
+  <Card title="Flask">
     Lightweight Python web framework.
 
     ```bash
@@ -166,7 +166,7 @@ The following frameworks work today. Varity detects them from your project files
 ### Go
 
 <CardGrid>
-  <Card title="Go modules" icon="rocket">
+  <Card title="Go modules">
     Go projects with a `go.mod` file are supported.
 
     ```bash
@@ -179,7 +179,7 @@ The following frameworks work today. Varity detects them from your project files
 ### Static
 
 <CardGrid>
-  <Card title="Plain HTML" icon="rocket">
+  <Card title="Plain HTML">
     Static sites with an `index.html` file are supported.
 
     ```bash
@@ -189,7 +189,7 @@ The following frameworks work today. Varity detects them from your project files
   </Card>
 </CardGrid>
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 You do not need to tell Varity which framework you are using. It reads your `package.json`, `requirements.txt`, or project structure and figures it out.
 </Aside>
 

--- a/src/content/docs/deploy/vercel-migration.mdx
+++ b/src/content/docs/deploy/vercel-migration.mdx
@@ -29,7 +29,7 @@ All changes are backed up to `.vercel-migration-backup/` so you can roll back.
 
 The fastest path is to ask your AI editor to migrate for you.
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 This works in Cursor, Claude Code, VS Code (Copilot), and any editor with the Varity MCP server installed. See [MCP Server Setup](/ai-tools/mcp-server-spec) to install.
 </Aside>
 

--- a/src/content/docs/deploy/vercel-migration.mdx
+++ b/src/content/docs/deploy/vercel-migration.mdx
@@ -127,4 +127,4 @@ This restores all files from `.vercel-migration-backup/`.
 
 - [Deploy your app](/deploy/deploy-your-app): understand what happens during deploy
 - [Environment variables](/deploy/env-variables): how credentials work
-- [Custom domains](/deploy/custom-domains): set a custom subdomain for your app
+- [Custom domains](/deploy/custom-domains): attach your own domain to a deployment

--- a/src/content/docs/deploy/what-you-can-deploy.mdx
+++ b/src/content/docs/deploy/what-you-can-deploy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Supported App Deployment Frameworks
-description: The three Varity deployment categories — Applications (repos, Docker images, static sites), CPU VMs, and GPU workloads — plus current beta limits.
+description: The three Varity deployment categories, Applications (repos, Docker images, static sites), CPU VMs, and GPU workloads, plus current beta limits.
 ---
 
 import { Aside, CardGrid, Card } from '@astrojs/starlight/components';
@@ -19,9 +19,9 @@ Varity is a newly launched platform in active beta. This page is the honest snap
 
 Varity serves three deployment categories:
 
-1. **Applications** — deploy from a Git repository, a prebuilt Docker image, or a static build.
-2. **CPU VMs** — dedicated virtual machines; you pick the exact machine from the marketplace.
-3. **GPU workloads** — GPU containers, GPU VMs, and GPU bare metal; you pick the exact GPU offer from the marketplace.
+1. **Applications**: deploy from a Git repository, a prebuilt Docker image, or a static build.
+2. **CPU VMs**: dedicated virtual machines; you pick the exact machine from the marketplace.
+3. **GPU workloads**: GPU containers, GPU VMs, and GPU bare metal; you pick the exact GPU offer from the marketplace.
 
 ### Applications
 
@@ -55,13 +55,17 @@ See [Supported Frameworks](/deploy/supported-frameworks/) for the full detection
 
 Rent a dedicated CPU virtual machine when you need full control of the box
 rather than a managed app runtime. The VM marketplace shows the exact machines
-on offer — you choose the machine, region, and price before you deploy.
+on offer. You choose the machine, region, and price before you deploy.
+
+See [CPU virtual machines](/machines/cpu-vms/) for the 13 available sizes, prices, and regions.
 
 ### GPU workloads
 
 GPU compute comes in three forms: **GPU containers**, **GPU VMs**, and
-**GPU bare metal**. The GPU marketplace shows the exact cards on offer — you
+**GPU bare metal**. The GPU marketplace shows the exact cards on offer. You
 choose the card, region, and price before you deploy.
+
+See [GPU machines](/machines/gpu/) for the available cards, or [Deployment categories](/machines/) to compare all three.
 
 ## Not Auto-Built From Source Yet
 

--- a/src/content/docs/deploy/what-you-can-deploy.mdx
+++ b/src/content/docs/deploy/what-you-can-deploy.mdx
@@ -53,7 +53,6 @@ If you try one of those as a source project, you get a clear unsupported-stack e
 
 These aren't available in the current beta. Don't plan around them yet:
 
-- Custom domains (your app lives at its `varity.app` URL for now)
 - Rollback as a one-click feature; recover by [redeploying a known-good version](/deploy/rollback/)
 - Cron jobs and scheduled tasks
 - Preview deployments

--- a/src/content/docs/deploy/what-you-can-deploy.mdx
+++ b/src/content/docs/deploy/what-you-can-deploy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Supported App Deployment Frameworks
-description: Supported app deployment frameworks on Varity, including Node, Python, Go, static projects, Docker image services, and current beta limits.
+description: The three Varity deployment categories — Applications (repos, Docker images, static sites), CPU VMs, and GPU workloads — plus current beta limits.
 ---
 
 import { Aside, CardGrid, Card } from '@astrojs/starlight/components';
@@ -16,6 +16,14 @@ import PageMeta from '../../../components/PageMeta.astro';
 Varity is a newly launched platform in active beta. This page is the honest snapshot of what works today, what is beta, and what is not ready yet, so nothing surprises you after you deploy.
 
 ## What Deploys Today
+
+Varity serves three deployment categories:
+
+1. **Applications** — deploy from a Git repository, a prebuilt Docker image, or a static build.
+2. **CPU VMs** — dedicated virtual machines; you pick the exact machine from the marketplace.
+3. **GPU workloads** — GPU containers, GPU VMs, and GPU bare metal; you pick the exact GPU offer from the marketplace.
+
+### Applications
 
 <CardGrid>
   <Card title="Node apps" icon="seti:javascript">
@@ -43,6 +51,18 @@ See [Supported Frameworks](/deploy/supported-frameworks/) for the full detection
 - Static sites → `https://varity.app/<your-app>/`
 - Dynamic apps → `https://<your-app>.varity.app/`
 
+### CPU VMs
+
+Rent a dedicated CPU virtual machine when you need full control of the box
+rather than a managed app runtime. The VM marketplace shows the exact machines
+on offer — you choose the machine, region, and price before you deploy.
+
+### GPU workloads
+
+GPU compute comes in three forms: **GPU containers**, **GPU VMs**, and
+**GPU bare metal**. The GPU marketplace shows the exact cards on offer — you
+choose the card, region, and price before you deploy.
+
 ## Not Auto-Built From Source Yet
 
 Varity does not build these languages from source yet: **Rust, Ruby / Rails, Elixir / Phoenix, Java / Spring, Deno, PHP / Laravel, .NET.**
@@ -57,7 +77,6 @@ These aren't available in the current beta. Don't plan around them yet:
 - Cron jobs and scheduled tasks
 - Preview deployments
 - Multi-region and edge runtime
-- Dedicated GPUs for your own containers
 - A fully managed database product (see the durability note below)
 
 ## Beta Expectations
@@ -68,7 +87,7 @@ Varity is in guided beta. For demos, side projects, and apps that tolerate beta,
 
 - **Databases are real but beta.** Auto-wired databases work and data survives container restarts within a deployment, but this is not yet a managed database product with automated backups, high availability, or point-in-time recovery. See [Databases & Data](/deploy/databases/).
 - **Private repos:** the safest path for a private or unsupported app today is a prebuilt Docker image.
-- **Heavy or unusual workloads** (browser automation, large file/video processing, long-running jobs, GPU work) may need a hand. Reach out via [Getting Help](/getting-started/getting-help/).
+- **Heavy or unusual workloads** (browser automation, large file/video processing, long-running jobs) may need a hand. Reach out via [Getting Help](/getting-started/getting-help/).
 
 ## Start Deploying
 

--- a/src/content/docs/getting-started/getting-help.mdx
+++ b/src/content/docs/getting-started/getting-help.mdx
@@ -46,7 +46,7 @@ When reporting bugs, include:
 
 **Do not report security vulnerabilities publicly.**
 
-Email **security@varity.so** instead. We typically respond within 24 hours.
+Email **security@varity.so** instead. We aim to acknowledge security reports within 48 hours.
 
 ## Feedback
 

--- a/src/content/docs/getting-started/how-varity-works.mdx
+++ b/src/content/docs/getting-started/how-varity-works.mdx
@@ -107,7 +107,7 @@ Varity chooses the default based on the app type. You can force the mode with `-
 Varity is in guided beta. Use it freely for demos, side projects, AI agent apps, and apps that tolerate beta limits. Bring your own external database for business critical data until managed database durability, backups, and restore are shipped.
 </Aside>
 
-Varity currently supports Node, Python, Go, static projects, and Docker or OCI HTTP service images. Cron jobs, preview deployments, one click rollback, and dedicated GPUs for user containers are not shipped yet.
+Varity serves three deployment categories: applications (Node, Python, Go, static projects, and Docker or OCI HTTP service images), CPU VMs, and GPU workloads (containers, VMs, and bare metal). Cron jobs, preview deployments, and one click rollback are not shipped yet.
 
 ## Next Steps
 

--- a/src/content/docs/getting-started/how-varity-works.mdx
+++ b/src/content/docs/getting-started/how-varity-works.mdx
@@ -24,7 +24,7 @@ For the exact framework matrix, use [Supported Frameworks](/deploy/supported-fra
 | Input | You provide source, a GitHub repo, dashboard settings, MCP request, or Docker image | [Deploy Your App](/deploy/deploy-your-app/) |
 | Build | Varity builds supported source projects or pulls a runnable image | [Supported Frameworks](/deploy/supported-frameworks/) |
 | Configure | Varity applies hosting, variables, services, and URL defaults | [Deployment Defaults](/deploy/intelligent-orchestration/) |
-| Launch | Your app becomes available on its Varity URL | [App URLs and Names](/deploy/custom-domains/) |
+| Launch | Your app becomes available on its Varity URL | [App URLs and Custom Domains](/deploy/custom-domains/) |
 | Operate | You use logs, status, environment updates, redeploy, and support | [Troubleshooting Deploys](/deploy/deployment-troubleshooting/) |
 
 ## Deploy Lifecycle
@@ -107,7 +107,7 @@ Varity chooses the default based on the app type. You can force the mode with `-
 Varity is in guided beta. Use it freely for demos, side projects, AI agent apps, and apps that tolerate beta limits. Bring your own external database for business critical data until managed database durability, backups, and restore are shipped.
 </Aside>
 
-Varity currently supports Node, Python, Go, static projects, and Docker or OCI HTTP service images. External custom domains, cron jobs, preview deployments, one click rollback, and dedicated GPUs for user containers are not shipped yet.
+Varity currently supports Node, Python, Go, static projects, and Docker or OCI HTTP service images. Cron jobs, preview deployments, one click rollback, and dedicated GPUs for user containers are not shipped yet.
 
 ## Next Steps
 

--- a/src/content/docs/getting-started/how-varity-works.mdx
+++ b/src/content/docs/getting-started/how-varity-works.mdx
@@ -107,7 +107,7 @@ Varity chooses the default based on the app type. You can force the mode with `-
 Varity is in guided beta. Use it freely for demos, side projects, AI agent apps, and apps that tolerate beta limits. Bring your own external database for business critical data until managed database durability, backups, and restore are shipped.
 </Aside>
 
-Varity serves three deployment categories: applications (Node, Python, Go, static projects, and Docker or OCI HTTP service images), CPU VMs, and GPU workloads (containers, VMs, and bare metal). Cron jobs, preview deployments, and one click rollback are not shipped yet.
+Varity serves three deployment categories: applications (Node, Python, Go, static projects, and Docker or OCI HTTP service images), [CPU VMs](/machines/cpu-vms/), and [GPU workloads](/machines/gpu/) (containers, VMs, and bare metal). Varity also runs an [OpenAI-compatible AI Gateway](/ai-gateway/) you can call without deploying anything. Cron jobs, preview deployments, and one click rollback are not shipped yet.
 
 ## Next Steps
 

--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -66,7 +66,7 @@ The MCP server connects Varity to your AI coding tool. It gives you a full set o
   </TabItem>
 </Tabs>
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 Once the MCP server is installed, you do not need to add any code to your app to deploy it. The MCP handles the full deploy flow automatically.
 </Aside>
 

--- a/src/content/docs/getting-started/introduction.mdx
+++ b/src/content/docs/getting-started/introduction.mdx
@@ -49,7 +49,7 @@ Source deployments support Node, Python, Go, and static projects. Docker image d
 
 **Supported services:** Postgres with vector extension support, Redis, MongoDB, MySQL, object storage, and model runtime services when detected from your app.
 
-**Not shipped yet:** external custom domains, cron jobs, preview deployments, one click rollback, managed database backups and restore, and dedicated GPUs for user containers.
+**Not shipped yet:** cron jobs, preview deployments, one click rollback, managed database backups and restore, and dedicated GPUs for user containers.
 
 ## Where to Go Next
 

--- a/src/content/docs/getting-started/introduction.mdx
+++ b/src/content/docs/getting-started/introduction.mdx
@@ -49,7 +49,7 @@ Source deployments support Node, Python, Go, and static projects. Docker image d
 
 **Supported services:** Postgres with vector extension support, Redis, MongoDB, MySQL, object storage, and model runtime services when detected from your app.
 
-**Not shipped yet:** cron jobs, preview deployments, one click rollback, managed database backups and restore, and dedicated GPUs for user containers.
+**Not shipped yet:** cron jobs, preview deployments, one click rollback, and managed database backups and restore.
 
 ## Where to Go Next
 

--- a/src/content/docs/getting-started/quickstart-nextjs.mdx
+++ b/src/content/docs/getting-started/quickstart-nextjs.mdx
@@ -29,6 +29,7 @@ Deploy an existing Next.js app to Varity in one command. Varity detects your fra
 
    ```bash
    pipx install varitykit
+   varitykit login
    ```
 
 2. **Open your project**
@@ -78,7 +79,7 @@ You do not import an SDK or change your code. When Varity deploys a Next.js proj
 
 For the full list of detected frameworks and auto-wired services, see [Supported Frameworks](/deploy/supported-frameworks) and [Auto-wired Services](/deploy/auto-wired-services).
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 You do not need to wire up connection details for auto-wired services. Varity injects them into your app's environment at runtime. Set any other secrets your app needs (such as third-party or auth-provider API keys) as environment variables.
 </Aside>
 

--- a/src/content/docs/getting-started/quickstart-python.mdx
+++ b/src/content/docs/getting-started/quickstart-python.mdx
@@ -28,6 +28,7 @@ Deploy an existing Python web app to Varity in one command. Varity detects your 
 
    ```bash
    pipx install varitykit
+   varitykit login
    ```
 
 2. **Open your project**
@@ -94,7 +95,7 @@ You do not import an SDK or change your code. When Varity deploys a Python app, 
 
 For the full list of detected frameworks and auto-wired services, see [Supported Frameworks](/deploy/supported-frameworks/) and [Auto-wired Services](/deploy/auto-wired-services/).
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 You do not need to wire up connection details for auto-wired services. Varity injects them into your app's environment at runtime. Set any other secrets your app needs (such as third-party or auth-provider API keys) as environment variables.
 </Aside>
 

--- a/src/content/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/getting-started/quickstart.mdx
@@ -16,7 +16,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 Three ways to get started. Pick the one that fits where you are today.
 
 <CardGrid>
-  <Card title="Migrate an existing app" icon="rocket">
+  <Card title="Migrate an existing app">
     You already have an app on Vercel. The migration tool moves it and deploys it.
   </Card>
   <Card title="Deploy your current repo" icon="puzzle">
@@ -39,6 +39,7 @@ If you already have a Next.js, React, Vue, Node.js, Python, Astro, Qwik, or Vite
 
    ```bash
    pipx install varitykit
+   varitykit login
    ```
 
 2. **Migrate and deploy**
@@ -47,7 +48,7 @@ If you already have a Next.js, React, Vue, Node.js, Python, Astro, Qwik, or Vite
    varitykit migrate --url https://github.com/username/my-app
    ```
 
-   This clones your repository, removes any platform-specific code, and deploys your app to Varity. Your app is live at `https://varity.app/my-app/` when done.
+   This clones your repository, removes any platform-specific code, and deploys your app to Varity. `migrate` always deploys with `--hosting dynamic`, so your app is live at `https://my-app.varity.app/` when done. (Static-only projects deployed with `varitykit app deploy` live at `https://varity.app/<name>/` instead.)
 
 3. **Preview before deploying** (optional)
 
@@ -59,7 +60,7 @@ If you already have a Next.js, React, Vue, Node.js, Python, Astro, Qwik, or Vite
 
 </Steps>
 
-<Aside type="tip" title="Coming from Vercel?">
+<Aside type="tip" icon="approve-check" title="Coming from Vercel?">
 The migration tool automatically removes `vercel.json`, `@vercel/*` packages, and Vercel-specific environment variable names. Everything is backed up to `.vercel-migration-backup/` so you can roll back.
 </Aside>
 
@@ -76,7 +77,7 @@ cd my-app
 varitykit app deploy
 ```
 
-Varity auto-detects the framework and hosting mode, then returns a live URL at `https://varity.app/<app-name>/`.
+Varity auto-detects the framework and hosting mode, then returns a live URL. Static sites live at `https://varity.app/<app-name>/`; dynamic apps live at `https://<app-name>.varity.app/`.
 
 ---
 
@@ -130,7 +131,7 @@ If you are using Claude Code or Cursor, the Varity MCP server lets your AI tool 
 
 </Steps>
 
-<Aside type="tip" title="First deploy?">
+<Aside type="tip" icon="approve-check" title="First deploy?">
 The MCP server will prompt you to log in the first time. Use your email or Google account. No account setup is needed beforehand.
 </Aside>
 

--- a/src/content/docs/getting-started/why-varity.mdx
+++ b/src/content/docs/getting-started/why-varity.mdx
@@ -59,7 +59,7 @@ Use [Pricing and Costs](/resources/pricing/) for the current pricing workflow an
 Varity is in guided beta. Bring your own external managed database for business critical data until managed database durability, backups, and restore are shipped.
 </Aside>
 
-Varity may not be the right fit yet if you need cron jobs, preview deployments, one click rollback, dedicated GPUs for your own containers, or a source build for Rust, Ruby, Elixir, Java, Deno, PHP, or .NET.
+Varity may not be the right fit yet if you need cron jobs, preview deployments, one click rollback, or a source build for Rust, Ruby, Elixir, Java, Deno, PHP, or .NET.
 
 Those unsupported source stacks can still deploy when packaged as runnable Docker or OCI HTTP service images.
 

--- a/src/content/docs/getting-started/why-varity.mdx
+++ b/src/content/docs/getting-started/why-varity.mdx
@@ -34,7 +34,7 @@ Use [Pricing and Costs](/resources/pricing/) for the current pricing workflow an
   <Card title="Predictable cost" icon="approve-check-circle">
     Your bill is planned around the app profile before deploy, then stays tied to that profile as traffic changes.
   </Card>
-  <Card title="Fast deploy path" icon="rocket">
+  <Card title="Fast deploy path">
     Supported source projects and runnable images can deploy from the CLI, dashboard, or AI editor workflow.
   </Card>
   <Card title="Managed setup" icon="setting">

--- a/src/content/docs/getting-started/why-varity.mdx
+++ b/src/content/docs/getting-started/why-varity.mdx
@@ -59,7 +59,7 @@ Use [Pricing and Costs](/resources/pricing/) for the current pricing workflow an
 Varity is in guided beta. Bring your own external managed database for business critical data until managed database durability, backups, and restore are shipped.
 </Aside>
 
-Varity may not be the right fit yet if you need external custom domains today, cron jobs, preview deployments, one click rollback, dedicated GPUs for your own containers, or a source build for Rust, Ruby, Elixir, Java, Deno, PHP, or .NET.
+Varity may not be the right fit yet if you need cron jobs, preview deployments, one click rollback, dedicated GPUs for your own containers, or a source build for Rust, Ruby, Elixir, Java, Deno, PHP, or .NET.
 
 Those unsupported source stacks can still deploy when packaged as runnable Docker or OCI HTTP service images.
 

--- a/src/content/docs/guides/deploy-from-ai-ide.mdx
+++ b/src/content/docs/guides/deploy-from-ai-ide.mdx
@@ -13,7 +13,7 @@ import PageMeta from '../../../components/PageMeta.astro';
   stability="stable"
 />
 
-Varity works seamlessly with AI coding tools. Install the MCP server once, and your AI editor can build and deploy apps to production without you ever leaving the chat.
+Varity works with AI coding tools. Install the MCP server once, and your AI editor can build and deploy apps to production without you ever leaving the chat.
 
 Works with Claude Code, Cursor, Windsurf, VS Code (Copilot), and any other editor that supports the Model Context Protocol.
 

--- a/src/content/docs/guides/deploy-nextjs.mdx
+++ b/src/content/docs/guides/deploy-nextjs.mdx
@@ -16,7 +16,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 Deploy a production Next.js app with a database and a live URL. No server configuration, no environment variable setup, no infrastructure decisions.
 
 <CardGrid>
-  <Card title="Zero configuration" icon="rocket">
+  <Card title="Zero configuration">
     Varity detects your framework, wires your database, and deploys from your editor or terminal.
   </Card>
   <Card title="Predictable pricing instead of usage-metered cloud bills" icon="seti:money">
@@ -258,8 +258,8 @@ How much would it cost to host a Next.js app with 500 users on Varity?
 
 See [How pricing works](/resources/pricing) for details.
 
-<Aside type="tip">
-Varity is currently in beta. All deployments run on production-grade infrastructure, but you are working with test data and a shared environment.
+<Aside type="tip" icon="approve-check">
+Varity is currently in beta. Deployments run on production-grade infrastructure with real data, and every account is isolated. There are no automated backups, no high availability, and no point-in-time recovery yet. Keep your own backups for anything you cannot afford to lose.
 </Aside>
 
 ## Troubleshooting

--- a/src/content/docs/machines/cpu-vms.mdx
+++ b/src/content/docs/machines/cpu-vms.mdx
@@ -1,0 +1,215 @@
+---
+title: CPU Virtual Machines
+description: All 13 Varity CPU VM sizes with exact vCPU, memory, disk, hourly price, and monthly cap, plus the OS images, the create flow, and how billing stops.
+---
+
+import { Aside, Steps, LinkCard } from '@astrojs/starlight/components';
+import PageMeta from '../../../components/PageMeta.astro';
+
+<PageMeta
+  author="Varity Team"
+  authorRole="Core Contributors"
+  lastUpdated="August 2026"
+  stability="beta"
+/>
+
+A CPU VM is a machine you rent for yourself. You pick a profile, pick an OS image, send an SSH public key, and get a box you administer. Varity does not build your code, wire services, or give it a `varity.app` URL. That is [Applications](/deploy/what-you-can-deploy/).
+
+The catalog holds **26 profiles: 13 sizes in 2 regions.** Specs and price are identical in both regions. Every profile was `available` when this page was written.
+
+Values below were read from `GET /api/deployment-profiles?workload=virtual_machine&execution_class=cpu_virtual_machine` on 22 August 2026.
+
+## Dedicated CPU
+
+These profiles report `cpu_class: "dedicated"`.
+
+| Profile | vCPU | Memory | Disk | Hourly | Monthly cap |
+| --- | --- | --- | --- | --- | --- |
+| Performance S | 2 | 4 GB | 20 GB | $0.038356 | $28.00 |
+| Performance M | 4 | 8 GB | 20 GB | $0.067123 | $49.00 |
+| Performance L | 8 | 16 GB | 20 GB | $0.121918 | $89.00 |
+| Performance L-Memory | 8 | 32 GB | 20 GB | $0.205479 | $150.00 |
+| Performance XL | 16 | 32 GB | 20 GB | $0.232877 | $170.00 |
+| Performance 24 | 24 | 48 GB | 20 GB | $0.343836 | $251.00 |
+| Performance 32 | 32 | 64 GB | 20 GB | $0.453425 | $331.00 |
+| Performance 64 | 64 | 128 GB | 20 GB | $0.89726 | $655.00 |
+
+## Shared CPU
+
+These profiles report `cpu_class: "shared"`. Cheaper per vCPU.
+
+| Profile | vCPU | Memory | Disk | Hourly | Monthly cap |
+| --- | --- | --- | --- | --- | --- |
+| Shared S | 2 | 2 GB | 20 GB | $0.019178 | $14.00 |
+| Shared M | 3 | 4 GB | 20 GB | $0.026027 | $19.00 |
+| Shared L | 4 | 8 GB | 20 GB | $0.038356 | $28.00 |
+| Shared XL | 8 | 16 GB | 20 GB | $0.067123 | $49.00 |
+| Shared 2XL | 16 | 32 GB | 20 GB | $0.121918 | $89.00 |
+
+Three shared sizes cost exactly the same as a dedicated size with half the hardware:
+
+| Same hourly price | Shared | Dedicated |
+| --- | --- | --- |
+| $0.038356 | Shared L (4 vCPU / 8 GB) | Performance S (2 vCPU / 4 GB) |
+| $0.067123 | Shared XL (8 vCPU / 16 GB) | Performance M (4 vCPU / 8 GB) |
+| $0.121918 | Shared 2XL (16 vCPU / 32 GB) | Performance L (8 vCPU / 16 GB) |
+
+So pay for Performance when you need the cores to be yours, not when you need more of them.
+
+## Regions
+
+Two regions, and they are interchangeable on paper:
+
+| Region | Country |
+| --- | --- |
+| `de-frankfurt` | Germany |
+| `pl-poz` | Poland |
+
+All 13 sizes exist in both, at identical specs and identical prices. Each region has its own `profile_id`. The region is a property of the profile, not a create-time argument.
+
+## Disk
+
+**Every CPU VM profile has a 20 GB disk.** All 26 report `storage_mb: 20480`. There is no larger boot disk to choose and no size that comes with more.
+
+For more, pass `additional_storage_gb` when you request a quote and again when you create the machine. It is an integer from 0 to 32768 GB, valid **only** when `execution_class` is `cpu_virtual_machine`. Additional storage is priced into the quote's `hourly_usd`, and it bills **outside** the monthly cap.
+
+## OS Images
+
+All 26 profiles offer the same five images. Pass the `id`, not the label.
+
+| `id` | Label |
+| --- | --- |
+| `os-ubuntu-24-04-lts-x64-70031bd79dea` | Ubuntu 24.04 (LTS) x64 |
+| `os-ubuntu-22-04-lts-x64-8eff1404d444` | Ubuntu 22.04 (LTS) x64 |
+| `os-debian-12-x64-6bf00e145a61` | Debian 12 x64 |
+| `os-fedora-41-x64-f29cddf55723` | Fedora 41 x64 |
+| `os-centos-stream-10-x64-4cc111f9cdc5` | CentOS Stream 10 x64 |
+
+An image a profile does not list is rejected at create time. Read `os_images` from the profile you picked rather than hardcoding these IDs.
+
+## How the Price Is Derived
+
+The hourly rate is the monthly cap divided by 730, rounded to whole microdollars. It is not an independent number.
+
+Performance XL, verbatim from the catalog:
+
+```
+monthly_cap_microusd  170000000
+170000000 / 730     = 232876.71…
+customer_price.amount_microusd = 232877
+```
+
+That holds for all 13 sizes. So the monthly cap is exactly 730 hours of runtime, and a machine that runs every hour of a 744-hour month pays the cap, not 744 × the hourly rate. Divide `amount_microusd` by 1,000,000 for dollars.
+
+The cap covers **compute only**. Additional NVMe storage is billed on top of it.
+
+## Create a Machine
+
+<Steps>
+
+1. **Pick a profile and an image**
+
+   Read the catalog and keep the `profile_id` (format `mp-` plus 24 hex characters) and one `os_images[].id`.
+
+   ```bash
+   curl "https://varity.app/api/deployment-profiles?workload=virtual_machine&execution_class=cpu_virtual_machine" \
+     -H "Authorization: Bearer $VARITY_API_KEY"
+   ```
+
+2. **Get a quote**
+
+   ```bash
+   curl -X POST https://varity.app/api/pricing/machine-quote \
+     -H "Authorization: Bearer $VARITY_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "profile_id": "mp-0628f148846594bc2dd04c9c",
+       "execution_class": "cpu_virtual_machine",
+       "os_image": "os-ubuntu-24-04-lts-x64-70031bd79dea"
+     }'
+   ```
+
+   The response carries `quote_token`, `quote_reference`, `resource_fingerprint`, `hourly_usd`, `authorization_usd`, `valid_until`, and `pricing_policy_version`. The quote expires. Read `valid_until` and request a new one rather than retrying an old token.
+
+3. **Create the machine**
+
+   ```bash
+   curl -X POST https://varity.app/api/machines \
+     -H "Authorization: Bearer $VARITY_API_KEY" \
+     -H "Idempotency-Key: my-vm-create-001" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "name": "my-worker",
+       "profile_id": "mp-0628f148846594bc2dd04c9c",
+       "execution_class": "cpu_virtual_machine",
+       "os_image": "os-ubuntu-24-04-lts-x64-70031bd79dea",
+       "ssh_public_key": "ssh-ed25519 AAAA...",
+       "accelerator_quote_token": "<quote_token from step 2>"
+     }'
+   ```
+
+   The quote's `quote_token` is sent as **`accelerator_quote_token`**. The field name is the same for CPU VMs as for GPU machines. `name` is lowercase letters, digits, and hyphens, up to 63 characters. `Idempotency-Key` is required (8 to 128 characters).
+
+   The response is `202` with `machine_id`, `replayed`, and an `operation` block.
+
+4. **Poll until access appears**
+
+   ```bash
+   curl https://varity.app/api/machines/$MACHINE_ID \
+     -H "Authorization: Bearer $VARITY_API_KEY"
+   ```
+
+   `access` is `null` until the machine is ready, then becomes `protocol: "ssh"` with `host`, `port`, and `username`. `lifecycle.status` moves through `accepted`, `running`, and `succeeded` or `failed`.
+
+</Steps>
+
+<Aside type="caution" title="Send the public key only">
+`ssh_public_key` takes a public key. Requests carrying private key material are rejected.
+</Aside>
+
+## Connect
+
+```bash
+ssh -p <port> <username>@<host>
+```
+
+Take all three values from the machine's `access` block. There is no default username or port to assume.
+
+## Billing
+
+The machine's `billing` block reports:
+
+- `state` is `pending`, `active`, or `stopped`.
+- `customer_price` is the hourly rate, in microdollars.
+- `monthly_cap_microusd` is present **only** for `cpu_virtual_machine`.
+- `month_to_date` holds `compute_microusd` (capped), `storage_microusd` (not capped), and `month_started_at`. It is `null` until the first billed hour completes, so a new machine legitimately shows nothing.
+
+## Restart
+
+```bash
+curl -X POST https://varity.app/api/machines/$MACHINE_ID/actions \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"action": "restart"}'
+```
+
+`action` is `restart` or `soft_reboot`. Both act in place: same machine, same SSH access, same billing. Rebooting does not pause charges.
+
+## Delete
+
+<Aside type="danger" title="Shutting down the guest OS does not stop billing">
+`shutdown` or `poweroff` inside the VM stops your software, not your reservation. Deleting the machine is the only way to stop CPU VM charges.
+</Aside>
+
+```bash
+curl -X DELETE https://varity.app/api/machines/$MACHINE_ID \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+Deletion is asynchronous, and acceptance is not proof of closure. Read the machine back and check `lifecycle.cleanup_state`. It reaches `complete` when release has actually finished. Deleting destroys the disk; there is no suspend state that keeps data while stopping charges.
+
+## Related
+
+<LinkCard title="Machine Catalogs" href="/machines/" description="All four catalogs, with counts and price ranges." />
+<LinkCard title="GPU Machines" href="/machines/gpu/" description="GPU containers, GPU VMs, and GPU bare metal." />
+<LinkCard title="API Reference" href="/ai-tools/api-reference/" description="Authentication and the full endpoint surface." />

--- a/src/content/docs/machines/gpu.mdx
+++ b/src/content/docs/machines/gpu.mdx
@@ -1,0 +1,312 @@
+---
+title: GPU Machines
+description: Every card model, real hourly price, host spec, and region across the three Varity GPU execution classes (containers, VMs, and bare metal).
+---
+
+import { Aside, Steps, LinkCard } from '@astrojs/starlight/components';
+import PageMeta from '../../../components/PageMeta.astro';
+
+<PageMeta
+  author="Varity Team"
+  authorRole="Core Contributors"
+  lastUpdated="August 2026"
+  stability="beta"
+/>
+
+GPU on Varity is **three separate catalogs**, not one. They rent different things and use different endpoints. Containers also return a different profile schema.
+
+| Execution class | Profiles | You get | Created via | SSH |
+| --- | --- | --- | --- | --- |
+| `container` | 9 | One container on one GPU | `POST /api/deployments` | No |
+| `virtual_machine` | 186 | A VM with 1, 2, 4, or 8 GPUs | `POST /api/machines` | Yes |
+| `bare_metal` | 4 | A physical 8-GPU host | `POST /api/machines` | Yes |
+
+All values on this page were read from `GET /api/deployment-profiles?workload=gpu` on 22 August 2026. Every profile in all three catalogs was `available`.
+
+<Aside type="caution" title="GPU prices track available supply">
+Unlike applications and CPU VMs, GPU rates are not a fixed price list. Varity places GPU workloads on independent capacity, so which cards exist, in which regions, at which hourly rate, follows what is actually on offer at the moment you ask. The tables below are a dated snapshot, not a rate card.
+
+Read `GET /api/deployment-profiles?workload=gpu&execution_class=<class>` for the current catalog, and take the hourly figure from the quote you are about to spend against. The quote carries `valid_until` and a `resource_fingerprint`; if either the deadline passes or the configuration changes, request a fresh one.
+</Aside>
+
+<Aside type="caution" title="No monthly cap on GPU">
+The monthly cap that CPU VMs carry does not exist on GPU. `monthly_cap_microusd` is absent from every GPU profile. Any monthly figure you compute from an hourly rate is your own estimate, not a ceiling Varity enforces. A forgotten 8× H100 VM at $59.562/hour accrues about $1,429 a day.
+</Aside>
+
+## GPU Containers
+
+Nine offers, four card models. Pick one, deploy a container image onto it. There is no host to administer, no OS image to choose, and no region in the profile.
+
+| Offer | GPU model | VRAM | Interface | GPUs | Hourly |
+| --- | --- | --- | --- | --- | --- |
+| RTX 4090 24 GB | `rtx4090` | 24 GB | pcie | 1 | $1.431 |
+| A100 80 GB | `a100` | 80 GB | sxm | 1 | $2.9835 |
+| A100 80 GB | `a100` | 80 GB | sxm | 1 | $3.024 |
+| A100 80 GB | `a100` | 80 GB | sxm | 1 | $3.1185 |
+| A100 80 GB | `a100` | 80 GB | sxm | 1 | $3.294 |
+| H100 80 GB | `h100` | 80 GB | sxm | 1 | $3.6585 |
+| H200 141 GB | `h200` | 141 GB | sxm | 1 | $4.6305 |
+| H200 141 GB | `h200` | 141 GB | sxm | 1 | $4.806 |
+| H200 141 GB | `h200` | 141 GB | sxm | 1 | $5.13 |
+
+Repeated labels are separate offers with their own `id` and their own price. There are four distinct A100 offers and three distinct H200 offers. Take the cheapest one that is `available`.
+
+Container profiles differ from machine profiles field by field:
+
+- Identifier is `id` with a `gpo-` prefix, not `profile_id` with `mp-`.
+- Name is `label`, not `display_name`.
+- Price is `customer_price.hourly_usd`, a decimal in dollars, not `amount_microusd`.
+- `hardware` describes the card (`vendor`, `model`, `vram_mb`, `interface`, `count`), not a host. There are no `cpu_units`, `memory_mb`, or `storage_mb`.
+- There is no `region` and no `os_images`.
+- `availability` is an object (`status`, `matching_capacity_count`, `aggregate_available_units`, `source_age_seconds`), not a string.
+- `schema_version` is `gpu-container-profiles-v1`.
+
+Every container offer carries `price_basis: "exact"` and `pricing_policy_version: "gpu-hourly-v2-2026-07-28"`.
+
+### Deploy a GPU Container
+
+Quote it, then deploy it as an application with the GPU attached.
+
+<Steps>
+
+1. **Read the container catalog**
+
+   ```bash
+   curl "https://varity.app/api/deployment-profiles?workload=gpu&execution_class=container" \
+     -H "Authorization: Bearer $VARITY_API_KEY"
+   ```
+
+2. **Quote the offer**
+
+   ```bash
+   curl -X POST https://varity.app/api/pricing/accelerator-quote \
+     -H "Authorization: Bearer $VARITY_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "execution_class": "container",
+       "profile_id": "gpo-8057971715b95861f8775a0f"
+     }'
+   ```
+
+   Returns `quote_token`, `hourly_usd`, `authorization_usd`, and `valid_until`. Pass the token through unchanged; do not inspect or log it.
+
+3. **Create the deployment**
+
+   ```bash
+   curl -X POST https://varity.app/api/deployments \
+     -H "Authorization: Bearer $VARITY_API_KEY" \
+     -H "Idempotency-Key: gpu-container-001" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "name": "my-inference",
+       "image": { "ref": "ghcr.io/acme/infer:1.0", "port": 8000 },
+       "accelerator": {
+         "profile_id": "gpo-8057971715b95861f8775a0f",
+         "count": 1,
+         "alternatives": [
+           { "vendor": "nvidia", "model": "h100", "vram_mb": 81920, "interface": "sxm" }
+         ]
+       },
+       "accelerator_quote_token": "<quote_token from step 2>"
+     }'
+   ```
+
+   Copy `alternatives` straight out of the profile. `accelerator` and `accelerator_quote_token` must be sent together. Either one alone is rejected. `count` is 1 to 24 and `alternatives` holds 1 to 8 entries. Static-hosting deployments cannot carry an accelerator at all.
+
+</Steps>
+
+## GPU VMs
+
+186 profiles across **55 named configurations, 21 card models, and 53 regions**. Same card in a different region or on a different host is a different profile at a different price, so the spread within one name is wide. L40S 48 GB ranges from $1.431 to $5.805.
+
+Prices below come from `customer_price.amount_microusd ÷ 1,000,000`. Memory and disk are converted from `memory_mb` and `storage_mb`. "Offers" is how many profiles carry that name.
+
+### Single GPU
+
+| Profile | GPU model | VRAM | Interface | Offers | Hourly | Cheapest offer: vCPU / RAM / disk / region |
+| --- | --- | --- | --- | --- | --- | --- |
+| A30 24 GB | `a30` | 24 GB | pcie | 1 | $0.513 | 16 / 45 GB / 238 GB / `us-central-1` |
+| RTXA6000 48 GB | `rtxa6000` | 48 GB | pcie | 5 | $0.7965 to $3.78 | 6 / 22 GB / 238 GB / `us-central-2` |
+| RTX 4090 24 GB | `rtx4090` | 24 GB | pcie | 2 | $1.134 to $1.1745 | 12 / 65 GB / 792 GB / `osl1` |
+| RTX6000ADA 48 GB | `rtx6000ada` | 48 GB | pcie | 7 | $1.161 to $3.078 | 12 / 67 GB / 326 GB / `us-central-2` |
+| RTX5090 32 GB | `rtx5090` | 32 GB | pcie | 1 | $1.269 | 12 / 112 GB / 838 GB / `oslo-norway-3` |
+| L40 48 GB | `l40` | 48 GB | pcie | 5 | $1.3905 to $1.9575 | 14 / 67 GB / 582 GB / `us-central-3` |
+| L40S 48 GB | `l40s` | 48 GB | pcie | 13 | $1.431 to $5.805 | 12 / 67 GB / 582 GB / `us-central-2` |
+| RTX4000ADA 20 GB | `rtx4000ada` | 20 GB | pcie | 1 | $1.5525 | 8 / 30 GB / 466 GB / `toronto-canada-1` |
+| A4000 16 GB | `a4000` | 16 GB | pcie | 1 | $1.566 | 8 / 42 GB / 233 GB / `newyork-usa-1` |
+| L4 24 GB | `l4` | 24 GB | pcie | 2 | $1.863 | 8 / 45 GB / 466 GB / `warsaw-poland-1` |
+| A100 80 GB | `a100` | 80 GB | pcie / sxm | 16 | $2.133 to $6.426 | 28 / 112 GB / 792 GB / `canada-1` |
+| A10 24 GB | `a10` | 24 GB | pcie | 2 | $2.5245 | 30 / 186 GB / 1.3 TB / `sanjose-usa-2` |
+| A5000 24 GB | `a5000` | 24 GB | pcie | 1 | $2.781 | 8 / 42 GB / 233 GB / `newyork-usa-1` |
+| RTXPRO6000 96 GB | `rtxpro6000` | 96 GB | pcie | 6 | $3.5505 to $4.293 | 16 / 134 GB / 675 GB / `us-central-9` |
+| A40 48 GB | `a40` | 48 GB | pcie | 4 | $3.645 | 24 / 112 GB / 1.3 TB / `bangalore-india-1` |
+| GH200 96 GB | `gh200` | 96 GB | pcie | 1 | $4.4955 | 64 / 402 GB / 3.7 TB / `dulles-usa-3` |
+| V100 32 GB | `v100` | 32 GB | pcie | 1 | $4.59 | 8 / 28 GB / 233 GB / `newyork-usa-1` |
+| H100 80 GB | `h100` | 80 GB | pcie / sxm | 11 | $6.4665 to $11.745 | 24 / 224 GB / 931 GB / `paris-france-1` |
+| H200 141 GB | `h200` | 141 GB | sxm | 5 | $8.7615 to $8.7885 | 24 / 224 GB / 671 GB / `atlanta-usa-1` |
+| B200 192 GB | `b200` | 192 GB | sxm | 1 | $13.905 | 20 / 209 GB / 477 GB / `me-west-1` |
+
+A100 and H100 appear on both PCIe and SXM hosts. The interface is a property of the individual offer, so read `alternatives[0].interface` on the profile you actually pick.
+
+### Multi GPU
+
+| Profile | GPUs | VRAM each | Interface | Offers | Hourly | Cheapest offer: vCPU / RAM / region |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2x RTXA6000 48 GB | 2 | 48 GB | pcie | 3 | $1.6065 to $7.56 | 14 / 45 GB / `us-central-2` |
+| 2x A16 16 GB | 2 | 16 GB | pcie | 2 | $1.998 | 12 / 119 GB / `singapore-singapore-1` |
+| 2x RTX 4090 24 GB | 2 | 24 GB | pcie | 1 | $2.2815 | 24 / 130 GB / `osl1` |
+| 2x RTX6000ADA 48 GB | 2 | 48 GB | pcie | 4 | $2.322 to $3.807 | 26 / 134 GB / `us-central-3` |
+| 2x L40 48 GB | 2 | 48 GB | pcie | 5 | $2.781 to $3.915 | 26 / 134 GB / `us-central-3` |
+| 2x L40S 48 GB | 2 | 48 GB | pcie | 8 | $2.8485 to $11.4885 | 24 / 134 GB / `us-central-2` |
+| 2x A4000 16 GB | 2 | 16 GB | pcie | 1 | $3.132 | 16 / 84 GB / `newyork-usa-1` |
+| 2x L4 24 GB | 2 | 24 GB | pcie | 2 | $3.726 | 16 / 89 GB / `warsaw-poland-1` |
+| 2x A100 80 GB | 2 | 80 GB | pcie / sxm | 6 | $4.239 to $6.8715 | 60 / 224 GB / `canada-1` |
+| 2x A5000 24 GB | 2 | 24 GB | pcie | 1 | $5.562 | 16 / 84 GB / `newyork-usa-1` |
+| 2x RTXPRO6000 96 GB | 2 | 96 GB | pcie | 4 | $7.0875 to $8.586 | 30 / 268 GB / `us-east-1` |
+| 2x V100 32 GB | 2 | 32 GB | pcie | 1 | $9.18 | 16 / 56 GB / `newyork-usa-1` |
+| 2x H100 80 GB | 2 | 80 GB | pcie / sxm | 5 | $11.826 to $16.4295 | 80 / 317 GB / `finland-2` |
+| 4x RTXA6000 48 GB | 4 | 48 GB | pcie | 2 | $3.213 to $15.1335 | 30 / 89 GB / `us-central-2` |
+| 4x A16 16 GB | 4 | 16 GB | pcie | 1 | $4.023 | 24 / 238 GB / `bangalore-india-1` |
+| 4x RTX6000ADA 48 GB | 4 | 48 GB | pcie | 2 | $4.6305 to $7.6005 | 52 / 268 GB / `us-central-2` |
+| 4x RTX 4090 24 GB | 4 | 24 GB | pcie | 1 | $4.698 | 60 / 328 GB / `oslo-norway-3` |
+| 4x L40 48 GB | 4 | 48 GB | pcie | 5 | $5.562 to $11.6775 | 50 / 268 GB / `us-central-3` |
+| 4x L40S 48 GB | 4 | 48 GB | pcie | 6 | $5.697 to $22.842 | 46 / 268 GB / `us-central-2` |
+| 4x A4000 16 GB | 4 | 16 GB | pcie | 1 | $6.2775 | 32 / 168 GB / `newyork-usa-1` |
+| 4x L4 24 GB | 4 | 24 GB | pcie | 1 | $7.452 | 32 / 179 GB / `warsaw-poland-1` |
+| 4x A100 80 GB | 4 | 80 GB | pcie | 2 | $8.478 to $10.584 | 124 / 447 GB / `canada-1` |
+| 4x A5000 24 GB | 4 | 24 GB | pcie | 1 | $11.1375 | 32 / 168 GB / `newyork-usa-1` |
+| 4x RTXPRO6000 96 GB | 4 | 96 GB | pcie | 5 | $13.716 to $17.172 | 120 / 335 GB / `finland-1` |
+| 4x V100 32 GB | 4 | 32 GB | pcie | 1 | $18.3465 | 32 / 112 GB / `newyork-usa-1` |
+| 4x H100 80 GB | 4 | 80 GB | sxm | 2 | $23.409 to $23.652 | 176 / 633 GB / `finland-3` |
+| 4x H200 141 GB | 4 | 141 GB | sxm | 2 | $28.755 to $28.998 | 176 / 633 GB / `finland-3` |
+| 8x RTX 4090 24 GB | 8 | 24 GB | pcie | 1 | $6.2775 | 88 / 212 GB / `casper-usa-2` |
+| 8x RTX5090 32 GB | 8 | 32 GB | pcie | 1 | $10.9755 | 120 / 212 GB / `casper-usa-2` |
+| 8x L40 48 GB | 8 | 48 GB | pcie | 3 | $12.555 to $15.687 | 252 / 432 GB / `canada-1` |
+| 8x L4 24 GB | 8 | 24 GB | pcie | 1 | $14.904 | 64 / 358 GB / `warsaw-poland-1` |
+| 8x A100 80 GB | 8 | 80 GB | pcie / sxm | 12 | $17.577 to $47.0475 | 252 / 1.7 TB / `canada-1` |
+| 8x RTXPRO6000 96 GB | 8 | 96 GB | pcie | 1 | $28.3635 | 120 / 1.4 TB / `us-central-9` |
+| 8x H100 80 GB | 8 | 80 GB | sxm | 3 | $40.149 to $59.562 | 192 / 1.6 TB / `canada-1` |
+| 8x H200 141 GB | 8 | 141 GB | sxm | 3 | $50.1795 to $57.51 | 208 / 1.7 TB / `tokyo-japan-5` |
+
+Total VRAM and price move independently. 192 GB of VRAM costs $3.213/hour as 4x RTXA6000 48 GB in `us-central-2`, or $6.2775/hour as 8x RTX 4090 24 GB in `casper-usa-2`. Multiply `accelerator.count` by `vram_mb` before comparing prices.
+
+### GPU VM Regions
+
+53 regions:
+
+`amsterdam-netherlands-2`, `atlanta-usa-1`, `austin-usa-1`, `bangalore-india-1`, `beltsville-usa-1`, `calgary-canada-1`, `canada-1`, `casper-usa-2`, `chicago-usa-2`, `chicago-usa-3`, `culpeper-usa-1`, `dallas-usa-3`, `desmoines-usa-1`, `dulles-usa-1`, `dulles-usa-3`, `eu-north-1`, `eu-west-1`, `finland-1`, `finland-2`, `finland-3`, `frankfurt-germany-7`, `houston-usa-1`, `houston-usa-2`, `jerusalem-israel-1`, `kansascity-usa-1`, `kansascity-usa-6`, `london-uk-1`, `me-west-1`, `mon1`, `montreal-canada-2`, `mumbai-india-1`, `newyork-usa-1`, `newyork-usa-2`, `osl1`, `oslo-norway-3`, `paris-france-1`, `paris-france-5`, `phoenix-usa-2`, `saltlakecity-usa-1`, `sanjose-usa-2`, `singapore-singapore-1`, `sydney-australia-1`, `tokyo-japan-1`, `tokyo-japan-5`, `toronto-canada-1`, `us-1`, `us-central-1`, `us-central-2`, `us-central-3`, `us-central-9`, `us-east-1`, `us-southeast-1`, `warsaw-poland-1`
+
+Region is a property of the profile, not a create-time argument. Filter the catalog by `region` to pick where a machine runs.
+
+### GPU VM OS Images
+
+Image choice is per profile and varies a lot: **80 of 186 profiles offer exactly one image**, and the largest offer 18. Across the catalog there are 49 distinct labels.
+
+149 of 186 profiles include at least one image whose label names a CUDA version, for example `Ubuntu 24.04 + CUDA 12.8 Open + Docker`, `ubuntu22.04_cuda12.2_shade_os`, or `Ubuntu Server 22.04 LTS R570 CUDA 12.8`. The remaining 37 do not, and some catalog images are plain OS builds (`Debian 12 Plain`, `AlmaLinux 9 Plain`, `ubuntu20.04`).
+
+Do not assume a driver or CUDA toolchain is present. Read `os_images` on the specific profile and pick the label you need.
+
+## GPU Bare Metal
+
+Four profiles. One configuration, in four regions, at one price. No hypervisor.
+
+| Region | Profile | GPUs | VRAM each | vCPU | RAM | Disk | Hourly |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `ams` | 8x RTXPRO6000 96 GB | 8 | 96 GB | 192 | 1.4 TB | 1.2 TB | $53.4735 |
+| `chicago-usa-4` | 8x RTXPRO6000 96 GB | 8 | 96 GB | 192 | 1.4 TB | 1.2 TB | $53.4735 |
+| `syd2` | 8x RTXPRO6000 96 GB | 8 | 96 GB | 192 | 1.4 TB | 1.2 TB | $53.4735 |
+| `tyo4` | 8x RTXPRO6000 96 GB | 8 | 96 GB | 192 | 1.4 TB | 1.2 TB | $53.4735 |
+
+All four offer exactly one OS image: `ubuntu24.04_cuda12.4_shade_os`. There is nothing to choose.
+
+The GPU VM catalog also carries an `8x RTXPRO6000 96 GB` at $28.3635/hour in `us-central-9`. Bare metal costs more because you get the physical host, not a VM on it.
+
+## Create a GPU VM or Bare-Metal Machine
+
+Identical to the [CPU VM flow](/machines/cpu-vms/#create-a-machine), with `execution_class` set to `virtual_machine` or `bare_metal`.
+
+<Steps>
+
+1. **Quote it**
+
+   ```bash
+   curl -X POST https://varity.app/api/pricing/machine-quote \
+     -H "Authorization: Bearer $VARITY_API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "profile_id": "mp-0157cd6e4cf82ff83291d645",
+       "execution_class": "virtual_machine",
+       "os_image": "os-ubuntu24-04-a2801be96ab2"
+     }'
+   ```
+
+   `additional_storage_gb` is **not** accepted here. It is valid only for `cpu_virtual_machine`. What the profile lists as `storage_mb` is what you get.
+
+2. **Create it before `valid_until`**
+
+   ```bash
+   curl -X POST https://varity.app/api/machines \
+     -H "Authorization: Bearer $VARITY_API_KEY" \
+     -H "Idempotency-Key: gpu-vm-create-001" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "name": "trainer-01",
+       "profile_id": "mp-0157cd6e4cf82ff83291d645",
+       "execution_class": "virtual_machine",
+       "os_image": "os-ubuntu24-04-a2801be96ab2",
+       "ssh_public_key": "ssh-ed25519 AAAA...",
+       "accelerator_quote_token": "<quote_token from step 1>"
+     }'
+   ```
+
+   The quote carries `valid_until` and a `resource_fingerprint` that binds it to that exact configuration. If either the deadline or the configuration changes, request a fresh quote rather than reusing the token.
+
+3. **Poll for access**
+
+   ```bash
+   curl https://varity.app/api/machines/$MACHINE_ID \
+     -H "Authorization: Bearer $VARITY_API_KEY"
+   ```
+
+   `access` is `null` until ready, then carries `protocol: "ssh"`, `host`, `port`, and `username`.
+
+</Steps>
+
+```bash
+ssh -p <port> <username>@<host>
+```
+
+## Billing
+
+- Every GPU profile quotes `billing_period: "hour"` in USD. The binding rate is the `hourly_usd` in the quote you accepted, not the catalog list price.
+- There is no `monthly_cap_microusd` on any GPU profile.
+- `month_to_date` reporting on the machine record is a CPU VM field. A GPU machine does not report its own running total there. Reconcile GPU spend through billing.
+- Extra storage cannot be attached to a GPU machine.
+
+## Restart and Delete
+
+```bash
+curl -X POST https://varity.app/api/machines/$MACHINE_ID/actions \
+  -H "Authorization: Bearer $VARITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"action": "restart"}'
+```
+
+`restart` and `soft_reboot` act in place. The machine keeps its identity, its access, and its billing.
+
+<Aside type="danger" title="Deleting is the only way to stop GPU billing">
+Shutting the guest OS down from inside stops your workload, not your reservation. The GPUs stay allocated and keep billing, with no cap to stop them.
+</Aside>
+
+```bash
+curl -X DELETE https://varity.app/api/machines/$MACHINE_ID \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+Deletion is asynchronous and acceptance is not proof of closure. Read the machine back and check `lifecycle.cleanup_state` for `complete`. Deletion destroys the disk. Copy anything you need off the machine first.
+
+## Related
+
+<LinkCard title="Machine Catalogs" href="/machines/" description="All four catalogs, with counts and price ranges." />
+<LinkCard title="CPU Virtual Machines" href="/machines/cpu-vms/" description="All 13 CPU VM sizes, prices, and the monthly cap." />
+<LinkCard title="API Reference" href="/ai-tools/api-reference/" description="Authentication and the full endpoint surface." />

--- a/src/content/docs/machines/index.mdx
+++ b/src/content/docs/machines/index.mdx
@@ -1,0 +1,104 @@
+---
+title: Machine Catalogs
+description: Live profile counts, regions, and hourly price ranges for the four Varity machine catalogs (CPU VMs, GPU containers, GPU VMs, and GPU bare metal).
+---
+
+import { Aside, LinkCard } from '@astrojs/starlight/components';
+import PageMeta from '../../../components/PageMeta.astro';
+
+<PageMeta
+  author="Varity Team"
+  authorRole="Core Contributors"
+  lastUpdated="August 2026"
+  stability="beta"
+/>
+
+Varity publishes **four** separate machine catalogs. Each one is a different product with a different price shape and a different way of getting a machine. Pick the catalog first.
+
+Every number on this page was read from `GET /api/deployment-profiles` on 22 August 2026.
+
+## The Four Catalogs
+
+| Catalog | `workload` | `execution_class` | Profiles | Regions | Hourly price |
+| --- | --- | --- | --- | --- | --- |
+| CPU VMs | `virtual_machine` | `cpu_virtual_machine` | 26 | 2 | $0.019178 to $0.89726 |
+| GPU containers | `gpu` | `container` | 9 | not returned | $1.431 to $5.13 |
+| GPU VMs | `gpu` | `virtual_machine` | 186 | 53 | $0.513 to $59.562 |
+| GPU bare metal | `gpu` | `bare_metal` | 4 | 4 | $53.4735 |
+
+Both query parameters are required. Every profile in all four catalogs was `available` at the time of reading.
+
+## What You Get
+
+| Catalog | You rent | How you create it | Access | Monthly cap |
+| --- | --- | --- | --- | --- |
+| CPU VMs | A CPU virtual machine, 2 to 64 vCPU | `POST /api/machines` | SSH | Yes |
+| GPU containers | A container running on one GPU | `POST /api/deployments` | Container deployment, no SSH | No |
+| GPU VMs | A VM with 1, 2, 4, or 8 attached GPUs | `POST /api/machines` | SSH | No |
+| GPU bare metal | A physical 8-GPU host, no hypervisor | `POST /api/machines` | SSH | No |
+
+Only CPU VMs carry `monthly_cap_microusd`. GPU profiles do not have a cap at all. A forgotten GPU machine accrues indefinitely.
+
+## Which One
+
+| You want to… | Use |
+| --- | --- |
+| Run a worker, daemon, database, or build agent you administer | [CPU VMs](/machines/cpu-vms/) |
+| Control the kernel or install system packages, cheaply | [CPU VMs](/machines/cpu-vms/), from $0.019178/hour |
+| Run one container on one GPU without managing a host | [GPU containers](/machines/gpu/#gpu-containers), 4 card types, $1.431 to $5.13/hour |
+| Train or fine-tune on a specific card, with SSH | [GPU VMs](/machines/gpu/#gpu-vms), 21 card models, 53 regions |
+| Get a whole 8× RTXPRO6000 host with no virtualization layer | [GPU bare metal](/machines/gpu/#gpu-bare-metal), $53.4735/hour |
+| Ship a web app and get a URL, with no machine to maintain | [Applications](/deploy/what-you-can-deploy/) |
+| Call a hosted model instead of running one | [AI Gateway](/ai-gateway/) |
+
+<Aside type="tip" icon="approve-check" title="You may not need a machine">
+Applications are a separate managed product: you bring a repo or image, Varity places it and returns a URL, and you never pick a host. Machines are the opposite. You choose the exact profile, region, and price, and you own the box.
+</Aside>
+
+## GPU Containers Use a Different Schema
+
+CPU VM, GPU VM, and GPU bare-metal profiles share one shape (`schema_version: public-machine-profile-v1`). GPU container profiles are deliberately different (`gpu-container-profiles-v1`). Do not write one parser for all four.
+
+| | Machine profiles | GPU container profiles |
+| --- | --- | --- |
+| Identifier | `profile_id`, prefix `mp-` | `id`, prefix `gpo-` |
+| Human name | `display_name` | `label` |
+| Price field | `customer_price.amount_microusd` (integer microdollars) | `customer_price.hourly_usd` (decimal dollars) |
+| Host hardware | `cpu_units`, `memory_mb`, `storage_mb` | none (card only) |
+| GPU facts | `hardware.accelerator.alternatives[]` | `hardware` and `accelerator.alternatives[]` |
+| `region` | present | not returned |
+| `os_images` | present | not returned |
+| `availability` | a string, e.g. `"available"` | an object: `status`, `matching_capacity_count`, `aggregate_available_units`, `source_age_seconds` |
+| Created via | `POST /api/machines` | `POST /api/deployments` |
+
+## Reading a Catalog
+
+```bash
+curl "https://varity.app/api/deployment-profiles?workload=virtual_machine&execution_class=cpu_virtual_machine" \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+```bash
+curl "https://varity.app/api/deployment-profiles?workload=gpu&execution_class=virtual_machine" \
+  -H "Authorization: Bearer $VARITY_API_KEY"
+```
+
+Swap `execution_class` for `container` or `bare_metal` to read the other two GPU catalogs.
+
+## Prices
+
+Every catalog quotes `billing_period: "hour"` in USD.
+
+- CPU VMs publish `amount_microusd` and `monthly_cap_microusd`. The hourly rate is the monthly cap divided by 730.
+- GPU VMs and bare metal publish `amount_microusd` only.
+- GPU containers publish `hourly_usd` directly, with `price_basis: "exact"` and `pricing_policy_version: "gpu-hourly-v2-2026-07-28"`.
+
+Catalog prices are the list rate at the moment the catalog was read. CPU VM rates are fixed: the hourly figure is the monthly cap divided by 730. GPU rates are not a fixed price list. They follow the capacity actually on offer, so the GPU figures on this page are a dated snapshot rather than a rate card. See [GPU machines](/machines/gpu/) for the detail.
+
+Before creating anything you request a quote, which returns the binding `hourly_usd`, an `authorization_usd`, and a `valid_until` timestamp.
+
+## Next
+
+<LinkCard title="CPU Virtual Machines" href="/machines/cpu-vms/" description="All 13 CPU VM sizes, both regions, exact hourly prices and monthly caps." />
+<LinkCard title="GPU Machines" href="/machines/gpu/" description="All three GPU execution classes, every card model, and real prices." />
+<LinkCard title="API Reference" href="/ai-tools/api-reference/" description="Authentication and the full endpoint surface." />

--- a/src/content/docs/resources/faq.mdx
+++ b/src/content/docs/resources/faq.mdx
@@ -26,13 +26,13 @@ Varity is a predictable cloud platform focused on deployment. The two core packa
 |---------|-----------------------|--------|
 | Pricing | Billed by usage meters (requests, bandwidth, invocations) | Up to a fixed monthly maximum per app, prorated by running time |
 | Backend services | Separate add-ons, separate bills | Auto-wired in the same deploy |
-| Auth | Configure separately | Configured automatically |
+| Auth | Configure separately | Configure separately. Varity does not manage end-user identity |
 | Setup | Build config and env wiring | Zero config, one command |
 
 ### Is my data secure?
 
 Yes. Varity uses:
-- Encryption for sensitive data in transit and at rest
+- Encryption in transit (TLS 1.2+). Platform-managed encryption at rest is in active development. See [Security](/resources/security/)
 - Automatic SSL on every deployment
 
 ### What frameworks are supported?

--- a/src/content/docs/resources/glossary.mdx
+++ b/src/content/docs/resources/glossary.mdx
@@ -88,7 +88,7 @@ The compiled output of your application (for example, the `dist/` or `.next/` fo
 
 ### Redeploy a Previous Version
 
-Varity tracks your deployment history locally. To return to an earlier version, redeploy that version of your code. This is a fresh deploy from your local history, not a managed rollback.
+Varity reads your live deployments from the server, so the same list appears from any machine. To return to an earlier version, redeploy that version of your code. This is a fresh deploy from your local history, not a managed rollback.
 
 ## Hosting Terms
 
@@ -112,6 +112,6 @@ Container-based compute for full-stack applications. Best for Next.js server-sid
 
 A global network of servers that delivers your app files from the location closest to each user. All Varity static deployments include CDN delivery automatically.
 
-<Aside type="tip">
-Not sure which hosting type your app needs? Just run `varitykit app deploy`. Varity detects it automatically.
+<Aside type="tip" icon="approve-check">
+Not sure which hosting type your app needs? Run `varitykit app deploy`. Varity detects it automatically.
 </Aside>

--- a/src/content/docs/resources/troubleshooting.mdx
+++ b/src/content/docs/resources/troubleshooting.mdx
@@ -124,7 +124,7 @@ This comes from your own auth provider, not from Varity (Varity does not maintai
 
 ### Session not persisting
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 Sessions are stored in localStorage. Private browsing or clearing storage will log users out.
 </Aside>
 

--- a/src/content/docs/tutorials/build-with-ai.mdx
+++ b/src/content/docs/tutorials/build-with-ai.mdx
@@ -15,7 +15,7 @@ import PageMeta from '../../../components/PageMeta.astro';
 
 This tutorial shows you how to build and deploy an app using only natural language prompts. You'll use your AI editor (Cursor or Claude Code) to write the app, then use Varity's MCP server to handle setup checks, the deploy workflow, and status checks.
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 The entire workflow takes 10-15 minutes, and your hosting bill stays flat instead of scaling with traffic.
 </Aside>
 
@@ -210,8 +210,6 @@ That's it. No complex infrastructure setup.
 
 ## What Just Happened?
 
-Here is what you accomplished, without writing any code yourself:
-
 1. **Built a production app**: Authentication, database, dashboard
 2. **Added a custom data model**: Invoices with create, read, update, and delete
 3. **Deployed to production**: Live URL with database and hosting configured automatically
@@ -222,8 +220,6 @@ Here is what you accomplished, without writing any code yourself:
 **Code written:** 0 lines
 
 ## Next Steps
-
-Now that you have a live app, you can:
 
 - **Add more features:** "Add a clients page with name, email, and company fields"
 - **Customize the UI:** "Change the primary color to purple"

--- a/src/content/docs/tutorials/deploy-ai-agent.mdx
+++ b/src/content/docs/tutorials/deploy-ai-agent.mdx
@@ -15,8 +15,12 @@ import PageMeta from '../../../components/PageMeta.astro';
 
 Varity automatically detects AI agent apps and configures the right hosting for them. You write the code, run one command, and your agent is live.
 
-<Aside type="tip">
+<Aside type="tip" icon="approve-check">
 If your agent uses a local language model (via the `ollama` package), Varity detects it and auto-provisions a model server alongside your app. No extra setup required.
+</Aside>
+
+<Aside type="tip" icon="approve-check" title="This uses Varity's own AI Gateway">
+The examples below point at `https://varity.app/v1`, Varity's OpenAI-compatible endpoint, so the model call and the deployment are billed to the same account and use the same key. Any OpenAI-compatible client works by changing `base_url`. See [AI Gateway](/ai-gateway/) for the model catalog, or keep your own provider's key if you prefer.
 </Aside>
 
 ## One-Click Agent Templates
@@ -78,7 +82,10 @@ This example builds a simple agent endpoint that accepts a prompt and returns a 
    import os
 
    app = FastAPI()
-   client = openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+   client = openai.OpenAI(
+       base_url="https://varity.app/v1",
+       api_key=os.environ["VARITY_API_KEY"],
+   )
 
    class PromptRequest(BaseModel):
        prompt: str
@@ -86,7 +93,7 @@ This example builds a simple agent endpoint that accepts a prompt and returns a 
    @app.post("/run")
    async def run_agent(request: PromptRequest):
        response = client.chat.completions.create(
-           model="gpt-4o-mini",
+           model="llama-3-3-70b",
            messages=[{"role": "user", "content": request.prompt}]
        )
        return {"result": response.choices[0].message.content}
@@ -109,7 +116,7 @@ This example builds a simple agent endpoint that accepts a prompt and returns a 
    Create a `.env` file in your project root:
 
    ```bash title=".env"
-   OPENAI_API_KEY=sk-...
+   VARITY_API_KEY=<your Varity API key>
    ```
 
    Varity reads this file at deploy time and injects the variable into your app's runtime environment.
@@ -156,12 +163,15 @@ This example builds an Express API that wraps the OpenAI API.
    const app = express();
    app.use(express.json());
 
-   const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+   const client = new OpenAI({
+     baseURL: 'https://varity.app/v1',
+     apiKey: process.env.VARITY_API_KEY,
+   });
 
    app.post('/run', async (req, res) => {
      const { prompt } = req.body;
      const response = await client.chat.completions.create({
-       model: 'gpt-4o-mini',
+       model: 'llama-3-3-70b',
        messages: [{ role: 'user', content: prompt }]
      });
      res.json({ result: response.choices[0].message.content });
@@ -194,7 +204,7 @@ This example builds an Express API that wraps the OpenAI API.
 3. **Add your API key**
 
    ```bash title=".env"
-   OPENAI_API_KEY=sk-...
+   VARITY_API_KEY=<your Varity API key>
    ```
 
 4. **Deploy**

--- a/src/plugins/rehype-table-scroll.mjs
+++ b/src/plugins/rehype-table-scroll.mjs
@@ -1,0 +1,30 @@
+import { visit } from 'unist-util-visit';
+
+/**
+ * Wrap markdown tables in a scrollable, keyboard-focusable region.
+ *
+ * Making the table itself `display: block` was the CSS-only way to stop wide
+ * tables widening the document, but it removes the table from the accessibility
+ * tree, so screen readers stop announcing rows and columns. Wrapping keeps the
+ * table a real table and moves the scrolling to the wrapper.
+ */
+export function rehypeTableScroll() {
+  return (tree) => {
+    visit(tree, 'element', (node, index, parent) => {
+      if (node.tagName !== 'table' || !parent || index === null) return;
+      const cls = parent.properties?.className;
+      if (Array.isArray(cls) && cls.includes('table-scroll')) return;
+      parent.children[index] = {
+        type: 'element',
+        tagName: 'div',
+        properties: {
+          className: ['table-scroll'],
+          tabIndex: 0,
+          role: 'region',
+          'aria-label': 'Scrollable table',
+        },
+        children: [node],
+      };
+    });
+  };
+}

--- a/src/styles/varity-theme.css
+++ b/src/styles/varity-theme.css
@@ -13,7 +13,9 @@
    SECTION 1: FONTS
    System fonts for performance + trust
    ======================================== */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+/* Fonts are loaded via a <link> in astro.config.mjs head.
+   As an @import here they were only discovered after this stylesheet parsed,
+   which serialised HTML -> css -> fonts.googleapis -> gstatic (1,980 ms blocking). */
 
 /* ========================================
    SECTION 2: DESIGN TOKENS
@@ -170,7 +172,7 @@
   --sl-color-gray-1: var(--gray-50);
   --sl-color-gray-2: var(--gray-200);
   --sl-color-gray-3: var(--gray-400);
-  --sl-color-gray-4: var(--gray-500);
+  --sl-color-gray-4: var(--gray-400);
   --sl-color-gray-5: var(--gray-700);
   --sl-color-gray-6: var(--gray-800);
   --sl-color-gray-7: var(--gray-900);
@@ -189,14 +191,16 @@
 
   /* ----- LAYOUT ----- */
   --header-height: 64px;
-  --sl-content-width: 48rem;  /* 768px - optimal reading width */
+  --sl-content-width: 56rem;  /* 896px: reference tables run 7-8 columns and wrapped every cell at 48rem */
   --sl-sidebar-width: 19rem;  /* 304px - even wider for better readability */
   --sl-content-pad-x: 1.5rem;
 
   --text-primary: var(--gray-50);
   --text-secondary: var(--gray-400);
-  --text-tertiary: var(--gray-500);
-  --text-muted: var(--gray-600);
+  /* gray-500 (#71717a) is 3.97:1 and gray-600 (#52525b) is 2.48:1 on the dark
+     background; both fail WCAG AA for text. gray-400 (#a1a1aa) is 7.48:1. */
+  --text-tertiary: var(--gray-400);
+  --text-muted: var(--gray-400);
 }
 
 /* ========================================
@@ -204,6 +208,12 @@
    Optional light theme support
    ======================================== */
 [data-theme="light"] {
+  /* Links use var(--color-brand) directly, so it must be overridden here.
+     #14b8a6 on white is 2.49:1 and #0d9488 is 3.74:1; both fail WCAG AA.
+     #0f766e is 5.47:1. */
+  --color-brand: #0f766e;
+  --color-brand-light: #0d9488;
+
   /* ----- STARLIGHT COLORS: BACKGROUND ----- */
   --sl-color-bg: #ffffff;
   --sl-color-bg-nav: rgba(255, 255, 255, 0.9);
@@ -212,10 +222,10 @@
 
   /* ----- STARLIGHT COLORS: TEXT ----- */
   --sl-color-text: #111827;
-  --sl-color-text-accent: var(--varity-brand-600);
+  --sl-color-text-accent: #0f766e;
 
   /* ----- STARLIGHT COLORS: ACCENT ----- */
-  --sl-color-accent: var(--varity-brand-600);
+  --sl-color-accent: #0f766e;
   --sl-color-accent-low: rgba(13, 148, 136, 0.1);
   --sl-color-accent-high: var(--varity-brand-600);
 
@@ -551,7 +561,7 @@ i {
 /* ----- LAYOUT CSS CUSTOM PROPERTIES ----- */
 :root {
   /* TOC width - wider to prevent heading wrapping */
-  --sl-toc-width: 14rem;  /* 224px - Supabase standard */
+  --sl-toc-width: 11.5rem; /* 14rem exceeded the gutter Starlight allocates below 1440px, clipping every TOC row by ~33px */  /* 224px - Supabase standard */
   /* Homepage content max width */
   --varity-homepage-max: 96rem;
 }
@@ -862,10 +872,28 @@ html[data-has-sidebar] .sl-markdown-content :is(pre, table, .expressive-code, .c
 /* Desktop (72rem+): Full 3-column layout */
 /* Handled by default Starlight + overrides above */
 
-/* Laptop (50-72rem): Hide TOC, 2-column layout */
+/* Laptop (50-72rem): drop the desktop TOC rail, 2-column layout.
+   Starlight renders BOTH the desktop TOC and <mobile-starlight-toc> inside
+   .right-sidebar-container, so hiding the container removed in-page navigation
+   at every width below 72rem. Pages here run to 20,000px. Hide the desktop
+   panel only and let the mobile TOC render. */
 @media (max-width: 72rem) {
-  .right-sidebar-container {
+  .right-sidebar-container .right-sidebar-panel:not(:has(mobile-starlight-toc)) {
     display: none;
+  }
+
+  /* The mobile TOC inside is position:fixed, so the container must not claim
+     layout width. width:100% here squeezed the content column and pushed code
+     blocks past the viewport at 1024px. */
+  .right-sidebar-container {
+    position: static;
+    width: auto;
+    padding: 0;
+    border: 0;
+  }
+
+  .right-sidebar-container mobile-starlight-toc {
+    display: block;
   }
 
   /* Expand content to fill space */
@@ -1179,11 +1207,14 @@ article.card .body {
   border: 1px solid var(--border-secondary);
   border-radius: var(--radius-md);
   color: var(--text-tertiary);
-  opacity: 0.6;
+  /* Was 0.6, which left the button opaque over the end of long code lines.
+     Expressive Code's default is hidden until hover; the hover rule restores it. */
+  opacity: 0;
   transition: all var(--transition-fast);
 }
 
-.expressive-code:hover .copy button {
+.expressive-code:hover .copy button,
+.expressive-code .copy button:focus-visible {
   opacity: 1;
 }
 
@@ -1273,12 +1304,13 @@ th, td {
 }
 
 th {
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-raised, rgba(255, 255, 255, 0.03));
   font-weight: var(--font-semibold);
   font-size: var(--text-sm);
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-wide);
-  color: var(--text-tertiary);
+  /* uppercase + wide tracking inflated headers: "Cheapest offer: vCPU / RAM /
+     disk / region" wrapped to 6 lines at 390px and 3 lines at 1280px. */
+  letter-spacing: normal;
+  color: var(--text-secondary);
 }
 
 td {
@@ -1299,17 +1331,17 @@ tr:hover td {
    Styled unordered and ordered lists
    ======================================== */
 
-.sl-markdown-content ul {
+.sl-markdown-content ul:not([role="tablist"]) {
   list-style: none;
   padding-left: var(--space-6);
 }
 
-.sl-markdown-content ul li {
+.sl-markdown-content ul:not([role="tablist"]) li {
   position: relative;
   margin-bottom: var(--space-2);
 }
 
-.sl-markdown-content ul li::before {
+.sl-markdown-content ul:not([role="tablist"]) li::before {
   content: '';
   position: absolute;
   left: calc(-1 * var(--space-4));
@@ -1627,3 +1659,64 @@ site-search kbd {
 .sl-markdown-content {
   animation: fadeInUp 0.2s ease-out;
 }
+
+/* Markdown tables must scroll inside their own box. Without this the table
+   widens the document and the whole page scrolls sideways on mobile: at 390px
+   /ai-gateway/models/ reached 1014px and 20 pages overflowed. */
+/* Tables are wrapped in .table-scroll by src/plugins/rehype-table-scroll.mjs.
+   Scrolling lives on the wrapper so the table keeps its `display: table`
+   semantics and screen readers still announce rows and columns. */
+.sl-markdown-content .table-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.sl-markdown-content .table-scroll:focus-visible {
+  outline: 2px solid var(--sl-color-text-accent);
+  outline-offset: 2px;
+}
+
+.sl-markdown-content .table-scroll > table {
+  width: max-content;
+  min-width: 100%;
+  margin: var(--space-6) 0;
+}
+
+/* Card grids must collapse to one column rather than forcing a min-width. */
+@media (max-width: 480px) {
+  .sl-markdown-content .card-grid { grid-template-columns: 1fr; }
+  .sl-markdown-content .card-grid > article.card { min-width: 0; }
+}
+
+/* ---- Mobile corrections ---- */
+@media (max-width: 50rem) {
+  /* Hover never fires on touch, so the copy button must stay visible.
+     Pad the code instead so the button does not sit on the last characters. */
+  .expressive-code .copy button { opacity: 1; }
+  .expressive-code pre > code { padding-inline-end: 3rem; }
+
+  /* Steps indented content 90px, leaving code blocks 268px wide at 390px. */
+  .sl-steps > li { padding-left: var(--space-6); margin-left: var(--space-2); }
+
+  /* Landing-page support text was 11.5px to 13.4px. */
+  .eyebrow, .section-kicker, dt { font-size: 0.8125rem; }
+  small { font-size: 0.875rem; }
+
+  /* Inline code sat at 11.375px, under the 12px legibility floor. */
+  .sl-markdown-content :is(p, li, td, th, a) > code { font-size: 0.8125rem; }
+
+  /* Tap targets: Google's guideline is 48px. */
+  .sidebar-content a { min-height: 48px; display: flex; align-items: center; }
+
+  /* Starlight tab buttons were 28px tall with no gap between them. */
+  .sl-markdown-content [role="tablist"] a,
+  .sl-markdown-content [role="tablist"] button {
+    min-height: 48px;
+    display: inline-flex;
+    align-items: center;
+  }
+}
+
+/* Light mode needs a real table-header fill; the dark rgba value is white on white. */
+[data-theme="light"] th { background: var(--gray-50, #fafafa); }


### PR DESCRIPTION
## Affected repositories
`varity-docs` only. No product code touched.

## What this does
Adds eight pages for product surfaces that shipped without documentation, and corrects claims across the existing site that live probes proved wrong.

**New pages, written from live API reads rather than from documents**
- `ai-gateway/{index,models,compatibility}` — the OpenAI-compatible endpoint, the 42-model catalog with per-model capability flags (only 11 of 42 support tool calls), and an explicit list of what the compatibility layer excludes. Documents the four `/v1/inference/*` endpoints and the `x-varity-data-handling` retention contract, both shipped and previously undocumented.
- `machines/{index,cpu-vms,gpu}` — the four profile catalogs (26 CPU VM, 9 GPU container, 186 GPU VM, 4 GPU bare metal). CPU VM rates are fixed and derived from the monthly cap; GPU rates track available supply and are stated as a dated snapshot, not a rate card.
- `api/{errors,limits}` — the error envelope with a per-code anchor for every code the gateway emits. **The live API sends `docs_url` to `/api/errors#<code>`, which had no page to land on.**

## Contracts
Verified against `varity.app/api/openapi.json` (33 paths / 45 operations), `varity.app/v1/openapi.json`, and the `varitykit` CLI source.

- `Idempotency-Key` is **required**, 8 to 128 chars, on `POST /machines` and `DELETE /machines/{id}` — docs previously said optional at 1 to 160
- `app delete` / `app info` take an app **name**, not a deployment id
- `rollback` and custom domains are shipped, not roadmap
- `.env` precedence is `.env.varity`, `.env.local`, `.env`
- `migrate` always deploys `--hosting dynamic`, so it returns a subdomain URL
- `varitykit login` added to the quickstarts; deploy is login-gated and the documented sequence aborted without it

## Verification
- `npm run build` — 55 pages, clean
- `npm test` — 3/3 pass (architecture governance, 33 OpenAPI paths / 22 MCP tools, positioning)
- Zero horizontal overflow across 52 pages at 360/390/412/768/1024/1280/1920
- 52 breadcrumb JSON-LD blocks valid, 0 failing (intermediate `ListItem` was missing `item`, failing Google's requirement on 54 pages)
- Light-mode contrast raised to AA: content links 2.49:1 → 5.47:1, primary CTA 3.47:1 → 5.47:1
- Mobile table of contents restored below 1152px (was absent site-wide on pages up to 20,000px tall)
- Tables wrap in a focusable scroll region, preserving table semantics for screen readers

## Rollout
Merge to `master`; 4everland autodeploys. Purely additive — 44 live URLs plus 8 new, none removed.

## Rollback
Revert this commit and redeploy. No schema, credential, or provider state involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGLZsMzRkW4D3F8EKEDdLy

## Architecture governance

Architecture impact: none
Reason: Documentation-only change in varity-docs. Adds eight MDX pages, corrects factual claims on existing pages against live API and CLI source, and adjusts CSS plus one rehype plugin for table accessibility. No runtime service, contract, or data path is modified.
Affected runtime services/modules: none
Interfaces/data/security/topology changed: none
Architecture/ADR files: none
