### PR TITLE
docs: client parity fixes from the new-developer audit of the MCP and CLI

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -706,19 +706,9 @@ The MCP server supports two transports:
 - **stdio** (default): for desktop editors like Cursor, Claude Code, VS Code, Windsurf
 - **HTTP**: for browser-based AI tools like Claude.ai and ChatGPT
 
-### Hosted MCP
+### Hosted MCP (retired)
 
-Connect directly to the hosted Varity MCP at:
-
-```
-https://mcp.varity.so
-```
-
-**Claude.ai:** Settings → Connectors → Add MCP Server → URL: `https://mcp.varity.so`
-
-**ChatGPT:** Settings → Connectors → Create → MCP server URL: `https://mcp.varity.so`
-
-Hosted OAuth login is in progress: hosted OAuth and per-user deployment authorization are not yet certified end to end. Until that verification passes, do not use the hosted endpoint for owner-scoped operations (deploys, env changes, deletes) — connect via the stdio package (`npx -y @varity-labs/mcp`) instead.
+The hosted endpoint `mcp.varity.so` is retired. Browser-based tools that only accept a remote MCP URL are not supported today; use the stdio package (`npx -y @varity-labs/mcp`) from Claude Code, Cursor, VS Code, or Windsurf, or the [llms.txt context files](#llmstxt-alternative) for LLMs without MCP support.
 
 ### Self-Hosted HTTP
 
@@ -4736,17 +4726,7 @@ The AI calls `varity_migrate`, which clones the repository, removes Vercel-speci
 
 ## Browser-based AI tools (Claude.ai, ChatGPT)
 
-If you use a browser-based AI tool instead of a desktop editor, connect to the hosted MCP endpoint:
-
-```
-https://mcp.varity.so
-```
-
-**Claude.ai:** Settings > Connectors > Add MCP Server > URL: `https://mcp.varity.so`
-
-**ChatGPT:** Settings > Connectors > Create > MCP server URL: `https://mcp.varity.so`
-
-The first connection asks you to authenticate via the Varity login page.
+The hosted endpoint `mcp.varity.so` is retired. Browser-based tools that only accept a remote MCP URL are not supported today; use the stdio package (`npx -y @varity-labs/mcp`) from Claude Code, Cursor, VS Code, or Windsurf, or the [llms.txt context files](#llmstxt-alternative) for LLMs without MCP support.
 
 ## Troubleshooting
 

--- a/public/mcp-schema.json
+++ b/public/mcp-schema.json
@@ -18,8 +18,7 @@
             ]
           }
         }
