### PR TITLE
feat(observability): report browser errors from docs.varity.so to Better Stack

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,6 +116,23 @@ the module can strip raw URL query, hash, and referrer fields before the single
 manual pageview is sent. `ANALYTICS.md` owns the full privacy and report
 taxonomy contract.
 
+### Browser error reporting module
+
+- **Interface:** one Better Stack browser error tag mounted once from the
+  global Head override.
+- **Implementation:** `src/lib/betterstack-browser.mjs` and
+  `src/components/BetterStackBrowser.astro`.
+- **Seam:** the `betterstack.net/b.js` loader, initialised only when the
+  browser hostname is exactly `docs.varity.so`.
+- **Test surface:** `tests/test-betterstack-browser.cjs` and built HTML
+  inspection.
+
+The tag reports uncaught browser errors on the published site to the dedicated
+`docs.varity.so` error application. Its public application token is compiled
+into every page like the Umami website ID; no runtime credential is present.
+Local dev servers and preview hosts never initialise the tag, and it does not
+identify users.
+
 ## Content and artifact provenance
 
 | Published surface | Checked-in owner | Narrower authority to reconcile | Required verification |
@@ -182,6 +199,9 @@ and requires no production credential.
   closed on unknown routes, events, properties, Portal links, and UTM values.
   It never reads search input text or sends raw URL query, hash, or referrer
   fields.
+- The browser error tag is exact-host fenced, drops browser-extension frames,
+  and never identifies users. Uncaught errors leave the browser only from the
+  published `docs.varity.so` host.
 - All content in this public repository must be safe for public disclosure.
 - Examples use environment-variable names and non-secret sample values only.
 - Public interface documentation must stay provider-neutral and must not expose

--- a/package.json
+++ b/package.json
@@ -19,14 +19,16 @@
     "preview": "astro preview",
     "astro": "astro",
     "lint": "astro check",
-    "test": "npm run test:architecture && npm run test:contracts && npm run test:positioning && npm run test:analytics",
+    "test": "npm run test:architecture && npm run test:contracts && npm run test:positioning && npm run test:analytics && npm run test:errors",
     "test:architecture": "node tests/test-architecture-governance.cjs",
     "test:contracts": "node tests/test-contract-artifacts.cjs",
     "test:built-contracts": "VERIFY_DIST=1 node tests/test-contract-artifacts.cjs",
     "test:built-analytics": "VERIFY_DIST=1 node tests/test-docs-analytics.cjs",
     "test:positioning": "node tests/test-positioning-static.cjs",
     "test:analytics": "node tests/test-docs-analytics.cjs",
