### PR TITLE
docs(pricing): drop the retired $21 refill fee; state the two-hour machine minimum

### DIFF
--- a/src/content/docs/resources/pricing.mdx
+++ b/src/content/docs/resources/pricing.mdx
@@ -36,15 +36,15 @@ Dynamic apps select one of four fixed presets. Each price is a **monthly maximum
 
 ## CPU VMs
 
-CPU VMs bill **hourly against a hard monthly cap**: the hourly rate is derived from the VM's monthly maximum divided by 730 hours, and the month's compute charge never exceeds that cap. Every VM includes a **20 GB NVMe boot disk** and **one public IPv4**, with no separate ingress or egress charge. Additional NVMe storage is **$0.09/GB-month**, prorated hourly. Billing continues while the VM's resources remain reserved; stopping the guest OS does not by itself release them; delete the VM to stop billing. VM sizes and regions are published in the Developer Portal as they pass Varity's end-to-end release verification.
+CPU VMs bill **hourly against a hard monthly cap**: the hourly rate is derived from the VM's monthly maximum divided by 730 hours, and the month's compute charge never exceeds that cap. Every VM includes a **20 GB NVMe boot disk** and **one public IPv4**, with no separate ingress or egress charge. Additional NVMe storage is **$0.09/GB-month**, prorated hourly. Every VM carries a **two-hour minimum**: the first two hours at the quoted hourly rate are booked when the machine is created, and longer runtimes bill by elapsed hour. Billing continues while the VM's resources remain reserved; stopping the guest OS does not by itself release them; delete the VM to stop billing. VM sizes and regions are published in the Developer Portal as they pass Varity's end-to-end release verification.
 
 ## GPU
 
-GPU pricing is a **live quote**: the exact hourly rate is computed server-side from currently available capacity and shown before you commit. Any continuous-use monthly figure is an estimate for planning, never a cap. GPU workloads are paid-only and are excluded from the launch credit.
+GPU pricing is a **live quote**: the exact hourly rate is computed server-side from currently available capacity and shown before you commit. Any continuous-use monthly figure is an estimate for planning, never a cap. GPU machines carry the same two-hour minimum as CPU VMs, booked when the machine is created. GPU workloads are paid-only and are excluded from the launch credit.
 
 ## AI Gateway
 
-The AI Gateway bills the provider's actual cost for your requests **plus a 5% Varity fee**, drawn from a prepaid balance. The minimum refill is **$20** (a $21 charge before tax, including the fee). AI Gateway balances are separate from other Varity products and cannot be spent on Cloud, VM, GPU, or static hosting.
+The AI Gateway bills the provider's actual cost for your requests **plus a 5% Varity fee**, drawn from a prepaid balance. The minimum refill is **$20** and the maximum is $1,000; you are charged exactly the balance you are credited, with no funding fee. AI Gateway balances are separate from other Varity products and cannot be spent on Cloud, VM, GPU, or static hosting.
 
 ## Launch Credit
 

