### PR TITLE
feat(analytics): add privacy-safe Docs acquisition tracking

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -1,0 +1,138 @@
+# Docs acquisition and browser-behavior analytics
+
+Status: checked-in implementation contract. Account reports are configuration
+recommendations only and are not created by this repository.
+
+## Ownership
+
+Umami owns public acquisition and browser behavior for `docs.varity.so` only.
+It does not establish an accepted deployment operation, a healthy public URL, a
+paying customer, or a retained deployment. Those facts remain with the
+canonical deployment, verification, and billing projections.
+
+The dedicated Docs website is identified by the public tracker ID in
+`src/lib/docs-analytics.mjs`. The tracker is fenced to the exact production
+hostname. Marketing and Developer Portal website IDs are not accepted by this
+module.
+
+## Module and interface
+
+The analytics module has one interface:
+
+- `pageviewPayload` creates one sanitized native Umami pageview.
+- `eventPayload` creates a closed custom event.
+- `sanitizeOutboundPayload` is the final fail-closed send guard.
+- `installDocsAnalytics` connects the interface to the tracker, clicks, and
+  Starlight search results.
+
+Its implementation owns exact route/page/category keys, UTM normalization,
+event names, event property schemas, Portal handoffs, Do Not Track, and tracker
+startup. Callers do not construct analytics payloads.
+
+The deletion test is positive: deleting the module would redistribute hostname
+fencing, privacy sanitization, schemas, and route classification across the
+Head override, search adapter, and page links. No remote adapter seam is added;
+there is one browser implementation and one pure test surface.
+
+## Pageview policy
+
+Automatic pageviews are disabled with `data-auto-pageview="false"`. The module
+sends one manual native pageview after the tracker loads on each full document
+load. This policy prevents Umami's default URL and referrer fields from leaving
+the browser before the sanitizer runs.
+
+The site does not enable Astro view transitions, so each navigation is a full
+document load. If client-side navigation is enabled later, that shape change
+must add an exactly-once navigation test before capture can continue.
+
+The pageview uses the checked-in page key as its title and
+`category:<category-key>` as its tag. Category views are read from the tag
+breakdown instead of emitting a second view event. Emitting a custom category
+event on every load would make every visit contain at least two events and
+would corrupt Umami's bounce definition.
+
+## Privacy and cardinality
+
+Capture occurs only when all of these conditions hold:
+
+- `window.location.hostname` is exactly `docs.varity.so`;
+- the pathname is in the checked-in 52-route catalog;
+- Do Not Track is not enabled; and
+- the outbound payload passes the final closed schema.
+
+The tracker and sanitizer remove the URL hash and referrer. The URL query is
+rebuilt from an accepted four-field UTM tuple and cannot contain search text,
+code, secrets, tokens, click IDs, or arbitrary query keys. `utm_source`,
+`utm_medium`, `utm_campaign`, and `utm_content` must each occur exactly once,
+normalize to lowercase, and match one checked-in policy. If any field is
+missing, duplicated, or invalid, the whole tuple is discarded. `utm_term` is
+always discarded.
+
+The source/medium policies follow the conversion-funnel taxonomy: `blog/content`,
+`docs/content`, `x/social`, `x/reply`, `linkedin/social`, `reddit/social`,
+`hn/social`, `producthunt/social`, `discord/social`, `github/referral`,
+`portal/referral`, `newsletter/email`, and `google/organic`. `templates/seo` is
+accepted only as `public-template-gallery` with the bounded generic Docs
+placement; arbitrary template slugs do not enter this Docs-owned catalog.
+
+The closed custom events are:
+
+| Event | Properties added by the module | Caller detail |
+|---|---|---|
+| `docs_search_results_presented` | `page`, `category` | `count_bucket`: `0`, `1`, `2-5`, `6-10`, or `11+` |
+| `docs_cta_click` | `page`, `category` | one checked-in CTA key |
+| `docs_portal_handoff` | `page`, `category` | `home`, `settings`, or `deploy` |
+
+Search input values are never read. A bounded MutationObserver adapter waits for
+Pagefind's loading render and subsequent completed result-list render, then
+counts top-level result elements only. A newer input disconnects the prior
+observer, a completed render disconnects before emission, and an incomplete
+render expires after ten seconds. This rejects stale out-of-order renders and
+deduplicates later mutations. An unknown route, send type, event, property,
+property value, Portal target, or UTM tuple returns no payload.
+
+## Docs-to-Portal campaign links
+
+Every authored clickable Portal link uses this canonical shape:
+
+```text
+https://developer.store.varity.so/<target>?utm_source=docs&utm_medium=content&utm_campaign=docs-to-portal&utm_content=<checked-in-placement-key>
+```
+
+The analytics test enumerates every Markdown and HTML Portal hyperlink, proves
+its target and four UTM values are canonical for the source page, and fails if
+an ungoverned link is added.
+
+## Saved reports for the fenced account writer
+
+These reports answer browser questions only. They are not configured by this
+repository:
+
+1. **Docs acquisition (UTM):** hostname `docs.varity.so`; break down the four
+   accepted UTM dimensions; label the result attributed browser arrivals.
+2. **Docs content:** native pageviews by sanitized path and title key, with the
+   `category:*` tag breakdown.
+3. **Search usefulness:**
+   `docs_search_results_presented -> docs_cta_click | docs_portal_handoff`,
+   broken down by `count_bucket`; label counts as browser attempts.
+4. **Portal handoff goal:** event `docs_portal_handoff`, broken down by
+   `page`, `category`, and `handoff`.
+5. **Docs journey:** native pageview -> optional CTA/search event ->
+   `docs_portal_handoff`; never extend it to browser `deploy_success` as proof
+   of an accepted, healthy, paying, or retained deployment.
+6. **Returning-browser retention:** canonical hostname only, with mature cohort
+   denominators stated for each interval.
+
+Any saved report must include the exact hostname fence and must preserve the
+event/property names above. Recorder, replay, and heatmap remain disabled.
+
+## Verification and deployment gate
+
+`npm run test:analytics` verifies privacy, schemas, route coverage, tracker
+configuration, and every Portal-link caller. `npm run check` remains the full
+repository gate. Localhost browser verification must prove that no request is
+sent from `localhost`, while a production-host browser context sends only the
+closed payload shapes.
+
+No account mutation, deployment, publication, or live data reset is performed
+by this implementation.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -97,6 +97,25 @@ network-dependent, refers to retired product surfaces, and is retained only as
 historical diagnostic material until a separate cleanup change proves which
 checks should be ported or deleted.
 