-      },
-      "hostedHttp": "https://mcp.varity.so"
+      }
     },
     "transports": [
       "stdio",

--- a/src/content/docs/ai-tools/mcp-server-spec.mdx
+++ b/src/content/docs/ai-tools/mcp-server-spec.mdx
@@ -87,6 +87,10 @@ The MCP server works with **any editor that supports MCP**: Cursor, Claude Code,
   </TabItem>
 </Tabs>
 
+<Aside type="note">
+**Headless or CI use.** The server reads your API key from `VARITY_API_KEY` (or `VARITY_DEPLOY_KEY`) in its environment, or from `~/.varitykit/config.json` after `varity_login`. Add an `env` block to the config above when no browser is available.
+</Aside>
+
 ## Tools Reference
 
 The server exposes a full set of tools. Read-only tools run safely with no side effects. Destructive tools create files or deploy infrastructure.
@@ -250,9 +254,9 @@ List deployments or get the status of a specific one. Shows URL, status, framewo
 
 ---
 
-### `varity_deploy_logs`: Get build logs
+### `varity_deploy_logs`: Get runtime logs
 
-Get build and deployment logs for debugging failed or recent deployments.
+Get recent runtime logs for a live deployment from the public API. Local build errors come from `varity_build`.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
@@ -448,21 +452,11 @@ Run `claude mcp list` to verify the server is registered. Re-add with `claude mc
 The MCP server supports two transports:
 
 - **stdio** (default): for desktop editors like Cursor, Claude Code, VS Code, Windsurf
-- **HTTP**: for browser-based AI tools like Claude.ai and ChatGPT
+- **HTTP**: self-hosted only (see below); there is no hosted endpoint
 
-### Hosted MCP
+### Hosted MCP (retired)
 
-Connect directly to the hosted Varity MCP at:
-
-```
-https://mcp.varity.so
-```
-
-**Claude.ai:** Settings → Connectors → Add MCP Server → URL: `https://mcp.varity.so`
-
-**ChatGPT:** Settings → Connectors → Create → MCP server URL: `https://mcp.varity.so`
-
-Hosted OAuth login is in progress: hosted OAuth and per-user deployment authorization are not yet certified end to end. Until that verification passes, do not use the hosted endpoint for owner-scoped operations (deploys, env changes, deletes). Connect via the stdio package (`npx -y @varity-labs/mcp`) instead.
+The hosted endpoint `mcp.varity.so` is retired. Browser-based tools that only accept a remote MCP URL are not supported today; use the stdio package (`npx -y @varity-labs/mcp`) from Claude Code, Cursor, VS Code, or Windsurf, or the [llms.txt context files](#llmstxt-alternative) for LLMs without MCP support.
 
 ### Self-Hosted HTTP
 

--- a/src/content/docs/cli/commands/auth.mdx
+++ b/src/content/docs/cli/commands/auth.mdx
@@ -39,7 +39,7 @@ You need a deploy key from the Varity developer portal:
 
 2. **Copy your deploy key**
 
-   Find the deploy key section on the Settings page and copy the key.
+   Open the **API keys** tab and click **Create API key** (a payment method or active starter credit is required), then copy the key. The portal calls it an API key; the CLI stores it as your deploy key. Either `varitykit login` or the `VARITY_DEPLOY_KEY` environment variable supplies it.
 
 3. **Run the login command**
 

--- a/src/content/docs/cli/commands/deploy.mdx
+++ b/src/content/docs/cli/commands/deploy.mdx
@@ -76,8 +76,15 @@ Dynamic hosting is powered by cloud compute. `--hosting` defaults to `auto`, whi
 | `--name` | None | Custom app name. Static apps live at `https://varity.app/<name>/`; dynamic apps live at `https://<name>.varity.app/` |
 | `--mode` | `auto` | Deployment mode (advanced) |
 | `--target` | None | Deployment target |
-| `--tier` | None | Hardware tier to reserve |
-| `--repo-url` | None | Deploy directly from a GitHub repo URL |
+| `--tier` | None | Hardware tier to reserve: `free`, `starter`, `growth`, `enterprise`, or `scale` |
+| `--repo-url` | None | GitHub repo URL to build from. Auto-detected from `.git/config`; required for source deploys, since nothing is uploaded from your machine |
+| `--template` | None | Deploy a certified template by id (`varitykit app templates`). Mutually exclusive with `--repo-url` and `--image` |
+| `--env KEY=VALUE` | None | Set an environment variable on the deployment (repeatable) |
+| `--service` | None | Attach an auto-wired service: `postgres`, `redis`, `ollama`, `mongodb`, `mysql`, or `minio` (repeatable) |
+| `--volume-size` / `--volume-path` | None | Persistent volume in GB and its absolute mount path (both required together) |
+| `--command` / `--arg` / `--health-path` | None | Advanced runtime overrides for image and Dockerfile deploys |
+| `--dockerfile-path` / `--docker-context-path` | None | Advanced build overrides for repo deploys |
+| `--memory-mb` / `--cpu-units` / `--storage-mb` | None | Advanced reserved-resource overrides for image and prebuilt deploys |
 | `--skip-build` | `false` | Skip the build step (deploy prebuilt output) |
 | `--image` | None | Deploy a prebuilt OCI image instead of building from source |
 | `--image-registry` | None | Registry host for a private `--image` |
@@ -90,17 +97,17 @@ Dynamic hosting is powered by cloud compute. `--hosting` defaults to `auto`, whi
 
 <Steps>
 
-1. **Build your project**
+1. **Push your project to GitHub**
 
-   ```bash
-   npm run build
-   ```
+   Varity builds from the repository in the cloud, so the code you want live must be pushed.
 
-2. **Deploy**
+2. **Deploy from the checkout**
 
    ```bash
    varitykit app deploy
    ```
+
+   Outside a Git checkout, pass `--repo-url https://github.com/you/my-app`, `--image <ref>`, or `--template <id>`.
 
 3. **View your live app**
 
@@ -148,18 +155,20 @@ varitykit app list
 Output:
 
 ```
-ID                  | Status  | URL
---------------------|---------|---------------------------
-deploy-1737492000   | live    | https://varity.app/your-app/
-deploy-1737491000   | archived| https://varity.app/your-app/ (archived)
+Name       | Type    | URL                          | Deployed
+-----------|---------|------------------------------|-----------------
+your-app   | static  | https://varity.app/your-app/ | 2026-09-06 12:00
+my-api     | dynamic | https://my-api.varity.app/   | 2026-09-05 18:30
 ```
+
+Pass the global `--json` flag (`varitykit --json app list`) for machine-readable output.
 
 ## View Deployment Details
 
 Get detailed information about a specific deployment:
 
 ```bash
-varitykit app info deploy-1737492000
+varitykit app info your-app
 ```
 
 ## Delete a Deployment

--- a/src/content/docs/cli/overview.mdx
+++ b/src/content/docs/cli/overview.mdx
@@ -41,6 +41,7 @@ VarityKit is a Python-based CLI that helps you deploy and manage applications. I
 | [`varitykit login`](/cli/commands/auth) | Log in with your deploy key from the developer portal |
 | [`varitykit doctor`](/cli/commands/doctor) | Validate your development environment |
 | [`varitykit completions`](#completions) | Set up shell completions (bash, zsh, fish) |
+| `varitykit bootstrap` | Install a cloned project's npm and pip dependencies (`--skip-npm`, `--skip-pip`, `--skip-docker`) |
 
 ### Authentication
 
@@ -58,6 +59,12 @@ VarityKit is a Python-based CLI that helps you deploy and manage applications. I
 | `varitykit app list` | List all deployments |
 | `varitykit app info` | Show deployment details |
 | `varitykit app delete --yes` | Delete a deployment |
+| `varitykit app status [RUN_ID]` | Show one deployment operation or your most recent deployment |
+| `varitykit app templates` | List certified templates (`--json` for the raw catalog) |
+| `varitykit app env NAME KEY=VALUE...` | Set environment variables on a live app, then redeploy in place (`--replace` overwrites the set) |
+| `varitykit app redeploy NAME` | Reapply the saved configuration on the same URL |
+| `varitykit app restart NAME` | Restart with a verified replacement on the same URL |
+| `varitykit app rollback DEPLOYMENT_ID` | Redeploy an earlier configuration (`--confirm` skips the prompt) |
 
 ### Domains
 
@@ -89,8 +96,13 @@ varitykit doctor
 # Log in with your developer portal deploy key
 varitykit login
 
-# Deploy (auto-detects static vs dynamic)
+# Deploy from the GitHub repo of the current checkout (auto-detects static vs dynamic)
 varitykit app deploy
+
+# Or name the source explicitly
+varitykit app deploy --repo-url https://github.com/you/my-app
+varitykit app deploy --image ghcr.io/you/app:latest --port 8080
+varitykit app deploy --template agent-zero --name my-agent
 
 # Or force a specific mode
 varitykit app deploy --hosting dynamic
@@ -125,10 +137,10 @@ Run `varitykit doctor` to automatically check all requirements and get installat
 
 ### Static Sites
 
-Deploy static websites and single-page applications:
+Deploy static websites and single-page applications from their GitHub repository:
 
 ```bash
-varitykit app deploy
+varitykit app deploy --repo-url https://github.com/you/my-site
 ```
 
 - **Best for**: Marketing sites, documentation, SPAs

--- a/src/content/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/getting-started/quickstart.mdx
@@ -74,10 +74,10 @@ If your project already runs locally, deploy it directly.
 
 ```bash
 cd my-app
-varitykit app deploy
+varitykit app deploy --repo-url https://github.com/you/my-app
 ```
 
-Varity auto-detects the framework and hosting mode, then returns a live URL. Static sites live at `https://varity.app/<app-name>/`; dynamic apps live at `https://<app-name>.varity.app/`.
+Varity builds from your GitHub repository in the cloud (nothing is uploaded from your machine), so the project must be pushed to GitHub first. `--repo-url` is auto-detected inside a Git checkout that has a GitHub remote. Prebuilt containers deploy with `--image`, and certified apps with `--template`. Varity auto-detects the framework and hosting mode, then returns a live URL. Static sites live at `https://varity.app/<app-name>/`; dynamic apps live at `https://<app-name>.varity.app/`.
 
 ---
 
@@ -132,7 +132,7 @@ If you are using Claude Code or Cursor, the Varity MCP server lets your AI tool 
 </Steps>
 
 <Aside type="tip" icon="approve-check" title="First deploy?">
-The MCP server will prompt you to log in the first time. Use your email or Google account. No account setup is needed beforehand.
+The first deploy needs an API key. Create one in the developer portal under **Settings > API keys** (a payment method or starter credit is required), then ask your AI tool to "Log in to Varity with key <your key>", or set `VARITY_API_KEY` in the MCP server's environment.
 </Aside>
 
 ---

--- a/src/content/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/getting-started/quickstart.mdx
@@ -132,7 +132,7 @@ If you are using Claude Code or Cursor, the Varity MCP server lets your AI tool 
 </Steps>
 
 <Aside type="tip" icon="approve-check" title="First deploy?">
-The first deploy needs an API key. Create one in the developer portal under **Settings > API keys** (a payment method or starter credit is required), then ask your AI tool to "Log in to Varity with key <your key>", or set `VARITY_API_KEY` in the MCP server's environment.
+The first deploy needs an API key. Create one in the developer portal under **Settings > API keys** (a payment method or starter credit is required), then ask your AI tool to "Log in to Varity with key `<your key>`", or set `VARITY_API_KEY` in the MCP server's environment.
 </Aside>
 
 ---

--- a/src/content/docs/guides/deploy-from-ai-ide.mdx
+++ b/src/content/docs/guides/deploy-from-ai-ide.mdx
@@ -266,17 +266,7 @@ The AI calls `varity_migrate`, which clones the repository, removes Vercel-speci
 
 ## Browser-based AI tools (Claude.ai, ChatGPT)
 
-If you use a browser-based AI tool instead of a desktop editor, connect to the hosted MCP endpoint:
-
-```
-https://mcp.varity.so
-```
-
-**Claude.ai:** Settings > Connectors > Add MCP Server > URL: `https://mcp.varity.so`
-
-**ChatGPT:** Settings > Connectors > Create > MCP server URL: `https://mcp.varity.so`
-
-The first connection asks you to authenticate via the Varity login page.
+The hosted endpoint `mcp.varity.so` is retired. Browser-based tools that only accept a remote MCP URL are not supported today; use the stdio package (`npx -y @varity-labs/mcp`) from Claude Code, Cursor, VS Code, or Windsurf, or the [llms.txt context files](#llmstxt-alternative) for LLMs without MCP support.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What changed

Followed the docs literally as a new developer with the MCP (2.3.17 from main) and varitykit (2.1.13 from main) against production, and fixed every place the docs diverged from what the clients do.

- **Hosted MCP retired.** `mcp.varity.so` was presented as the way to use the MCP from Claude.ai/ChatGPT in `ai-tools/mcp-server-spec.mdx`, `guides/deploy-from-ai-ide.mdx`, `public/llms-full.txt` (twice) and `public/mcp-schema.json` (`hostedHttp`). All now say it is retired and route to stdio.
- **Quickstart Path 2 did not deploy.** `cd my-app && varitykit app deploy` in a plain folder aborts with "No deploy source found... --repo-url / --image / --template". The quickstart, CLI overview and `app deploy` reference now say source deploys build from the GitHub repo (auto-detected in a Git checkout) and drop the "npm run build first" step, which the CLI never uploads.
- **Quickstart login claim was false.** "Use your email or Google account. No account setup is needed" replaced with the real flow: portal Settings > API keys (payment method or starter credit required), then `varity_login` or `VARITY_API_KEY`.
- **Key naming.** `auth.mdx` said "find the deploy key section"; the portal tab is "API keys". Documented both names.
- **CLI reference parity.** Added `--template`, `--env`, `--service`, volume and advanced override flags to the options table; added `app status/templates/env/redeploy/restart/rollback` and `bootstrap` to the command table; `app list` sample output now shows the real Name/Type/URL/Deployed columns plus `--json`; `app info` takes a name, not an id.
- **MCP spec.** `VARITY_API_KEY`/`VARITY_DEPLOY_KEY` documented for headless use (the code has always read them); `varity_deploy_logs` returns runtime logs, not build logs.

## Why

A new developer cannot complete the documented quickstart today: the deploy command as written aborts, the login story is wrong, and the browser path points at a retired endpoint.

## Architecture impact

Architecture impact: none
Reason: documentation copy and generated-schema metadata only; no runtime code.
Affected runtime services/modules: none
Interfaces/data/security/topology changed: no
Architecture/ADR files: none

## Affected repositories

- varity-docs. Companion PRs: varity-mcp (2.3.18) and varity-platform `cli/` (2.1.14).

## Contracts

- `public/mcp-schema.json` loses the `hostedHttp` key (no consumer found by `git grep hostedHttp` across varity-mcp and varity-docs scripts).

## Verification

- Every mismatch above was observed by running the real client: CLI `--help` for every subcommand, `app deploy` in a plain folder (aborts), `login --key`, MCP `tools/list` over stdio.
- `npm test` passes; `public/mcp-schema.json` re-validated as JSON; `git grep mcp.varity.so` finds only "retired" sentences.
- `npm run check` could not complete here (`astro: Permission denied` in the fresh worktree); please rely on CI for lint/build.
- Note for the operator: docs.varity.so itself returned HTTP 403 "Insufficient data volume, unable to access temporarily!" on every path at 2026-09-06 19:55Z. This PR cannot fix that; the hosting quota needs topping up before any of these pages are visible.

## Rollout

Merge; the docs site republishes on merge.

## Rollback

Revert the commit.

## Checklist

- [x] Code examples are tested and working
- [x] No forbidden vocabulary in prose
- [x] No em-dashes in prose
- [ ] Build passes (`npm run build`) - CI
- [ ] Repository check passes (`npm run check`) - CI
- [x] Links are valid
- [x] Spelling and grammar reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm9bEejrB8XkvMLxXH6rD
