### PR TITLE
Configure repository routes for Matt Pocock agent skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ a static Astro/Starlight surface, not a control-plane runtime.
 ## Read first
 
 Cross-repository authority lives in the `varity-engineering` control
-repository, checked out at `/workspaces/varity-engineering/`. Read these before
+repository, checked out at `/home/macoding/varity-v2/varity-engineering/` on
+this host. Read these before
 changing product claims:
 
 - `CURRENT-STATE.md` — dated shipped, unfinished, and blocker status.
@@ -64,3 +65,9 @@ artifact provenance, security posture, or publishing topology changes.
 - Do not treat the legacy live-crawl harness in `tests/test-docs.cjs` as a merge
   gate. It is network-dependent and contains historical checks; the deterministic
   merge gate is `npm run check`.
+
+## Agent skills
+
+- GitHub Issues and shared operations: [issue tracker](docs/agents/issue-tracker.md).
+- Canonical triage roles: [label mapping](docs/agents/triage-labels.md).
+- Existing ownership maps, decisions and code: [domain routes](docs/agents/domain.md).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,14 @@
+# Domain docs
+
+This repository owns public content and checked-in contract projections. Exact backend source and live responses own shipped behavior.
+
+Use the existing `ARCHITECTURE.md` ownership map and the code routes below.
+Cross-repository decisions: `engineering:architecture/DECISIONS.md`; topology: `engineering:architecture/likec4/`. Resolve repository IDs through `engineering:repos.yaml`.
+
+- `astro.config.mjs`: documentation composition and navigation.
+- `src/content.config.ts`: content schema and loader.
+- `src/content/docs/`: public content.
+- `tests/test-contract-artifacts.cjs`: public contract-projection checks.
+- `src/lib/docs-analytics.mjs`: browser acquisition capture.
+
+If `CONTEXT.md` or `CONTEXT-MAP.md` exists, read relevant terms and use its vocabulary. Missing glossaries are not defects: continue without scaffolding them. Record only resolved domain terms lazily, keep implementation in code, reuse existing decision locations, and surface conflicts with accepted decisions explicitly.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,12 @@
+# Issue tracker: GitHub
+
+Issues and specs: https://github.com/varity-labs/varity-docs/issues.
+Use `env -u GITHUB_TOKEN gh` with explicit `--repo varity-labs/varity-docs`;
+read `ops:agents/skills/setup-matt-pocock-skills/issue-tracker-github.md`
+for issue operations, wayfinder sub-issues, dependencies, claims and resolution.
+`repository-id:path` routes resolve through `engineering:repos.yaml`.
+
+**PRs as a request surface: no.**
+
+`engineering:FIX-QUEUE.tsv` remains the cross-repository coordination queue.
+Use existing task/gate evidence and issue links; do not create a parallel local tracker.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,14 @@
+# Triage labels
+
+| Skill role | GitHub label | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | Maintainer evaluation |
+| `needs-info` | `needs-info` | Awaiting reporter information |
+| `ready-for-agent` | `ready-for-agent` | Specified for an autonomous agent |
+| `ready-for-human` | `ready-for-human` | Requires human implementation |
+| `wontfix` | `wontfix` | Will not be actioned |
+
+Wayfinder uses `wayfinder:map`, `wayfinder:research`, `wayfinder:prototype`,
+`wayfinder:grilling`, and `wayfinder:task` on the same tracker.
+Verify provisioning with `env -u GITHUB_TOKEN gh label list --repo varity-labs/varity-docs --limit 1000`.
+Preserve existing label meanings; a missing configured label is a setup gap, not a substitute role.


### PR DESCRIPTION
## What changed

Documentation agents can resolve the repository tracker and existing content/contract owners. Startup guidance points to the current Workspace V2 control checkout.

Adds three compact skill configuration files and a `CLAUDE.md` pointer. The configuration reuses GitHub Issues, existing domain/code routes and shared skill operations. Product source, runtime configuration and public content are unchanged.

## Why

Installed engineering skills need repository-specific tracker, label and domain routes to operate without guessing or creating parallel documentation.

## Related issues

No issue is closed by this change.

## Architecture impact

Architecture impact: none
Reason: This changes agent startup routing and skill configuration while preserving existing product ownership and interfaces.
Affected runtime services/modules: none
Interfaces/data/security/topology changed: no
Architecture/ADR files: none

Affected repositories: `varity-labs/varity-docs` receives this change; `varity-engineering` supplies topology, decisions and `FIX-QUEUE.tsv`, and `varity-ops` supplies the pinned shared skill operations. Existing runtime contracts are unchanged.

## Verification

- [x] Checked every configured source path and local Markdown link.
- [x] Owned-path whitespace and reverse-patch checks passed.
- [x] `node tests/test-architecture-governance.cjs` passed, including this PR body through the actual pull-request declaration parser.
- [x] Reviewed the explicit file scope; no product source or secret values were added.
- [ ] Application build, runtime tests and browser verification were not run for this instruction/configuration-only change. Existing repository CI remains the merge gate.

## Checklist

- [x] New configuration uses plain prose and adds no public vocabulary, slogans or pricing claims.
- [x] Configuration links and spelling were reviewed.
- [ ] Build/lint and full repository checks await existing CI; they were not run locally.

## Screenshots

Not applicable: there is no visual change.

## Regression impact

Existing source/decision routes remain in their owning repositories; no runtime caller, data shape or budget changes. The regression risk is an incorrect agent-navigation route, covered by source-path, local-link and scope checks. These checks prove configuration integrity, not deployed behavior.

## Rollout and rollback

Merge through existing repository CI after the shared skills are available in `varity-ops`; agents consume the configuration on their next repository read. Revert this setup commit to restore the prior repository instructions. GitHub label provisioning is separate and is not removed by a source revert.