-    "check": "npm test && npm run lint && npm run build && npm run test:built-contracts && npm run test:built-analytics"
+    "test:errors": "node tests/test-betterstack-browser.cjs",
+    "test:built-errors": "VERIFY_DIST=1 node tests/test-betterstack-browser.cjs",
+    "check": "npm test && npm run lint && npm run build && npm run test:built-contracts && npm run test:built-analytics && npm run test:built-errors"
   },
   "dependencies": {
     "@astrojs/sitemap": "3.6.0",

--- a/src/components/BetterStackBrowser.astro
+++ b/src/components/BetterStackBrowser.astro
@@ -1,0 +1,32 @@
+---
+// Better Stack's browser error tag. Keeping the tag in one module prevents a
+// second browser error SDK from being mounted. The tag only initialises on the
+// exact production hostname, the same fence the Umami tracker uses, so local
+// dev servers and preview hosts never report into the production application.
+import { BETTERSTACK_BROWSER } from '../lib/betterstack-browser.mjs';
+---
+
+<script is:inline id="docs-betterstack" define:vars={{ ...BETTERSTACK_BROWSER }}>
+  if (window.location.hostname === hostname) {
+    !function (b, e, t, r) {
+      b[t] = b[t] || function () { (b[t].q = b[t].q || []).push(arguments); };
+      b[t].l = +new Date();
+      var s = e.createElement('script');
+      s.async = 1;
+      s.crossOrigin = 'anonymous';
+      s.src = 'https://betterstack.net/b.js?t=' + r;
+      (e.head || e.getElementsByTagName('head')[0]).appendChild(s);
+    }(window, document, 'betterstack', applicationToken);
+    betterstack('config', {
+      environment: 'production',
+      sentry: {
+        denyUrls: ['chrome-extension://', 'moz-extension://', 'safari-web-extension://'],
+        ignoreErrors: [
+          'ResizeObserver loop completed with undelivered notifications.',
+          'ResizeObserver loop limit exceeded',
+        ],
+      },
+    });
+    betterstack('init');
+  }
+</script>

--- a/src/components/overrides/Head.astro
+++ b/src/components/overrides/Head.astro
@@ -7,6 +7,7 @@
 // same source the default Head.astro consumes.
 import Default from "@astrojs/starlight/components/Head.astro";
 import DocsAnalytics from "../DocsAnalytics.astro";
+import BetterStackBrowser from "../BetterStackBrowser.astro";
 
 const SITE = "https://docs.varity.so";
 const OG_IMAGE = `${SITE}/og-image.png`;
@@ -170,3 +171,4 @@ const jsonLd = {
 <Default />
 <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
 <DocsAnalytics />
+<BetterStackBrowser />

--- a/src/lib/betterstack-browser.mjs
+++ b/src/lib/betterstack-browser.mjs
@@ -1,0 +1,10 @@
+// Better Stack browser error reporting for docs.varity.so.
+//
+// The application token is public by design and is compiled into every page,
+// exactly like the Umami website id in docs-analytics.mjs and the token the
+// Developer Portal ships in its own HTML. It identifies the dedicated
+// `docs.varity.so` error application; no runtime credential lives here.
+export const BETTERSTACK_BROWSER = Object.freeze({
+  hostname: 'docs.varity.so',
+  applicationToken: 'FLu3pfK3M1Za1khJdRt5cnrM',
+});

--- a/tests/test-betterstack-browser.cjs
+++ b/tests/test-betterstack-browser.cjs
@@ -1,0 +1,46 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const ROOT = path.resolve(__dirname, '..');
+const read = (file) => fs.readFileSync(path.join(ROOT, file), 'utf8');
+const count = (source, needle) => source.split(needle).length - 1;
+
+(async () => {
+  const { BETTERSTACK_BROWSER } = await import(pathToFileURL(path.join(ROOT, 'src/lib/betterstack-browser.mjs')).href);
+  assert.equal(BETTERSTACK_BROWSER.hostname, 'docs.varity.so');
+  assert.match(BETTERSTACK_BROWSER.applicationToken, /^[A-Za-z0-9]{20,}$/, 'application token must be the public browser token');
+
+  const head = read('src/components/overrides/Head.astro');
+  assert.equal(count(head, '<BetterStackBrowser />'), 1, 'exactly one browser error tag must be mounted');
+  assert.ok(head.indexOf('<BetterStackBrowser />') > head.indexOf('<Default />'), 'the tag must follow the default head');
+
+  const integration = read('src/components/BetterStackBrowser.astro');
+  for (const marker of [
+    "import { BETTERSTACK_BROWSER } from '../lib/betterstack-browser.mjs'",
+    'window.location.hostname === hostname',
+    "'https://betterstack.net/b.js?t='",
+    "betterstack('config'",
+    "betterstack('init')",
+    'chrome-extension://',
+    'moz-extension://',
+  ]) assert.ok(integration.includes(marker), `browser error tag is missing ${marker}`);
+  assert.equal(integration.includes("betterstack('user'"), false, 'the docs tag must not identify users');
+
+  const packageJson = read('package.json');
+  assert.equal(packageJson.includes('@sentry/'), false, 'no standalone Sentry SDK may compete with the tag');
+
+  if (process.env.VERIFY_DIST === '1') {
+    const builtHtml = read('dist/deploy/deploy-from-dashboard/index.html');
+    assert.equal(count(builtHtml, 'id="docs-betterstack"'), 1, 'built page must contain one browser error tag');
+    assert.equal(count(builtHtml, 'https://betterstack.net/b.js?t='), 1, 'built page must load the tag once');
+    assert.ok(builtHtml.includes(`"${BETTERSTACK_BROWSER.applicationToken}"`), 'built page must carry the public application token');
+    assert.ok(builtHtml.includes(`"${BETTERSTACK_BROWSER.hostname}"`), 'built page must carry the exact-host fence');
+  }
+
+  console.log('PASS Better Stack browser error tag (single mount, exact-host fence, public token)');
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What changed

Mounts the Better Stack browser error tag (`betterstack.net/b.js`) once from the global Starlight Head override, fenced to the exact `docs.varity.so` hostname the same way the Umami tracker is, carrying the public application token of the dedicated `docs.varity.so` error application (Better Stack application 2739112, `javascript_errors`, eu-central-1a, created 2026-09-05 21:22Z). A new repository test asserts the single mount, the exact-host fence, the absence of user identification and of a competing standalone Sentry SDK, and (with `VERIFY_DIST=1`) that the built HTML carries exactly one tag with the token. `ARCHITECTURE.md` gains the module and its security posture.

## Why

docs.varity.so had no error reporting at all: the previous Better Stack application for the site (2714791) never ingested a single event because the HTML carried no SDK, and it was deleted today as dead. Uncaught browser errors on the published docs are now visible next to the portal's and the backend services'.

The token is the browser application token, public by design and compiled into the HTML exactly like the Umami website id (`src/lib/docs-analytics.mjs`) and the token the Developer Portal ships in its own HTML (`src/components/BetterStackBrowser.tsx` there). No runtime credential is added. This repository's `.gitignore` excludes `.env.*`, so the token lives in a checked-in module rather than an `.env.production` file.

## Related issues

Closes #<!-- none -->

## Affected repositories

- `varity-docs` only. No backend, portal, CLI or MCP change.

## Contracts

- New outbound browser request from the published site: `https://betterstack.net/b.js?t=<public token>` and the events that SDK sends to Better Stack. Only on `window.location.hostname === "docs.varity.so"`; local dev servers, previews and IPFS gateway hostnames never initialise it.
- No change to any public artifact (`openapi.yaml`, `mcp-schema.json`, `llms.txt`, `llms-full.txt`), page content, route, or the Umami analytics contract.

## Verification

Run in a fresh worktree at `origin/master` (`ac0da61`) with `npm ci` (Node 22.19.0):

- `npm run check` (the CI command plus the built-HTML checks) - PASS: architecture governance, contract artifacts (33 OpenAPI paths, 22 MCP tools), positioning, analytics (52 routes, 9 Portal links), new `test:errors`, `astro check`, build (55 pages), `test:built-contracts`, `test:built-analytics`, new `test:built-errors`.
- Built inline script extracted from `dist/index.html` and passed `node --check`; `betterstack.net/b.js` occurs exactly once per page.
- Localhost: `boot.sh docs <this worktree>` on :4321, CloakBrowser `--goto http://localhost:4321/deploy/deploy-from-dashboard/` at 21:25Z returned `consoleErrors: []` (the tag correctly stays inert off the production hostname).
- Better Stack read-back (`applications`, `application 2739112`, 21:24Z): Active, `javascript_errors`, eu-central-1a; exactly one application named `docs.varity.so`.

## Rollout

Merge to `master`. The repository workflow (`.github/workflows/test-docs.yml`) only verifies; publishing is done by the external static host that serves docs.varity.so (live headers show `x-ipfs-path` behind BunnyCDN). Post-publish proof: `curl -s https://docs.varity.so/ | grep -c betterstack.net/b.js` returns `1`, then `mcp__betterstack__errors` on application 2739112 after a browser session on the live site.

## Rollback

Revert this commit. The tag is a single `<BetterStackBrowser />` mount in `src/components/overrides/Head.astro`; removing it removes every outbound request. No data migration, no other consumer.

## Architecture impact

Architecture impact: updated
Reason: the published site gains one third-party browser error SDK, a new outbound request and security-posture item recorded in ARCHITECTURE.md.
Affected runtime services/modules: none (varity-docs static site only; new Browser error reporting module)
Interfaces/data/security/topology changed: yes - one new outbound browser request to betterstack.net from the docs.varity.so host only
Architecture/ADR files: ARCHITECTURE.md

## Regression memory

1. What already works here, and how do I know? The Umami tracker mounted from `Head.astro` (`DocsAnalytics.astro`) and its test `tests/test-docs-analytics.cjs`; both untouched and still passing (52 routes, 9 Portal links, built HTML has one `docs-umami` tracker). `git grep` shows `Head.astro` is the only consumer of `DocsAnalytics.astro` and the only override that renders `<head>` additions.
2. What is the blast radius if I am wrong? Every page of docs.varity.so loads one extra async script; a syntax error in the inline tag would surface as a console error on every page, so the inline script is syntax-checked from the built output and the page is loaded in a real browser with zero console errors.
3. Which existing budget, limit or invariant could mine contradict? The single-mount invariant (one tracker per SDK) - enforced by the new test on both source and built HTML; the exact-host privacy fence - reused, not redefined.
4. Could my verification pass while the product is broken? The localhost check cannot prove ingestion because the fence is deliberately inert off the production host, so the post-publish proof (live HTML grep = 1 and `mcp__betterstack__errors` on 2739112 after a pageview) is listed in Rollout and is required before this is called shipped.

## Checklist

- [x] Code examples are tested and working (n/a: no prose or examples changed)
- [x] No forbidden vocabulary in prose
- [x] No em-dashes in prose
- [x] Build passes (`npm run build`)
- [x] Repository check passes (`npm run check`)
- [x] Links are valid
- [x] Spelling and grammar reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm9bEejrB8XkvMLZxXH6rD