+### Acquisition analytics module
+
+- **Interface:** one sanitized native pageview plus the closed search-results,
+  CTA, and Portal-handoff events documented in `ANALYTICS.md`.
+- **Implementation:** `src/lib/docs-analytics.mjs`,
+  `src/components/DocsAnalytics.astro`, and the global Head override.
+- **Seam:** the Umami browser tracker after exact-host, Do Not Track, route,
+  UTM, event, and property validation.
+- **Test surface:** `tests/test-docs-analytics.cjs`, built HTML inspection, and
+  localhost browser verification.
+
+Umami owns Docs acquisition and browser behavior only. The module cannot write
+accepted deployment, runtime-health, paying, or retained-deployment truth. Its
+public website ID identifies the dedicated `docs.varity.so` website; no runtime
+credential is present in this repository. Automatic pageviews are disabled so
+the module can strip raw URL query, hash, and referrer fields before the single
+manual pageview is sent. `ANALYTICS.md` owns the full privacy and report
+taxonomy contract.
+
 ## Content and artifact provenance
 
 | Published surface | Checked-in owner | Narrower authority to reconcile | Required verification |
@@ -159,6 +178,10 @@ and requires no production credential.
 
 - The static site holds no runtime secret and repository CI has no private
   checkout token.
+- The analytics tracker is exact-host fenced, respects Do Not Track, and fails
+  closed on unknown routes, events, properties, Portal links, and UTM values.
+  It never reads search input text or sends raw URL query, hash, or referrer
+  fields.
 - All content in this public repository must be safe for public disclosure.
 - Examples use environment-variable names and non-secret sample values only.
 - Public interface documentation must stay provider-neutral and must not expose

--- a/package.json
+++ b/package.json
@@ -19,12 +19,14 @@
     "preview": "astro preview",
     "astro": "astro",
     "lint": "astro check",
-    "test": "npm run test:architecture && npm run test:contracts && npm run test:positioning",
+    "test": "npm run test:architecture && npm run test:contracts && npm run test:positioning && npm run test:analytics",
     "test:architecture": "node tests/test-architecture-governance.cjs",
     "test:contracts": "node tests/test-contract-artifacts.cjs",
     "test:built-contracts": "VERIFY_DIST=1 node tests/test-contract-artifacts.cjs",
+    "test:built-analytics": "VERIFY_DIST=1 node tests/test-docs-analytics.cjs",
     "test:positioning": "node tests/test-positioning-static.cjs",
