### PR TITLE
fix(observability): load the docs Better Stack tag with the js tag token, not the ingest token

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -128,7 +128,8 @@ taxonomy contract.
   inspection.
 
 The tag reports uncaught browser errors on the published site to the dedicated
-`docs.varity.so` error application. Its public application token is compiled
+`docs.varity.so` error application. The application's public js tag token
+(`js_tag_token` in the Errors API, distinct from its ingest token) is compiled
 into every page like the Umami website ID; no runtime credential is present.
 Local dev servers and preview hosts never initialise the tag, and it does not
 identify users.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:analytics": "node tests/test-docs-analytics.cjs",
     "test:errors": "node tests/test-betterstack-browser.cjs",
     "test:built-errors": "VERIFY_DIST=1 node tests/test-betterstack-browser.cjs",
+    "test:live-errors": "VERIFY_LIVE=1 node tests/test-betterstack-browser.cjs",
     "check": "npm test && npm run lint && npm run build && npm run test:built-contracts && npm run test:built-analytics && npm run test:built-errors"
   },
   "dependencies": {

--- a/src/components/BetterStackBrowser.astro
+++ b/src/components/BetterStackBrowser.astro
@@ -16,7 +16,7 @@ import { BETTERSTACK_BROWSER } from '../lib/betterstack-browser.mjs';
       s.crossOrigin = 'anonymous';
       s.src = 'https://betterstack.net/b.js?t=' + r;
       (e.head || e.getElementsByTagName('head')[0]).appendChild(s);
-    }(window, document, 'betterstack', applicationToken);
+    }(window, document, 'betterstack', jsTagToken);
     betterstack('config', {
       environment: 'production',
       sentry: {

--- a/src/lib/betterstack-browser.mjs
+++ b/src/lib/betterstack-browser.mjs
@@ -1,10 +1,14 @@
 // Better Stack browser error reporting for docs.varity.so.
 //
-// The application token is public by design and is compiled into every page,
-// exactly like the Umami website id in docs-analytics.mjs and the token the
-// Developer Portal ships in its own HTML. It identifies the dedicated
-// `docs.varity.so` error application; no runtime credential lives here.
+// `jsTagToken` is the application's `js_tag_token` (Better Stack Errors API,
+// `GET https://errors.betterstack.com/api/v1/applications`), the value the
+// Frontend tab prints into the `<script>` snippet. It is NOT the ingest
+// `token`/DSN of the same application: `betterstack.net/b.js?t=` answers that
+// one with `console.error('[betterstack.js]: Invalid token...')` and reports
+// nothing, which is exactly what shipped in #119. The js tag token is public
+// by design and is compiled into every page, exactly like the Umami website
+// id in docs-analytics.mjs; no runtime credential lives here.
 export const BETTERSTACK_BROWSER = Object.freeze({
   hostname: 'docs.varity.so',
-  applicationToken: 'FLu3pfK3M1Za1khJdRt5cnrM',
+  jsTagToken: 'pvHyZ213jyJBGJbKBNH4uCMq',
 });

--- a/tests/test-betterstack-browser.cjs
+++ b/tests/test-betterstack-browser.cjs
@@ -10,7 +10,7 @@ const count = (source, needle) => source.split(needle).length - 1;
 (async () => {
   const { BETTERSTACK_BROWSER } = await import(pathToFileURL(path.join(ROOT, 'src/lib/betterstack-browser.mjs')).href);
   assert.equal(BETTERSTACK_BROWSER.hostname, 'docs.varity.so');
-  assert.match(BETTERSTACK_BROWSER.applicationToken, /^[A-Za-z0-9]{20,}$/, 'application token must be the public browser token');
+  assert.match(BETTERSTACK_BROWSER.jsTagToken, /^[A-Za-z0-9]{20,}$/, 'js tag token must be the public browser token');
 
   const head = read('src/components/overrides/Head.astro');
   assert.equal(count(head, '<BetterStackBrowser />'), 1, 'exactly one browser error tag must be mounted');
@@ -35,11 +35,21 @@ const count = (source, needle) => source.split(needle).length - 1;
     const builtHtml = read('dist/deploy/deploy-from-dashboard/index.html');
     assert.equal(count(builtHtml, 'id="docs-betterstack"'), 1, 'built page must contain one browser error tag');
     assert.equal(count(builtHtml, 'https://betterstack.net/b.js?t='), 1, 'built page must load the tag once');
-    assert.ok(builtHtml.includes(`"${BETTERSTACK_BROWSER.applicationToken}"`), 'built page must carry the public application token');
+    assert.ok(builtHtml.includes(`"${BETTERSTACK_BROWSER.jsTagToken}"`), 'built page must carry the public js tag token');
     assert.ok(builtHtml.includes(`"${BETTERSTACK_BROWSER.hostname}"`), 'built page must carry the exact-host fence');
   }
 
-  console.log('PASS Better Stack browser error tag (single mount, exact-host fence, public token)');
+  if (process.env.VERIFY_LIVE === '1') {
+    // Network check, deliberately outside `npm test`/CI: the only way to tell the
+    // js tag token from the same application's ingest token is to ask b.js.
+    const response = await fetch(`https://betterstack.net/b.js?t=${BETTERSTACK_BROWSER.jsTagToken}`);
+    const body = await response.text();
+    assert.equal(response.status, 200, 'b.js must answer 200 for the js tag token');
+    assert.equal(body.includes('Invalid token'), false, 'b.js rejected the token: this is the ingest token, not js_tag_token');
+    assert.ok(body.length > 100000, `b.js must serve the SDK, got ${body.length} bytes`);
+  }
+
+  console.log('PASS Better Stack browser error tag (single mount, exact-host fence, public js tag token)');
 })().catch((error) => {
   console.error(error);
   process.exitCode = 1;


### PR DESCRIPTION
## What changed

The Better Stack browser tag shipped in #119 carries the wrong credential. It compiles application 2739112's ingest `token` (the DSN credential) into `betterstack.net/b.js?t=`, and Better Stack answers that with an 83-byte stub, `console.error('[betterstack.js]: Invalid token. Please check your configuration.')`. The SDK never initialises, `window.betterstack.q` keeps the two queued calls forever, no error is ever reported, and every docs pageview prints a console error instead.

This PR swaps the value for the application's `js_tag_token` (the value the Frontend tab prints into the snippet, read from `GET https://errors.betterstack.com/api/v1/applications`), renames the field `applicationToken` to `jsTagToken` so the two same-length tokens cannot be confused again, corrects the module comment and `ARCHITECTURE.md`, and adds an opt-in network check (`npm run test:live-errors`) that asks `b.js` whether it accepts the committed token. The check is deliberately outside `npm test` and CI, which stay offline and unprivileged.

## Why

`docs.varity.so` had no error reporting: application 2714791 never ingested because the HTML carried no SDK, and #119 replaced it with an SDK that loads and immediately refuses the token. Both states look identical to the offline test suite, because a 24-character ingest token and a 24-character js tag token satisfy the same regex. The Developer Portal hit the same class on 2026-09-03 (varity-portal #120, "sync the committed frontend tag token to the live one").

## Related issues

Closes #<!-- none -->

## Affected repositories

- `varity-docs` only. No backend, portal, CLI or MCP change. Better Stack application 2739112 is unchanged (no console or API mutation).

## Contracts

- The outbound browser request stays `https://betterstack.net/b.js?t=<public js tag token>` from `window.location.hostname === "docs.varity.so"` only; the value of `t` changes. The SDK it now loads reports to `s2739112.eu-central-1a.betterstackdata.com` (the host referenced inside the served `b.js`).
- `BETTERSTACK_BROWSER.applicationToken` is renamed `jsTagToken`. Consumers enumerated with `git grep -n applicationToken` at `b39fd0b`: `src/lib/betterstack-browser.mjs:9` (definition), `src/components/BetterStackBrowser.astro:19`, `tests/test-betterstack-browser.cjs:13` and `:38`. All four are in this diff; nothing else in the repository reads the object.
- No change to any public artifact (`openapi.yaml`, `mcp-schema.json`, `llms.txt`, `llms-full.txt`), page content, route, or the Umami analytics contract.

## Verification

Observed 2026-09-06 00:52Z to 00:57Z, worktree at `origin/master` (`b39fd0b`), `npm ci`, Node 22.19.0:

- Defect reproduced, not asserted: `curl https://betterstack.net/b.js?t=<live docs HTML token>` returns HTTP 200, 83 bytes, body `console.error('[betterstack.js]: Invalid token. Please check your configuration.')`; the same request with the portal's committed frontend token returns 354,218 bytes of SDK. A headless Chromium session on the live site (Chrome for Testing 147, playwright-core 1.60) observed `b.js` 200, `typeof window.betterstack === "function"` and `window.betterstack.q.length === 2` three seconds later, and no outbound request to any `betterstackdata.com` host after a thrown probe error.
- `curl https://betterstack.net/b.js?t=<js_tag_token>` returns HTTP 200, 354,218 bytes, no `Invalid token`, references `s2739112.eu-central-1a.betterstackdata.com`. The Errors API reports `js_tag_token != token` for 2739112.
- `npm run check` (the CI command plus built-HTML checks): PASS. architecture governance, contract artifacts (33 OpenAPI paths, 22 MCP tools), positioning (52 files), analytics (52 routes, 9 Portal links), `test:errors`, `astro check` (0 errors), build, `test:built-contracts`, `test:built-analytics`, `test:built-errors`.
- `npm run test:live-errors`: PASS with the new token. Red-proofed: with the module stashed back to the ingest token the same command FAILS on `b.js rejected the token: this is the ingest token, not js_tag_token`.
- Built inline tag extracted from `dist/index.html` passes `node --check`; `dist/index.html` contains the js tag token once and `betterstack.net/b.js` once.
- Localhost is deliberately not a proof here: the tag is fenced to the production hostname and stays inert on `:4321` (verified in #119). The proof of this change is post-publish, see Rollout.

## Rollout

Merge to `master`. `.github/workflows/test-docs.yml` only verifies; the external static host publishes `master` (live headers: `x-ipfs-path` behind BunnyCDN; #119 merged 21:27Z and was live by 00:46Z). Post-publish proof, in order:

1. `curl -s https://docs.varity.so/ | grep -c betterstack.net/b.js` returns `1` and the page carries the js tag token, not the ingest token.
2. A real browser session on `https://docs.varity.so/` shows `b.js` 200 and an outbound POST to `s2739112.eu-central-1a.betterstackdata.com`.
3. `mcp__betterstack__errors` (application 2739112) lists the labelled probe error thrown in that session.

## Rollback

Revert this commit: the tag returns to the dead-but-harmless #119 state (one console error per pageview, nothing reported). Reverting #119 as well removes the tag entirely. No data migration, no other consumer.

## Architecture impact

Architecture impact: updated
Reason: the browser error reporting module's credential is corrected and its documented security posture now names the js tag token as distinct from the ingest token.
Affected runtime services/modules: none (varity-docs static site only; Browser error reporting module)
Interfaces/data/security/topology changed: no
Architecture/ADR files: ARCHITECTURE.md

## Regression memory

1. What already works here, and how do I know? The Umami tracker (`DocsAnalytics.astro`, `tests/test-docs-analytics.cjs`) and the single-mount `<BetterStackBrowser />` in `Head.astro` (`tests/test-betterstack-browser.cjs`), both untouched and passing in `npm run check`. Every consumer of the renamed field is listed under Contracts from `git grep`.
2. What is the blast radius if I am wrong? Every page of docs.varity.so loads the tag; a wrong value here means either the current dead state (stub script, console error) or a tag reporting into the wrong application. Both are caught by `test:live-errors` before merge and by the post-publish probe after.
3. Which existing budget, limit or invariant could mine contradict? The single-mount invariant and the exact-host privacy fence are unchanged and still asserted on source and built HTML. No new SDK, no user identification.
4. Could my verification pass while the product is broken? The offline suite can (it did for #119), which is why this PR adds the network check and red-proofs it against the old token. The final proof is an ingested event visible through the Better Stack MCP, recorded in the session report.

## Checklist

- [x] Code examples are tested and working (n/a: no prose or examples changed)
- [x] No forbidden vocabulary in prose
- [x] No em-dashes in prose
- [x] Build passes (`npm run build`)
- [x] Repository check passes (`npm run check`)
- [x] Links are valid
- [x] Spelling and grammar reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm9bEejrB8XkvMLZxXH6rD
