### PR TITLE
docs(pricing): founder pricing decisions 2026-09-06 (D1–D5) with contract locks

### DIFF
--- a/src/content/docs/cli/commands/deploy.mdx
+++ b/src/content/docs/cli/commands/deploy.mdx
@@ -42,7 +42,7 @@ varitykit app deploy
 - Global CDN distribution
 - Permanent deployment URLs
 - Automatic SSL
-- Free for verified accounts, up to 3 active static sites and 1 GB of pinned assets
+- First 3 static sites free, then $1/month per site, for verified accounts; 1 GB of pinned assets
 
 ### Dynamic Apps
 

--- a/src/content/docs/cli/overview.mdx
+++ b/src/content/docs/cli/overview.mdx
@@ -132,7 +132,7 @@ varitykit app deploy
 ```
 
 - **Best for**: Marketing sites, documentation, SPAs
-- **Cost**: Free for verified accounts, up to 3 active static sites and 1 GB of pinned assets. See [Pricing and Costs](/resources/pricing/).
+- **Cost**: First 3 static sites free, then $1/month per site, for verified accounts; 1 GB of pinned assets. See [Pricing and Costs](/resources/pricing/).
 - **Speed**: Global CDN distribution
 
 ### Dynamic Apps

--- a/src/content/docs/resources/billing.mdx
+++ b/src/content/docs/resources/billing.mdx
@@ -13,11 +13,11 @@ import PageMeta from '../../../components/PageMeta.astro';
   stability="stable"
 />
 
-Varity billing is built to be predictable: each paid app bills up to a fixed monthly maximum for the resources it reserves, prorated by running time, and the bill doesn't grow with your traffic. Static sites are free for verified accounts. This page covers the practical side: adding a card, what you're charged for, and where to see your costs.
+Varity billing is built to be predictable: each paid app bills up to a fixed monthly maximum for the resources it reserves, prorated by running time, and the bill doesn't grow with your traffic. Your first 3 static sites are free for a verified account, then $1/month per site. This page covers the practical side: adding a card, what you're charged for, and where to see your costs.
 
 ## A Card on File
 
-Varity asks for a payment method **before your first paid deploy**, so your app can go live and keep running. You add it once in the dashboard; you're only charged for apps you actually deploy. Free static sites don't need a card; a verified account is enough.
+Varity asks for a payment method **before your first paid deploy**, so your app can go live and keep running. You add it once in the dashboard; you're only charged for apps you actually deploy. Free static sites (your first 3) don't need a card; a verified account is enough.
 
 ## What You're Charged For
 
@@ -32,7 +32,7 @@ Your bill does **not** change with:
 This is the core difference from usage-metered hosting, where billing follows usage meters. With Varity, an unchanged profile keeps the same monthly maximum no matter how much traffic it serves. For the full model, see [How Pricing Works](/resources/pricing/).
 
 <Aside type="note">
-Static sites are free for verified accounts (up to 3 active sites and 1 GB of pinned assets). Dynamic apps select a Managed Cloud preset. Use the cost calculator in the dashboard (or the `varity_cost_calculator` tool in your AI editor) for a current estimate before you deploy.
+First 3 static sites free, then $1/month per site, for verified accounts (1 GB of pinned assets). Dynamic apps select a Managed Cloud preset. Use the cost calculator in the dashboard (or the `varity_cost_calculator` tool in your AI editor) for a current estimate before you deploy.
 </Aside>
 
 ## Seeing Your Costs

--- a/src/content/docs/resources/faq.mdx
+++ b/src/content/docs/resources/faq.mdx
@@ -92,7 +92,7 @@ No. Your existing auth works as-is. Set any secrets your provider needs as envir
 
 ### How much does Varity cost?
 
-Static sites are free for verified accounts (up to 3 active sites, 1 GB of pinned assets). Dynamic apps select a fixed Managed Cloud preset that bills up to a monthly maximum, prorated by running time.
+First 3 static sites free, then $1/month per site, for verified accounts (1 GB of pinned assets). Dynamic apps select a fixed Managed Cloud preset that bills up to a monthly maximum, prorated by running time.
 
 For current numbers, use [Pricing and Costs](/resources/pricing) or run `varity_cost_calculator`.
 

--- a/src/content/docs/resources/pricing.mdx
+++ b/src/content/docs/resources/pricing.mdx
@@ -15,9 +15,9 @@ import PageMeta from '../../../components/PageMeta.astro';
 
 Varity pricing is based on the resources a deployment reserves, not usage metering. For an unchanged deployment profile, your bill does not grow with request volume, bandwidth, or invocation count; changing the profile (resources, services, replicas, accelerators, or app count) can change the price.
 
-## Static Sites: Free
+## Static Sites: First 3 Free
 
-Static sites are **free** for verified accounts, with a limit of **3 active static sites** and **1 GB of total pinned assets** per account. No payment method is required for free static hosting, only a verified account. Larger or dynamic apps use Managed Cloud.
+**First 3 static sites free, then $1/month per site.** Your first **3 active static sites** are free for a verified account; each additional active static site is **$1.00/month**, prorated by the time it is live. Deleting a site frees its slot. Accounts keep a **1 GB of total pinned assets** limit. No payment method is required for the free sites, only a verified account. Larger or dynamic apps use Managed Cloud.
 
 ## Managed Cloud Presets
 
@@ -30,7 +30,7 @@ Dynamic apps select one of four fixed presets. Each price is a **monthly maximum
 | Scale | 2 | 4 GB | 25 GB | Up to $28/mo, prorated |
 | Pro | 4 | 8 GB | 50 GB | Up to $56/mo, prorated |
 
-- Attached services (Postgres, Redis, MongoDB, MySQL, object storage) select their own preset and bill as separate reserved deployments.
+- Attached services (Postgres, Redis, MongoDB, MySQL, object storage) each bill their own Starter reservation ($7/mo) as a separate reserved deployment, plus the storage you enter for them: **$7.00 service + N GB × $0.16 = your monthly maximum** per service. Storage defaults to 5 GB and can be set from 1 to 100 GB; Redis is in-memory and takes no volume. Ollama is retired for new deployments.
 - Persistent storage is an add-on at **$0.16/GB-month**, prorated on the same period. It bills while allocated, until the volume is deleted.
 - Each replica reserves its own resources: 2 replicas of a preset bill up to 2x that preset's maximum.
 
@@ -40,7 +40,7 @@ CPU VMs bill **hourly against a hard monthly cap**: the hourly rate is derived f
 
 ## GPU
 
-GPU pricing is a **live quote**: the exact hourly rate is computed server-side from currently available capacity and shown before you commit. Any continuous-use monthly figure is an estimate for planning, never a cap. GPU machines carry the same two-hour minimum as CPU VMs, booked when the machine is created. GPU workloads are paid-only and are excluded from the launch credit.
+GPU pricing is a **live quote**: the exact hourly rate is computed server-side from currently available capacity and shown before you commit. Any continuous-use monthly figure is an estimate for planning, never a cap. GPU machines and GPU containers carry the same two-hour minimum as CPU VMs, booked when the machine or container is created: the minimum for the first 2h is billed at deploy. GPU workloads are paid-only and are excluded from the launch credit.
 
 ## AI Gateway
 

--- a/tests/test-contract-artifacts.cjs
+++ b/tests/test-contract-artifacts.cjs
@@ -127,6 +127,16 @@ const pricingPage = read('src/content/docs/resources/pricing.mdx');
 if (/\$21|including the fee/.test(pricingPage)) errors.push('resources/pricing.mdx must not restate the retired AI Gateway funding fee');
 if (!pricingPage.includes('no funding fee')) errors.push('resources/pricing.mdx must state that a refill carries no funding fee');
 if ((pricingPage.match(/two-hour minimum/g) || []).length < 2) errors.push('resources/pricing.mdx must state the two-hour machine minimum for CPU VMs and GPU machines');
+// Founder pricing decisions 2026-09-06 (D1, D2/D3, D4, D5).
+if (!pricingPage.includes('First 3 static sites free, then $1/month per site')) errors.push('resources/pricing.mdx must state "First 3 static sites free, then $1/month per site" (decision D1)');
+if (/Static sites are \*\*free\*\*/.test(pricingPage)) errors.push('resources/pricing.mdx must not claim unconditional free static hosting (decision D1)');
+if (!pricingPage.includes('$7.00 service + N GB × $0.16')) errors.push('resources/pricing.mdx must show the per-service "$7.00 service + N GB × $0.16" formula (decision D2)');
+if (!/Redis is in-memory/.test(pricingPage)) errors.push('resources/pricing.mdx must state that Redis takes no volume (decision D3)');
+if (!/Ollama is retired/.test(pricingPage)) errors.push('resources/pricing.mdx must state that Ollama is retired for new deployments (decision D4)');
+if (!/GPU containers carry the same two-hour minimum/.test(pricingPage)) errors.push('resources/pricing.mdx must state the GPU container two-hour minimum (decision D5)');
+for (const page of ['src/content/docs/resources/billing.mdx', 'src/content/docs/resources/faq.mdx', 'src/content/docs/cli/overview.mdx', 'src/content/docs/cli/commands/deploy.mdx']) {
+  if (!read(page).includes('$1/month per site')) errors.push(`${page} must carry the "then $1/month per site" static pricing (decision D1)`);
+}
 
 if (process.env.VERIFY_DIST === '1') {
   for (const artifact of ['openapi.yaml', 'mcp-schema.json', 'llms.txt', 'llms-full.txt']) {


### PR DESCRIPTION
## Summary

Founder pricing decisions approved 2026-09-06, applied to the public docs:

- **D1 static sites** → `src/content/docs/resources/pricing.mdx` "Static Sites: First 3 Free": "First 3 static sites free, then $1/month per site"; the same line replaces the unconditional "free" copy in `resources/billing.mdx` (3 places), `resources/faq.mdx`, `cli/overview.mdx`, `cli/commands/deploy.mdx`.
- **D2/D3 attached services** → `pricing.mdx` Managed Cloud bullets: each service bills its Starter reservation plus user-entered storage, "$7.00 service + N GB × $0.16", default 5 GB, 1–100 GB, Redis in-memory (no volume).
- **D4 Ollama** → `pricing.mdx`: "Ollama is retired for new deployments".
- **D5 GPU containers** → `pricing.mdx` GPU section: GPU containers carry the same two-hour minimum as GPU machines, "the minimum for the first 2h is billed at deploy".
- **Contract lock** → `tests/test-contract-artifacts.cjs` now fails if any of the five statements above disappears, or if `pricing.mdx` returns to unconditional "Static sites are **free**".

The executable owners (gateway `services/varity-gateway/src/pricing/index.ts`, billing-meter, deploy-api) change in the companion varity-platform PR; the portal in the companion varity-portal PR. These docs describe the decided behaviour and must not be published to docs.varity.so before the platform release that implements it ships (see Rollout).

## Affected repositories

- `varity-docs` (this PR)
- Companion: `varity-platform` (gateway 1.14.35, deploy-api 0.5.242, billing-meter 1.2.53), `varity-portal`.

## Contracts

- No API contract in this repository. Copy now states: `free_sites_included: 3`, `additional_site_monthly_usd: 1` (gateway `GET /api/pricing` static body), the additive attached-service breakdown fields, and the new `service_retired` 400 code — all defined producer-side in the platform PR.

Architecture impact: none
Reason: documentation copy and its contract lock only; no runtime, topology, data or interface change in this repository.
Affected runtime services/modules: none (docs content `src/content/docs/resources/pricing.mdx`, `billing.mdx`, `faq.mdx`, `cli/overview.mdx`, `cli/commands/deploy.mdx`; lock `tests/test-contract-artifacts.cjs`)
Interfaces/data/security/topology changed: none
Architecture/ADR files: none

## Verification

- `npm test` (worktree, Node from the primary checkout's node_modules): `PASS public contract artifacts (33 OpenAPI paths, 22 MCP tools)`, `PASS — all 52 docs files clean of high-severity positioning violations`, `PASS docs analytics privacy/schema/callers (52 routes, 9 Portal links)`, `PASS Better Stack browser error tag`.
- `npm run test:contracts` re-run after adding the new locks: PASS.
- Not verified: a localhost render of the pricing page (no dev server started in this run).

## Rollout

Merge only together with, or after, the varity-platform release that implements D1–D5 (gateway 1.14.35 / billing-meter 1.2.53 / deploy-api 0.5.242 published and swapped) so the docs never describe a price the gateway does not yet serve.

## Rollback

`git revert` this merge; the contract lock reverts with it. No data or runtime effect.

## Regression memory (REGRESSIONS-LEDGER.md)

1. What already worked here that this touches: the pricing page copy and its lock (`two-hour minimum` count, `no funding fee`). Both assertions still pass; the new locks are additive.
2. Which ledger rules apply: R11-class "docs are not truth" — the copy is gated to ship after the executable change, not before.
3. What I enumerated: `grep -rn "free" src/content/docs` for static-hosting claims (5 files changed; `deploy/*.mdx` Ollama mentions describe existing deployments and were left unchanged).
4. What could still be wrong: `deploy/auto-wired-services.mdx`, `deploy/databases.mdx`, `deploy/what-you-can-deploy.mdx`, `tutorials/deploy-ai-agent.mdx` still mention Ollama as attachable; not changed in this PR (out of the six decisions' named scope, flagged for a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm9bEejrB8XkvMLZxXH6rD