-    "check": "npm test && npm run lint && npm run build && npm run test:built-contracts"
+    "test:analytics": "node tests/test-docs-analytics.cjs",
+    "check": "npm test && npm run lint && npm run build && npm run test:built-contracts && npm run test:built-analytics"
   },
   "dependencies": {
     "@astrojs/sitemap": "3.6.0",

--- a/src/components/DocsAnalytics.astro
+++ b/src/components/DocsAnalytics.astro
@@ -1,0 +1,28 @@
+---
+import { DOCS_ANALYTICS } from '../lib/docs-analytics.mjs';
+---
+
+<script is:inline>
+  window.docsAnalyticsBeforeSend = function (type, payload) {
+    return window.__docsAnalyticsBeforeSend?.(type, payload) || false;
+  };
+</script>
+<script>
+  import { installDocsAnalytics, sanitizeOutboundPayload } from '../lib/docs-analytics.mjs';
+
+  Object.assign(window, { __docsAnalyticsBeforeSend: sanitizeOutboundPayload });
+  installDocsAnalytics(window, document);
+</script>
+<script
+  is:inline
+  id="docs-umami"
+  src="https://cloud.umami.is/script.js"
+  data-website-id={DOCS_ANALYTICS.websiteId}
+  data-domains={DOCS_ANALYTICS.hostname}
+  data-auto-pageview="false"
+  data-exclude-search="true"
+  data-exclude-hash="true"
+  data-do-not-track="true"
+  data-before-send="docsAnalyticsBeforeSend"
+  defer
+></script>

--- a/src/components/DocsHome.astro
+++ b/src/components/DocsHome.astro
@@ -155,11 +155,11 @@ const trustLinks = [
       </p>
 
       <div class="hero-actions">
-        <a class="primary-action" href="/getting-started/quickstart/">
+        <a class="primary-action" href="/getting-started/quickstart/" data-docs-cta="start-deploying">
           <span>Start deploying</span>
           <Icon name="right-arrow" />
         </a>
-        <a class="secondary-action" href="/ai-tools/mcp-server-spec/">
+        <a class="secondary-action" href="/ai-tools/mcp-server-spec/" data-docs-cta="setup-mcp">
           <span>Set up MCP</span>
           <Icon name="right-arrow" />
         </a>

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -6,6 +6,7 @@
 // Reads page data from Astro.locals.starlightRoute (Starlight 0.37 API), the
 // same source the default Head.astro consumes.
 import Default from "@astrojs/starlight/components/Head.astro";
+import DocsAnalytics from "../DocsAnalytics.astro";
 
 const SITE = "https://docs.varity.so";
 const OG_IMAGE = `${SITE}/og-image.png`;
@@ -168,3 +169,4 @@ const jsonLd = {
 
 <Default />
 <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
+<DocsAnalytics />

--- a/src/content/docs/ai-gateway/index.mdx
+++ b/src/content/docs/ai-gateway/index.mdx
@@ -149,7 +149,7 @@ Inference requests require a Varity API key sent as a bearer credential:
 Authorization: Bearer $VARITY_API_KEY
 ```
 
-Create keys in the [Developer Portal settings page](https://developer.store.varity.so/dashboard/settings). Key plaintext is shown once
+Create keys in the [Developer Portal settings page](https://developer.store.varity.so/dashboard/settings?utm_source=docs&utm_medium=content&utm_campaign=docs-to-portal&utm_content=ai-gateway-api-keys). Key plaintext is shown once
 at creation and is never returned again. The same key format is used across the
 Varity [public API](/ai-tools/api-reference/).
 

--- a/src/content/docs/ai-tools/api-reference.mdx
+++ b/src/content/docs/ai-tools/api-reference.mdx
@@ -53,7 +53,7 @@ For non-browser callers, send your Varity API key as a bearer credential:
 Authorization: Bearer $VARITY_API_KEY
 ```
 
-Create API keys in the [Developer Portal settings page](https://developer.store.varity.so/dashboard/settings). API key plaintext is shown once. Listing and revoking keys require an authenticated Developer Portal session; plaintext keys are never returned after creation.
+Create API keys in the [Developer Portal settings page](https://developer.store.varity.so/dashboard/settings?utm_source=docs&utm_medium=content&utm_campaign=docs-to-portal&utm_content=api-reference-api-keys). API key plaintext is shown once. Listing and revoking keys require an authenticated Developer Portal session; plaintext keys are never returned after creation.
 
 ## Deploy
 

--- a/src/content/docs/cli/commands/auth.mdx
+++ b/src/content/docs/cli/commands/auth.mdx
@@ -35,7 +35,7 @@ You need a deploy key from the Varity developer portal:
 
 1. **Go to the developer portal**
 
-   Open [developer.store.varity.so/dashboard/settings](https://developer.store.varity.so/dashboard/settings) in your browser.
+   Open [developer.store.varity.so/dashboard/settings](https://developer.store.varity.so/dashboard/settings?utm_source=docs&utm_medium=content&utm_campaign=docs-to-portal&utm_content=cli-auth-api-keys) in your browser.
 
 2. **Copy your deploy key**
 

--- a/src/content/docs/deploy/deploy-docker-image.mdx
+++ b/src/content/docs/deploy/deploy-docker-image.mdx
@@ -53,7 +53,7 @@ Public and private Docker/OCI images are supported when the image starts a runna
   </TabItem>
   <TabItem label="Developer Portal">
 
-  1. Open [developer.store.varity.so/dashboard/deploy](https://developer.store.varity.so/dashboard/deploy)
+  1. Open [developer.store.varity.so/dashboard/deploy](https://developer.store.varity.so/dashboard/deploy?utm_source=docs&utm_medium=content&utm_campaign=docs-to-portal&utm_content=docker-image-dashboard)
   2. Select the **Docker image** tab
   3. Enter the image reference (for example `ghcr.io/acme/my-api:1.4.2`) and, optionally, the container port
   4. For a private image, add the registry host, username, and password or secret value

--- a/src/content/docs/deploy/deploy-from-dashboard.mdx
+++ b/src/content/docs/deploy/deploy-from-dashboard.mdx
@@ -19,7 +19,7 @@ This is the path most people use. If you prefer the terminal, see [Deploy Your A
 
 ## Before You Start
 
-- A Varity account. Sign in at [developer.store.varity.so](https://developer.store.varity.so).
+- A Varity account. Sign in at [developer.store.varity.so](https://developer.store.varity.so/?utm_source=docs&utm_medium=content&utm_campaign=docs-to-portal&utm_content=dashboard-account).
 - A payment method on file for paid products. Varity asks for a card before your first paid deploy so your app can go live and stay live; you are billed up to a fixed monthly maximum for the hardware your app reserves, prorated by running time, not for traffic. Free static sites need a verified account only. See [Billing](/resources/billing/).
 - Your app's source: a public GitHub repo, a connected GitHub account, or a public Docker image.
 
@@ -29,7 +29,7 @@ This is the path most people use. If you prefer the terminal, see [Deploy Your A
 
 1. **Sign in to the dashboard**
 
-   Go to [developer.store.varity.so](https://developer.store.varity.so) and sign in. Open **Deploy** to start a new deployment.
+   Go to [developer.store.varity.so](https://developer.store.varity.so/?utm_source=docs&utm_medium=content&utm_campaign=docs-to-portal&utm_content=dashboard-deploy) and sign in. Open **Deploy** to start a new deployment.
 
 2. **Choose your source**
 

--- a/src/content/docs/resources/glossary.mdx
+++ b/src/content/docs/resources/glossary.mdx
@@ -25,7 +25,7 @@ A web application deployed on Varity. Static apps get a URL at `https://varity.a
 
 A secret key that authenticates your deploys. Required when deploying from CI/CD or non-interactive environments.
 
-Generate one at [developer.store.varity.so](https://developer.store.varity.so) or with:
+Generate one at [developer.store.varity.so](https://developer.store.varity.so/dashboard/settings?utm_source=docs&utm_medium=content&utm_campaign=docs-to-portal&utm_content=glossary-api-keys) or with:
 
 ```bash
 varitykit auth login

--- a/src/content/docs/resources/pricing.mdx
+++ b/src/content/docs/resources/pricing.mdx
@@ -54,7 +54,7 @@ New accounts with a valid payment method receive a **$5 Managed Cloud credit, va
 
 Every price is computed by Varity's server-side pricing authority, so all surfaces show identical numbers:
 
-- Developer Portal: [developer.store.varity.so](https://developer.store.varity.so) shows the exact price before you confirm a deployment.
+- Developer Portal: [developer.store.varity.so](https://developer.store.varity.so/?utm_source=docs&utm_medium=content&utm_campaign=docs-to-portal&utm_content=pricing-portal) shows the exact price before you confirm a deployment.
 - MCP tool: `varity_cost_calculator` in your AI editor.
 
 <Aside type="note">

--- a/src/content/docs/tutorials/deploy-ai-agent.mdx
+++ b/src/content/docs/tutorials/deploy-ai-agent.mdx
@@ -27,7 +27,7 @@ The examples below point at `https://varity.app/v1`, Varity's OpenAI-compatible 
 
 Don't want to write code? Varity ships ready-to-deploy certified templates for popular open-source tools including **Agent Zero**, **Flowise**, **Open WebUI**, and **Uptime Kuma**. The certified list is gateway-owned and changes as templates pass live deploy and browser verification.
 
-The proven path for these templates is the **Developer Portal**. Open the template gallery at [developer.store.varity.so/dashboard/deploy](https://developer.store.varity.so/dashboard/deploy) and click deploy on any template. That's it. One click, live URL. If a template needs environment variables (like an API key), the portal prompts you for them before deploying.
+The proven path for these templates is the **Developer Portal**. Open the template gallery at [developer.store.varity.so/dashboard/deploy](https://developer.store.varity.so/dashboard/deploy?utm_source=docs&utm_medium=content&utm_campaign=docs-to-portal&utm_content=ai-agent-templates) and click deploy on any template. That's it. One click, live URL. If a template needs environment variables (like an API key), the portal prompts you for them before deploying.
 
 If you prefer the terminal or your AI editor, deploy the same certified templates by template ID:
 

--- a/src/lib/docs-analytics.mjs
+++ b/src/lib/docs-analytics.mjs
@@ -1,0 +1,346 @@
+export const DOCS_ANALYTICS = Object.freeze({
+  hostname: 'docs.varity.so',
+  websiteId: 'c55bf3fd-9a22-46b0-8dc9-21c949f068c4',
+});
+
+const PAGE_CATALOG = Object.freeze({
+  '/': ['home', 'home'],
+  '/ai-gateway/': ['ai-gateway', 'ai-gateway'],
+  '/ai-gateway/compatibility/': ['ai-gateway-compatibility', 'ai-gateway'],
+  '/ai-gateway/models/': ['ai-gateway-models', 'ai-gateway'],
+  '/ai-tools/api-reference/': ['ai-tools-api-reference', 'ai-tools'],
+  '/ai-tools/mcp-server-spec/': ['ai-tools-mcp-server-spec', 'ai-tools'],
+  '/ai-tools/overview/': ['ai-tools-overview', 'ai-tools'],
+  '/ai-tools/prompts/': ['ai-tools-prompts', 'ai-tools'],
+  '/api/errors/': ['api-errors', 'api'],
+  '/api/limits/': ['api-limits', 'api'],
+  '/cli/': ['cli', 'cli'],
+  '/cli/overview/': ['cli-overview', 'cli'],
+  '/cli/commands/auth/': ['cli-auth', 'cli'],
+  '/cli/commands/deploy/': ['cli-deploy', 'cli'],
+  '/cli/commands/doctor/': ['cli-doctor', 'cli'],
+  '/deploy/': ['deploy', 'deploy'],
+  '/deploy/auto-wired-services/': ['deploy-auto-wired-services', 'deploy'],
+  '/deploy/custom-domains/': ['deploy-custom-domains', 'deploy'],
+  '/deploy/databases/': ['deploy-databases', 'deploy'],
+  '/deploy/deploy-docker-image/': ['deploy-docker-image', 'deploy'],
+  '/deploy/deploy-from-dashboard/': ['deploy-from-dashboard', 'deploy'],
+  '/deploy/deploy-your-app/': ['deploy-your-app', 'deploy'],
+  '/deploy/deployment-troubleshooting/': ['deploy-troubleshooting', 'deploy'],
+  '/deploy/env-variables/': ['deploy-env-variables', 'deploy'],
+  '/deploy/intelligent-orchestration/': ['deploy-intelligent-orchestration', 'deploy'],
+  '/deploy/managed-credentials/': ['deploy-managed-credentials', 'deploy'],
+  '/deploy/rollback/': ['deploy-rollback', 'deploy'],
+  '/deploy/supported-frameworks/': ['deploy-supported-frameworks', 'deploy'],
+  '/deploy/vercel-migration/': ['deploy-vercel-migration', 'deploy'],
+  '/deploy/what-you-can-deploy/': ['deploy-capabilities', 'deploy'],
+  '/getting-started/': ['getting-started', 'getting-started'],
+  '/getting-started/getting-help/': ['getting-help', 'getting-started'],
+  '/getting-started/how-varity-works/': ['how-varity-works', 'getting-started'],
+  '/getting-started/installation/': ['installation', 'getting-started'],
+  '/getting-started/introduction/': ['introduction', 'getting-started'],
+  '/getting-started/quickstart/': ['quickstart', 'getting-started'],
+  '/getting-started/quickstart-nextjs/': ['quickstart-nextjs', 'getting-started'],
+  '/getting-started/quickstart-python/': ['quickstart-python', 'getting-started'],
+  '/getting-started/why-varity/': ['why-varity', 'getting-started'],
+  '/guides/deploy-from-ai-ide/': ['guide-ai-ide', 'guides'],
+  '/guides/deploy-nextjs/': ['guide-nextjs', 'guides'],
+  '/machines/': ['machines', 'machines'],
+  '/machines/cpu-vms/': ['machines-cpu-vms', 'machines'],
+  '/machines/gpu/': ['machines-gpu', 'machines'],
+  '/resources/billing/': ['resources-billing', 'resources'],
+  '/resources/faq/': ['resources-faq', 'resources'],
+  '/resources/glossary/': ['resources-glossary', 'resources'],
+  '/resources/pricing/': ['resources-pricing', 'resources'],
+  '/resources/security/': ['resources-security', 'resources'],
+  '/resources/troubleshooting/': ['resources-troubleshooting', 'resources'],
+  '/tutorials/build-with-ai/': ['tutorial-build-with-ai', 'tutorials'],
+  '/tutorials/deploy-ai-agent/': ['tutorial-deploy-ai-agent', 'tutorials'],
+});
+
+export const DOCS_EVENT_NAMES = Object.freeze([
+  'docs_search_results_presented',
+  'docs_cta_click',
+  'docs_portal_handoff',
+]);
+
+const EVENT_DETAILS = Object.freeze({
+  docs_search_results_presented: Object.freeze({
+    count_bucket: new Set(['0', '1', '2-5', '6-10', '11+']),
+  }),
+  docs_cta_click: Object.freeze({
+    cta: new Set(['start-deploying', 'setup-mcp', 'portal-home', 'portal-settings', 'portal-deploy']),
+  }),
+  docs_portal_handoff: Object.freeze({
+    handoff: new Set(['home', 'settings', 'deploy']),
+  }),
+});
+
+const STANDARD_UTM_CAMPAIGNS = new Set(['docs', 'docs-acquisition', 'docs-navigation', 'product-docs']);
+const STANDARD_UTM_CONTENT = new Set(['docs', 'footer', 'header', 'homepage', 'readme', 'release-notes']);
+const INBOUND_UTM_POLICIES = Object.freeze([
+  ['blog', 'content', STANDARD_UTM_CAMPAIGNS, STANDARD_UTM_CONTENT],
+  ['discord', 'social', STANDARD_UTM_CAMPAIGNS, STANDARD_UTM_CONTENT],
+  ['docs', 'content', STANDARD_UTM_CAMPAIGNS, STANDARD_UTM_CONTENT],
+  ['github', 'referral', STANDARD_UTM_CAMPAIGNS, STANDARD_UTM_CONTENT],
+  ['google', 'organic', STANDARD_UTM_CAMPAIGNS, STANDARD_UTM_CONTENT],
+  ['hn', 'social', STANDARD_UTM_CAMPAIGNS, STANDARD_UTM_CONTENT],
+  ['linkedin', 'social', STANDARD_UTM_CAMPAIGNS, STANDARD_UTM_CONTENT],
+  ['newsletter', 'email', STANDARD_UTM_CAMPAIGNS, STANDARD_UTM_CONTENT],
+  ['portal', 'referral', STANDARD_UTM_CAMPAIGNS, STANDARD_UTM_CONTENT],
+  ['producthunt', 'social', STANDARD_UTM_CAMPAIGNS, STANDARD_UTM_CONTENT],
+  ['reddit', 'social', STANDARD_UTM_CAMPAIGNS, STANDARD_UTM_CONTENT],
+  ['templates', 'seo', new Set(['public-template-gallery']), new Set(['docs'])],
+  ['x', 'reply', STANDARD_UTM_CAMPAIGNS, STANDARD_UTM_CONTENT],
+  ['x', 'social', STANDARD_UTM_CAMPAIGNS, STANDARD_UTM_CONTENT],
+]);
+const UTM_KEYS = Object.freeze(['utm_source', 'utm_medium', 'utm_campaign', 'utm_content']);
+const SEARCH_OBSERVER_LIFETIME_MS = 10_000;
+
+const PORTAL_CONTENT_BY_PAGE = Object.freeze({
+  'ai-gateway': new Set(['ai-gateway-api-keys']),
+  'ai-tools-api-reference': new Set(['api-reference-api-keys']),
+  'cli-auth': new Set(['cli-auth-api-keys']),
+  'deploy-docker-image': new Set(['docker-image-dashboard']),
+  'deploy-from-dashboard': new Set(['dashboard-account', 'dashboard-deploy']),
+  'resources-glossary': new Set(['glossary-api-keys']),
+  'resources-pricing': new Set(['pricing-portal']),
+  'tutorial-deploy-ai-agent': new Set(['ai-agent-templates']),
+});
+
+const PORTAL_PATHS = Object.freeze({
+  '/': Object.freeze({ handoff: 'home', cta: 'portal-home' }),
+  '/dashboard/settings': Object.freeze({ handoff: 'settings', cta: 'portal-settings' }),
+  '/dashboard/deploy': Object.freeze({ handoff: 'deploy', cta: 'portal-deploy' }),
+});
+
+function plainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function exactKeys(value, keys) {
+  return plainObject(value) && Object.keys(value).length === keys.length && keys.every((key) => Object.hasOwn(value, key));
+}
+
+function allowedKeys(value, required, optional = []) {
+  if (!plainObject(value) || !required.every((key) => Object.hasOwn(value, key))) return false;
+  const allowed = new Set([...required, ...optional]);
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function normalizedPath(pathname) {
+  if (typeof pathname !== 'string' || !pathname.startsWith('/')) return null;
+  return pathname === '/' || pathname.endsWith('/') ? pathname : `${pathname}/`;
+}
+
+export function pageContext(pathname) {
+  const path = normalizedPath(pathname);
+  const entry = path ? PAGE_CATALOG[path] : undefined;
+  return entry ? Object.freeze({ path, page: entry[0], category: entry[1] }) : null;
+}
+
+function normalizedAllowedValue(value, allowed) {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  return allowed.has(normalized) ? normalized : null;
+}
+
+export function sanitizedUtm(search) {
+  const input = new URLSearchParams(typeof search === 'string' ? search : '');
+  if (!UTM_KEYS.every((key) => input.getAll(key).length === 1)) return '';
+  const values = Object.fromEntries(UTM_KEYS.map((key) => [key, input.get(key)?.trim().toLowerCase()]));
+  const policy = INBOUND_UTM_POLICIES.find(([source, medium]) => values.utm_source === source && values.utm_medium === medium);
+  if (!policy || !policy[2].has(values.utm_campaign) || !policy[3].has(values.utm_content)) return '';
+  return `?${new URLSearchParams(values).toString()}`;
+}
+
+function safeLocationUrl(value) {
+  if (typeof value !== 'string') return null;
+  try {
+    const url = new URL(value, `https://${DOCS_ANALYTICS.hostname}`);
+    return url.hostname === DOCS_ANALYTICS.hostname ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizedBase(payload) {
+  if (!plainObject(payload)) return null;
+  if (payload.website !== DOCS_ANALYTICS.websiteId || payload.hostname !== DOCS_ANALYTICS.hostname) return null;
+  const url = safeLocationUrl(payload.url);
+  const context = url ? pageContext(url.pathname) : null;
+  if (!url || !context) return null;
+  return {
+    context,
+    payload: {
+      website: DOCS_ANALYTICS.websiteId,
+      hostname: DOCS_ANALYTICS.hostname,
+      url: `${context.path}${sanitizedUtm(url.search)}`,
+      title: context.page,
+      tag: `category:${context.category}`,
+    },
+  };
+}
+
+function sanitizedEventData(name, data, context) {
+  const definition = EVENT_DETAILS[name];
+  if (!definition || !plainObject(data)) return null;
+  const keys = Object.keys(definition);
+  const isCallerShape = exactKeys(data, keys);
+  const isSanitizedShape = exactKeys(data, ['page', 'category', ...keys]) && data.page === context.page && data.category === context.category;
+  if (!isCallerShape && !isSanitizedShape) return null;
+  const detail = {};
+  for (const key of keys) {
+    const value = normalizedAllowedValue(data[key], definition[key]);
+    if (!value) return null;
+    detail[key] = value;
+  }
+  return { page: context.page, category: context.category, ...detail };
+}
+
+export function sanitizeOutboundPayload(type, payload) {
+  if (type !== 'event') return false;
+  if (!plainObject(payload)) return false;
+  const pageviewKeys = Object.hasOwn(payload, 'title') || Object.hasOwn(payload, 'tag')
+    ? ['website', 'hostname', 'url', 'title', 'tag']
+    : ['website', 'hostname', 'url'];
+  const requiredKeys = payload.name === undefined ? pageviewKeys : [...pageviewKeys, 'name', 'data'];
+  if (!allowedKeys(payload, requiredKeys, ['screen', 'language', 'referrer'])) return false;
+  const base = sanitizedBase(payload);
+  if (!base) return false;
+  if (payload.name === undefined) return base.payload;
+  if (typeof payload.name !== 'string' || !DOCS_EVENT_NAMES.includes(payload.name)) return false;
+  const data = sanitizedEventData(payload.name, payload.data, base.context);
+  return data ? { ...base.payload, name: payload.name, data } : false;
+}
+
+export function pageviewPayload(location) {
+  if (!location || location.hostname !== DOCS_ANALYTICS.hostname) return null;
+  return sanitizeOutboundPayload('event', {
+    website: DOCS_ANALYTICS.websiteId,
+    hostname: DOCS_ANALYTICS.hostname,
+    url: `${location.pathname ?? ''}${location.search ?? ''}${location.hash ?? ''}`,
+  }) || null;
+}
+
+export function eventPayload(name, location, detail) {
+  const pageview = pageviewPayload(location);
+  if (!pageview) return null;
+  return sanitizeOutboundPayload('event', { ...pageview, name, data: detail }) || null;
+}
+
+export function searchResultCountBucket(count) {
+  if (!Number.isSafeInteger(count) || count < 0) return null;
+  if (count === 0) return '0';
+  if (count === 1) return '1';
+  if (count <= 5) return '2-5';
+  if (count <= 10) return '6-10';
+  return '11+';
+}
+
+export function portalHandoff(href, page) {
+  if (typeof href !== 'string' || typeof page !== 'string') return null;
+  let url;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'https:' || url.hostname !== 'developer.store.varity.so' || url.hash) return null;
+  const target = PORTAL_PATHS[url.pathname];
+  const allowedContent = PORTAL_CONTENT_BY_PAGE[page];
+  const content = url.searchParams.get('utm_content');
+  if (!target || !allowedContent || !content || !allowedContent.has(content)) return null;
+  const expected = new URLSearchParams({
+    utm_source: 'docs',
+    utm_medium: 'content',
+    utm_campaign: 'docs-to-portal',
+    utm_content: content,
+  });
+  return url.searchParams.toString() === expected.toString() ? target : null;
+}
+
+export function doNotTrackEnabled(navigatorLike, windowLike) {
+  return navigatorLike?.doNotTrack === '1' || navigatorLike?.msDoNotTrack === '1' || windowLike?.doNotTrack === '1';
+}
+
+export function installDocsAnalytics(windowLike, documentLike) {
+  if (!windowLike || !documentLike || windowLike.__docsAnalyticsInstalled) return null;
+  windowLike.__docsAnalyticsInstalled = true;
+  windowLike.docsAnalyticsBeforeSend = sanitizeOutboundPayload;
+
+  const allowed = () => !doNotTrackEnabled(windowLike.navigator, windowLike) && pageContext(windowLike.location?.pathname) !== null && windowLike.location?.hostname === DOCS_ANALYTICS.hostname;
+  const emit = (payload) => {
+    if (!payload || !allowed() || typeof windowLike.umami?.track !== 'function') return false;
+    windowLike.umami.track(payload);
+    return true;
+  };
+  const emitPageview = () => emit(pageviewPayload(windowLike.location));
+
+  const tracker = documentLike.getElementById?.('docs-umami');
+  if (typeof windowLike.umami?.track === 'function') emitPageview();
+  else tracker?.addEventListener?.('load', emitPageview, { once: true });
+
+  const onClick = (event) => {
+    const anchor = event.target?.closest?.('a[href]');
+    if (!anchor) return;
+    const context = pageContext(windowLike.location?.pathname);
+    if (!context) return;
+    const declaredCta = anchor.getAttribute?.('data-docs-cta');
+    if (declaredCta) emit(eventPayload('docs_cta_click', windowLike.location, { cta: declaredCta }));
+    const handoff = portalHandoff(anchor.href, context.page);
+    if (handoff) {
+      emit(eventPayload('docs_cta_click', windowLike.location, { cta: handoff.cta }));
+      emit(eventPayload('docs_portal_handoff', windowLike.location, { handoff: handoff.handoff }));
+    }
+  };
+
+  let searchObservation;
+  const stopSearchObservation = () => {
+    if (!searchObservation) return;
+    searchObservation.observer.disconnect();
+    windowLike.clearTimeout?.(searchObservation.deadline);
+    searchObservation = undefined;
+  };
+  const onInput = (event) => {
+    if (!event.target?.matches?.('site-search input[type="search"], .pagefind-ui__search-input')) return;
+    stopSearchObservation();
+    const searchRoot = event.target.closest?.('site-search');
+    if (!searchRoot || typeof windowLike.MutationObserver !== 'function' || typeof windowLike.setTimeout !== 'function') return;
+
+    let sawCurrentLoading = false;
+    const observer = new windowLike.MutationObserver(() => {
+      if (searchObservation?.observer !== observer) return;
+      const resultsArea = searchRoot.querySelector?.('.pagefind-ui__results-area');
+      if (!resultsArea) return;
+      const renderedResults = resultsArea.querySelector?.('.pagefind-ui__results');
+      if (!renderedResults) {
+        if (resultsArea.querySelector?.('.pagefind-ui__message')) sawCurrentLoading = true;
+        return;
+      }
+      if (!sawCurrentLoading) return;
+      const count = renderedResults.querySelectorAll?.(':scope > .pagefind-ui__result').length ?? 0;
+      const countBucket = searchResultCountBucket(count);
+      stopSearchObservation();
+      if (countBucket) emit(eventPayload('docs_search_results_presented', windowLike.location, { count_bucket: countBucket }));
+    });
+    observer.observe(searchRoot, { childList: true, subtree: true, characterData: true });
+    const deadline = windowLike.setTimeout(() => {
+      if (searchObservation?.observer === observer) stopSearchObservation();
+    }, SEARCH_OBSERVER_LIFETIME_MS);
+    searchObservation = { observer, deadline };
+  };
+
+  documentLike.addEventListener?.('click', onClick);
+  documentLike.addEventListener?.('input', onInput);
+  return {
+    dispose() {
+      documentLike.removeEventListener?.('click', onClick);
+      documentLike.removeEventListener?.('input', onInput);
+      stopSearchObservation();
+      windowLike.__docsAnalyticsInstalled = false;
+    },
+  };
+}
+
+export const DOCS_ANALYTICS_PAGE_PATHS = Object.freeze(Object.keys(PAGE_CATALOG));

--- a/tests/test-docs-analytics.cjs
+++ b/tests/test-docs-analytics.cjs
@@ -1,0 +1,323 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function docsSources(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const target = path.join(directory, entry.name);
+    if (entry.isDirectory()) return docsSources(target);
+    return /\.mdx?$/.test(entry.name) ? [target] : [];
+  });
+}
+
+function routeForSource(file) {
+  let slug = path.relative(path.join(ROOT, 'src/content/docs'), file).replace(/\\/g, '/').replace(/\.mdx?$/, '');
+  if (slug === 'index') slug = '';
+  else slug = slug.replace(/\/index$/, '');
+  return slug ? `/${slug}/` : '/';
+}
+
+(async () => {
+  const analytics = await import(pathToFileURL(path.join(ROOT, 'src/lib/docs-analytics.mjs')).href);
+  const {
+    DOCS_ANALYTICS,
+    DOCS_ANALYTICS_PAGE_PATHS,
+    DOCS_EVENT_NAMES,
+    doNotTrackEnabled,
+    eventPayload,
+    installDocsAnalytics,
+    pageContext,
+    pageviewPayload,
+    portalHandoff,
+    sanitizeOutboundPayload,
+    sanitizedUtm,
+    searchResultCountBucket,
+  } = analytics;
+
+  assert.equal(DOCS_ANALYTICS.hostname, 'docs.varity.so');
+  assert.match(DOCS_ANALYTICS.websiteId, /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  assert.deepEqual(DOCS_EVENT_NAMES, [
+    'docs_search_results_presented',
+    'docs_cta_click',
+    'docs_portal_handoff',
+  ]);
+
+  const contentFiles = docsSources(path.join(ROOT, 'src/content/docs'));
+  const sourceRoutes = contentFiles.map(routeForSource).sort();
+  assert.deepEqual([...DOCS_ANALYTICS_PAGE_PATHS].sort(), sourceRoutes, 'every authored route must have one bounded analytics key');
+  assert.equal(pageContext('/not-a-doc/'), null);
+  assert.deepEqual(pageContext('/deploy/deploy-from-dashboard'), {
+    path: '/deploy/deploy-from-dashboard/',
+    page: 'deploy-from-dashboard',
+    category: 'deploy',
+  });
+
+  const location = {
+    hostname: 'docs.varity.so',
+    pathname: '/deploy/deploy-from-dashboard/',
+    search: '?utm_source=X&utm_medium=SOCIAL&utm_campaign=docs-acquisition&utm_content=header&q=private&token=secret&utm_term=code',
+    hash: '#private-fragment',
+  };
+  const pageview = pageviewPayload(location);
+  assert.deepEqual(pageview, {
+    website: DOCS_ANALYTICS.websiteId,
+    hostname: 'docs.varity.so',
+    url: '/deploy/deploy-from-dashboard/?utm_source=x&utm_medium=social&utm_campaign=docs-acquisition&utm_content=header',
+    title: 'deploy-from-dashboard',
+    tag: 'category:deploy',
+  });
+  assert.equal('referrer' in pageview, false);
+  assert.equal(pageview.url.includes('private'), false);
+  assert.equal(pageview.url.includes('#'), false);
+  assert.equal(pageview.url.includes('utm_term'), false);
+  assert.deepEqual(sanitizeOutboundPayload('event', {
+    ...pageview,
+    screen: '1920x1080',
+    language: 'en-US',
+    referrer: 'https://search.example/private?q=secret',
+  }), pageview, 'known Umami ambient fields must be accepted and stripped by the send hook');
+  assert.equal(sanitizeOutboundPayload('identify', pageview), false);
+  assert.equal(sanitizeOutboundPayload('unknown', pageview), false);
+
+  const standardPairs = [
+    ['blog', 'content'],
+    ['discord', 'social'],
+    ['docs', 'content'],
+    ['github', 'referral'],
+    ['google', 'organic'],
+    ['hn', 'social'],
+    ['linkedin', 'social'],
+    ['newsletter', 'email'],
+    ['portal', 'referral'],
+    ['producthunt', 'social'],
+    ['reddit', 'social'],
+    ['x', 'reply'],
+    ['x', 'social'],
+  ];
+  for (const [source, medium] of standardPairs) {
+    const tuple = `?utm_source=${source}&utm_medium=${medium}&utm_campaign=docs-acquisition&utm_content=header`;
+    assert.equal(sanitizedUtm(tuple), tuple, `canonical ${source}/${medium} tuple must be accepted`);
+  }
+  const templateTuple = '?utm_source=templates&utm_medium=seo&utm_campaign=public-template-gallery&utm_content=docs';
+  assert.equal(sanitizedUtm(templateTuple), templateTuple);
+  for (const invalidTuple of [
+    '?utm_source=docs&utm_medium=content&utm_campaign=docs-acquisition',
+    '?utm_source=docs&utm_medium=social&utm_campaign=docs-acquisition&utm_content=header',
+    '?utm_source=hn&utm_medium=content&utm_campaign=docs-acquisition&utm_content=header',
+    '?utm_source=producthunt&utm_medium=seo&utm_campaign=docs-acquisition&utm_content=header',
+    '?utm_source=templates&utm_medium=seo&utm_campaign=docs-acquisition&utm_content=header',
+    '?utm_source=templates&utm_medium=content&utm_campaign=public-template-gallery&utm_content=docs',
+    '?utm_source=x&utm_source=docs&utm_medium=social&utm_campaign=docs-acquisition&utm_content=header',
+    '?utm_source=unreviewed&utm_medium=social&utm_campaign=docs-acquisition&utm_content=header',
+  ]) assert.equal(sanitizedUtm(invalidTuple), '', `invalid or partial tuple must be dropped atomically: ${invalidTuple}`);
+  assert.equal(pageviewPayload({ ...location, hostname: 'preview.example' }), null);
+  assert.equal(pageviewPayload({ ...location, pathname: '/unknown/' }), null);
+
+  const searchEvent = eventPayload('docs_search_results_presented', location, { count_bucket: '2-5' });
+  assert.deepEqual(searchEvent.data, {
+    page: 'deploy-from-dashboard',
+    category: 'deploy',
+    count_bucket: '2-5',
+  });
+  assert.equal(eventPayload('unknown_event', location, {}), null);
+  assert.equal(eventPayload('docs_search_results_presented', location, { count_bucket: '2-5', query: 'secret' }), null);
+  assert.equal(eventPayload('docs_search_results_presented', location, { count_bucket: '500' }), null);
+  assert.equal(sanitizeOutboundPayload('event', { ...pageview, unexpected: true }), false);
+  assert.equal(sanitizeOutboundPayload('event', { ...searchEvent, data: { ...searchEvent.data, query: 'secret' } }), false);
+
+  assert.equal(searchResultCountBucket(0), '0');
+  assert.equal(searchResultCountBucket(1), '1');
+  assert.equal(searchResultCountBucket(5), '2-5');
+  assert.equal(searchResultCountBucket(10), '6-10');
+  assert.equal(searchResultCountBucket(11), '11+');
+  assert.equal(searchResultCountBucket(-1), null);
+  assert.equal(doNotTrackEnabled({ doNotTrack: '1' }, {}), true);
+  assert.equal(doNotTrackEnabled({ doNotTrack: '0' }, {}), false);
+
+  const listeners = new Map();
+  const emitted = [];
+  const timers = new Map();
+  let nextTimer = 0;
+  class FakeMutationObserver {
+    static instances = [];
+    constructor(callback) {
+      this.callback = callback;
+      this.disconnected = false;
+      FakeMutationObserver.instances.push(this);
+    }
+    observe(target, options) {
+      this.target = target;
+      this.options = options;
+    }
+    disconnect() {
+      this.disconnected = true;
+    }
+  }
+  let searchState = 'idle';
+  let renderedCount = 0;
+  const renderedResults = {
+    querySelectorAll: (selector) => {
+      assert.equal(selector, ':scope > .pagefind-ui__result');
+      return { length: renderedCount };
+    },
+  };
+  const resultsArea = {
+    querySelector: (selector) => {
+      if (selector === '.pagefind-ui__results') return searchState === 'complete' ? renderedResults : null;
+      if (selector === '.pagefind-ui__message') return searchState === 'loading' ? {} : null;
+      return null;
+    },
+  };
+  const searchRoot = {
+    querySelector: (selector) => selector === '.pagefind-ui__results-area' && searchState !== 'idle' ? resultsArea : null,
+  };
+  const runtimeLocation = {
+    hostname: 'docs.varity.so',
+    pathname: '/deploy/deploy-from-dashboard/',
+    search: '?utm_source=x&utm_medium=social&utm_campaign=docs-acquisition&utm_content=header&q=private',
+    hash: '#private',
+  };
+  const runtimeWindow = {
+    location: runtimeLocation,
+    navigator: { doNotTrack: '0' },
+    umami: { track: (payload) => emitted.push(payload) },
+    MutationObserver: FakeMutationObserver,
+    setTimeout: (callback) => {
+      const id = ++nextTimer;
+      timers.set(id, callback);
+      return id;
+    },
+    clearTimeout: (id) => timers.delete(id),
+  };
+  const runtimeDocument = {
+    addEventListener: (name, handler) => listeners.set(name, handler),
+    removeEventListener: (name) => listeners.delete(name),
+    getElementById: () => null,
+  };
+  const installed = installDocsAnalytics(runtimeWindow, runtimeDocument);
+  assert.ok(installed);
+  assert.deepEqual(emitted.shift(), pageviewPayload(runtimeLocation), 'runtime must emit one sanitized native pageview');
+
+  const portalHref = 'https://developer.store.varity.so/dashboard/deploy?utm_source=docs&utm_medium=content&utm_campaign=docs-to-portal&utm_content=dashboard-deploy';
+  listeners.get('click')({
+    target: {
+      closest: () => ({ href: portalHref, getAttribute: () => null }),
+    },
+  });
+  assert.deepEqual(emitted.map(({ name }) => name), ['docs_cta_click', 'docs_portal_handoff']);
+  assert.deepEqual(emitted[1].data, { page: 'deploy-from-dashboard', category: 'deploy', handoff: 'deploy' });
+  emitted.length = 0;
+
+  const searchTarget = {
+    matches: () => true,
+    closest: (selector) => selector === 'site-search' ? searchRoot : null,
+    get value() { throw new Error('search input text must never be read'); },
+  };
+  listeners.get('input')({ target: searchTarget });
+  const firstObserver = FakeMutationObserver.instances.at(-1);
+  assert.deepEqual(firstObserver.options, { childList: true, subtree: true, characterData: true });
+
+  searchState = 'complete';
+  renderedCount = 11;
+  firstObserver.callback();
+  assert.deepEqual(emitted, [], 'a stale completion before the current loading signal must be ignored');
+
+  searchState = 'loading';
+  firstObserver.callback();
+  listeners.get('input')({ target: searchTarget });
+  const secondObserver = FakeMutationObserver.instances.at(-1);
+  assert.equal(firstObserver.disconnected, true, 'a newer input must deterministically replace the prior observer');
+
+  searchState = 'complete';
+  renderedCount = 1;
+  firstObserver.callback();
+  secondObserver.callback();
+  assert.deepEqual(emitted, [], 'out-of-order and pre-loading completions must not emit');
+
+  searchState = 'loading';
+  secondObserver.callback();
+  searchState = 'complete';
+  renderedCount = 3;
+  secondObserver.callback();
+  assert.deepEqual(emitted, [eventPayload('docs_search_results_presented', runtimeLocation, { count_bucket: '2-5' })]);
+  secondObserver.callback();
+  assert.equal(emitted.length, 1, 'completion mutations must be deduplicated');
+  assert.equal(secondObserver.disconnected, true);
+  assert.equal(timers.size, 0);
+
+  searchState = 'loading';
+  listeners.get('input')({ target: searchTarget });
+  const boundedObserver = FakeMutationObserver.instances.at(-1);
+  assert.equal(timers.size, 1);
+  [...timers.values()][0]();
+  assert.equal(boundedObserver.disconnected, true, 'the observer lifetime must be bounded when rendering never completes');
+  assert.equal(timers.size, 0);
+
+  listeners.get('input')({ target: searchTarget });
+  const disposedObserver = FakeMutationObserver.instances.at(-1);
+  installed.dispose();
+  assert.equal(listeners.size, 0);
+  assert.equal(disposedObserver.disconnected, true);
+  assert.equal(timers.size, 0);
+
+  const dntEmitted = [];
+  installDocsAnalytics(
+    { ...runtimeWindow, __docsAnalyticsInstalled: false, navigator: { doNotTrack: '1' }, umami: { track: (payload) => dntEmitted.push(payload) } },
+    runtimeDocument,
+  );
+  assert.deepEqual(dntEmitted, [], 'Do Not Track must suppress the runtime pageview');
+
+  const portalLinks = [];
+  for (const file of contentFiles) {
+    const source = fs.readFileSync(file, 'utf8');
+    const hrefs = [
+      ...source.matchAll(/\]\((https:\/\/developer\.store\.varity\.so[^)]+)\)/g),
+      ...source.matchAll(/href=["'](https:\/\/developer\.store\.varity\.so[^"']+)["']/g),
+    ].map((match) => match[1]);
+    const context = pageContext(routeForSource(file));
+    for (const href of hrefs) {
+      assert.ok(context, `missing analytics context for ${file}`);
+      assert.ok(portalHandoff(href, context.page), `non-canonical Portal handoff in ${path.relative(ROOT, file)}: ${href}`);
+      portalLinks.push(href);
+    }
+  }
+  assert.equal(portalLinks.length, 9, 'expected every authored Portal hyperlink to be governed');
+
+  const analyticsSource = fs.readFileSync(path.join(ROOT, 'src/components/DocsAnalytics.astro'), 'utf8');
+  for (const attribute of [
+    'data-domains={DOCS_ANALYTICS.hostname}',
+    'data-auto-pageview="false"',
+    'data-exclude-search="true"',
+    'data-exclude-hash="true"',
+    'data-do-not-track="true"',
+    'data-before-send="docsAnalyticsBeforeSend"',
+  ]) assert.ok(analyticsSource.includes(attribute), `tracker is missing ${attribute}`);
+
+  if (process.env.VERIFY_DIST === '1') {
+    const builtHtml = fs.readFileSync(path.join(ROOT, 'dist/deploy/deploy-from-dashboard/index.html'), 'utf8');
+    for (const attribute of [
+      'src="https://cloud.umami.is/script.js"',
+      `data-website-id="${DOCS_ANALYTICS.websiteId}"`,
+      'data-domains="docs.varity.so"',
+      'data-auto-pageview="false"',
+      'data-exclude-search="true"',
+      'data-exclude-hash="true"',
+      'data-do-not-track="true"',
+      'data-before-send="docsAnalyticsBeforeSend"',
+    ]) assert.ok(builtHtml.includes(attribute), `built tracker is missing ${attribute}`);
+    assert.equal((builtHtml.match(/id="docs-umami"/g) ?? []).length, 1, 'built page must contain one tracker');
+
+    const bundleMatch = builtHtml.match(/src="(\/_astro\/DocsAnalytics[^"?]+\.js)"/);
+    assert.ok(bundleMatch, 'built page must load the analytics runtime bundle');
+    const bundle = fs.readFileSync(path.join(ROOT, 'dist', bundleMatch[1]), 'utf8');
+    for (const eventName of DOCS_EVENT_NAMES) assert.ok(bundle.includes(eventName), `built runtime is missing ${eventName}`);
+  }
+
+  console.log(`PASS docs analytics privacy/schema/callers (${sourceRoutes.length} routes, ${portalLinks.length} Portal links)`);
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add one deep Docs analytics module for sanitized Umami pageviews, search-result buckets, CTA clicks, and governed Portal handoffs
- fence capture to docs.varity.so, respect Do Not Track, and reject unknown routes, events, properties, Portal targets, and UTM tuples
- add canonical UTM attribution to every authored Docs-to-Portal link and document analytics ownership

## Architecture declaration
Architecture impact: updated
Reason: Centralize Docs browser analytics privacy, event schemas, and Portal attribution behind one fail-closed module.
Affected runtime services/modules: Docs acquisition analytics module, DocsAnalytics Astro integration, global Head override
Interfaces/data/security/topology changed: Browser analytics interface, outbound event data schemas, and privacy controls changed; deployment topology unchanged.
Architecture/ADR files: ARCHITECTURE.md and ANALYTICS.md

## Test plan
- [x] npm run test:analytics — 52 routes and 9 Portal links
- [x] npm run check — all tests pass, Astro 0 errors, 55 pages built, built contracts and analytics pass
- [x] git diff --check
- [x] exact worktree served HTTP 200 on localhost:4321 through the canonical launcher
- [ ] fresh exact-worktree CloakBrowser capture — tracked Astro process exited before the browser connected; failures were ERR_CONNECTION_REFUSED with zero page console errors. An earlier source-equivalent hostile-URL capture passed. Founder instructed us not to keep recycling blocked dev servers.

## Accuracy-gate evidence
- Private gate was run against the exact branch through a temporary path adapter.
- The branch repository gate is green. The broader private accuracy gate remains red on independent existing canon/content debt: truth snapshot pricing.varityMonthly is missing, generated llms-full.txt contains hardcoded pricing, and existing pages trigger retired-language/unshipped-capability checks. This PR does not rewrite those claims.
- Corrected report: /tmp/varity-docs-umami-accuracy-corrected-20260901/gate.json (local evidence)

## Security Review
**Risk:** medium
**Rating:** PASS

- [x] No secret exposure; the Umami website ID is public tracker configuration
- [x] Auth boundaries intact
- [x] Template defaults unaffected
- [x] Intended Umami Cloud browser tracker is the only third-party access added
- [x] Credential Proxy integrity maintained
- [x] Tenant isolation unaffected
- [x] Inputs fail closed through exact route/event/property/UTM schemas and outbound sanitization
- [x] No dependency additions

## Agent notes
Tested against regression patterns: yes. Analytics cannot establish deployment, health, billing, or retention truth.
Follows shared rules: 0, 1, 2, 4, 5, 6, 7, 8.

Agent: Codex — Docs analytics integration