--- a/tests/test-contract-artifacts.cjs
+++ b/tests/test-contract-artifacts.cjs
@@ -118,6 +118,16 @@ for (const [name, content] of [['public/llms.txt', llms], ['public/llms-full.txt
 }
 if (llmsFull.length <= llms.length) errors.push('public/llms-full.txt must contain more context than public/llms.txt');
 
+// Pricing rules the executable owners state (varity-platform, tags gateway-v1.14.30 /
+// deploy-api-v0.5.239): the AI Gateway funding fee is 0 (ai-gateway-billing.ts
+// FUNDING_SERVICE_FEE_CENTS = 0), and every machine seals a 7 200 s minimum
+// runway that billing-meter books at create (accelerator_quote.py:44,
+// machine_operations_api.py:467, gpu-hourly-usage.ts machineUsageOverlapUsd).
+const pricingPage = read('src/content/docs/resources/pricing.mdx');
+if (/\$21|including the fee/.test(pricingPage)) errors.push('resources/pricing.mdx must not restate the retired AI Gateway funding fee');
+if (!pricingPage.includes('no funding fee')) errors.push('resources/pricing.mdx must state that a refill carries no funding fee');
+if ((pricingPage.match(/two-hour minimum/g) || []).length < 2) errors.push('resources/pricing.mdx must state the two-hour machine minimum for CPU VMs and GPU machines');
+
 if (process.env.VERIFY_DIST === '1') {
   for (const artifact of ['openapi.yaml', 'mcp-schema.json', 'llms.txt', 'llms-full.txt']) {
     const publicPath = path.join(root, 'public', artifact);


### PR DESCRIPTION
## Summary

Two documented pricing rules where `resources/pricing.mdx` disagreed with the executable owner (`PRICING.md` routing, `PRICING-AND-BILLING.md` C1), reconciled 2026-09-06:

| Rule | Documented | Executable source | Docs page (live, 2026-09-06 18:20Z) | Fix |
|---|---|---|---|---|
| AI Gateway refill fee | `PRICING-AND-BILLING.md` C1: fee model retired, "resolve by correcting the docs" | `varity-gateway/src/routes/ai-gateway-billing.ts:34` `FUNDING_SERVICE_FEE_CENTS = 0`; `:21-22` $20 min / $1,000 max; locked by `pricing-card-contract.test.ts` | "a $21 charge before tax, including the fee" | State the $20 minimum, $1,000 maximum, and no funding fee |
| Machine two-hour minimum | `billing-meter/BILLING-ARCHITECTURE.md:257` "the founder's two-hour minimum"; `gpu_hourly_usage.py:78-81` | `accelerator_quote.py:44` `GPU_MACHINE_QUOTE_MINIMUM_RUNWAY_SECONDS = 7_200`, applied to CPU VMs and GPU machines at `machine_operations_api.py:467`; booked by `gpu-hourly-usage.ts` `machineUsageOverlapUsd` (deployed tag `deploy-api-v0.5.239`, read with `git show`) | Absent from the CPU VM and GPU sections; portal PR #126 already states it | State the minimum in both sections |

GPU containers keep their elapsed-only contract (`machineUsageOverlapUsd` returns early for `container`); this PR deliberately says nothing about containers.

## Affected repositories

- `varity-docs` only (`src/content/docs/resources/pricing.mdx`, `tests/test-contract-artifacts.cjs`).

## Contracts

- No API or data contract changes. The new assertions in `test-contract-artifacts.cjs` lock the page to the executable values above so the retired fee cannot return.

## Verification

- `npm test` PASS (architecture, contracts, positioning, analytics, errors).
- `npm run lint && npm run build && npm run test:built-contracts` PASS (exit 0) in a fresh worktree from `origin/master` (`01c0cba`).
- Live docs page still shows the "$21" text (curl, 2026-09-06 18:20Z), confirming the defect is on the published surface.

## Rollout

- Merge to `master`; the docs site republishes through the existing pipeline. No runtime change.

## Rollback

- Revert this commit. No data or config to unwind.

## Regression memory (REGRESSIONS-LEDGER.md)

1. **What already works here, and how do I know?** The page renders and the contract tests pass on `origin/master`; the only consumers of `pricing.mdx` are the Astro build and `test-positioning-static.cjs` (forbidden-word scan), both run above.
2. **What is the blast radius if I am wrong?** One prose page. No code path reads it.
3. **Which existing budget, limit or invariant could mine contradict?** The $20/$1,000 refill bounds and the 7 200 s runway are quoted from the deployed tags, not from memory; the docs-accuracy config has no pin on the old "$21" string (grep, 2026-09-06).
4. **Could my verification pass while the product is broken?** The build proves the page compiles, not that the copy is true; truth is pinned by citing `git show <tag>:<path>` above and by the new contract assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm9bEejrB8XkvMLZxXH6rD

Architecture impact: none
Reason: documentation wording only; states the existing two-hour machine minimum and removes a retired fee sentence.
Affected runtime services/modules: none
Interfaces/data/security/topology changed: none
Architecture/ADR files: none
