### PR TITLE
fix(architecture): exempt dependabot[bot] from the PR-body format gate

### DIFF
--- a/tests/test-architecture-governance.cjs
+++ b/tests/test-architecture-governance.cjs
@@ -46,17 +46,24 @@ if (eventName === 'pull_request') {
   } else {
     const event = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
     const body = event.pull_request?.body || '';
-    const impact = body.match(/^Architecture impact:\s*(none|updated)\s*$/im);
-    const reason = body.match(/^Reason:\s*(.+)\s*$/im);
-    const affected = body.match(/^Affected runtime services\/modules:\s*(.+)\s*$/im);
-    const changed = body.match(/^Interfaces\/data\/security\/topology changed:\s*(.+)\s*$/im);
-    const files = body.match(/^Architecture\/ADR files:\s*(.+)\s*$/im);
+    const author = event.pull_request?.user?.login;
 
-    if (!impact) errors.push('PR body must contain exactly "Architecture impact: none" or "Architecture impact: updated"');
-    if (!reason || reason[1].includes('<!--')) errors.push('PR body must contain a concrete Reason');
-    if (!affected) errors.push('PR body must name affected runtime services/modules or none');
-    if (!changed) errors.push('PR body must declare interface/data/security/topology impact');
-    if (!files) errors.push('PR body must name architecture/ADR files or none');
+    // Dependabot owns its generated PR body. Keep all repository architecture
+    // entrypoint checks above unconditional, but do not require a human-authored
+    // declaration shape that Dependabot cannot produce.
+    if (author !== 'dependabot[bot]') {
+      const impact = body.match(/^Architecture impact:\s*(none|updated)\s*$/im);
+      const reason = body.match(/^Reason:\s*(.+)\s*$/im);
+      const affected = body.match(/^Affected runtime services\/modules:\s*(.+)\s*$/im);
+      const changed = body.match(/^Interfaces\/data\/security\/topology changed:\s*(.+)\s*$/im);
+      const files = body.match(/^Architecture\/ADR files:\s*(.+)\s*$/im);
+
+      if (!impact) errors.push('PR body must contain exactly "Architecture impact: none" or "Architecture impact: updated"');
+      if (!reason || reason[1].includes('<!--')) errors.push('PR body must contain a concrete Reason');
+      if (!affected) errors.push('PR body must name affected runtime services/modules or none');
+      if (!changed) errors.push('PR body must declare interface/data/security/topology impact');
+      if (!files) errors.push('PR body must name architecture/ADR files or none');
+    }
   }
 }
 


### PR DESCRIPTION
Architecture impact: none
Reason: exempts one actor from a PR-metadata check; no runtime/build/publication behavior changes.
Affected runtime services/modules: none — only tests/test-architecture-governance.cjs
Interfaces/data/security/topology changed: no
Architecture/ADR files: none required

## What and why

`tests/test-architecture-governance.cjs` (the `docs-build` required check) unconditionally required every PR body to match `Architecture impact: none|updated` plus four other fields, added 2026-07-18 (`c870c988`). Dependabot generates its own PR body and has never produced one matching this. Measured 2026-09-04: 10 Dependabot PRs open, all blocked by this exact check; the 9 historical merges in this repo's history all predate the gate.

Same bug class already fixed and proven live in `varity-platform` (PR #298, merged 2026-09-03) — this repo currently has 31 known vulnerabilities (20 high, 7 moderate, 4 low) that Dependabot's automated PRs are the mechanism meant to close.

## What changed

Skip the PR-body-format assertions for the `dependabot[bot]` actor. The architecture-entrypoint checks (`CLAUDE.md`/`ARCHITECTURE.md` required markers) run unconditionally regardless of this change, for every actor. Every non-Dependabot author faces the identical requirement as before.

## Verification

Verified against a real, currently-open Dependabot PR body fetched fresh from GitHub: fails on current `master`, passes with this fix under the `dependabot[bot]` actor, and the identical body still fails under any other actor.

## Rollout

Merge. No deploy, no restart.

## Rollback

`git revert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtNnBsr3MMsBv3s4d9Zpkw